### PR TITLE
[WIP] Implement async api

### DIFF
--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -1,11 +1,11 @@
 const { getOptions } = require('loader-utils')
 const mdx = require('@mdx-js/mdx')
 
-module.exports = function(content) {
+module.exports = async function(content) {
   const callback = this.async()
   const options = getOptions(this)
 
-  const result = mdx(content, options || {})
+  const result = await mdx(content, options || {})
 
   const code = `
   import React from 'react'

--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -7,30 +7,47 @@ const mdxAstToMdxHast = require('./mdx-ast-to-mdx-hast')
 const mdxHastToJsx = require('./mdx-hast-to-jsx')
 
 function createMdxAstCompiler(options = {}) {
+  const mdPlugins = options.mdPlugins || []
+
   options.blocks = options.blocks || ['[a-z]+(\\.){0,1}[a-z]']
+
   const fn = unified()
     .use(toMDAST, options)
     .use(images, options)
     .use(squeeze, options)
+
+  mdPlugins.forEach(plugin => fn.use(plugin, options))
+
+  fn
     .use(toMDXAST, options)
     .use(mdxAstToMdxHast, options)
 
   return fn
 }
 
-function compile(mdx, options = {}) {
-  const plugins = options.plugins || []
+async function compile(mdx, options = {}) {
+  // TODO: v1 change
+  // For now let's also default old plugins key to hastPlugins so this
+  // api change isn't breaking until v1.
+  const hastPlugins = options.hastPlugins || options.plugins || []
+  if (options.plugins) {
+    console.log('MDX DEPRECATION: options.plugins is no longer supported please see the latest plugin api docs')
+    console.log('https://github.com/mdx-js/mdx#options')
+  }
+
   const compilers = options.compilers || []
 
   const fn = createMdxAstCompiler(options)
 
-  plugins.forEach(plugins => fn.use(plugins, options))
+  hastPlugins.forEach(plugin => fn.use(plugin, options))
 
   fn.use(mdxHastToJsx, options)
 
   compilers.forEach(compiler => fn.use(compiler, options))
 
-  return fn.processSync(mdx).contents
+  const { contents } = await fn.process(mdx)
+
+  return contents
 }
 
 module.exports = compile

--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -18,9 +18,7 @@ function createMdxAstCompiler(options = {}) {
 
   mdPlugins.forEach(plugin => fn.use(plugin, options))
 
-  fn
-    .use(toMDXAST, options)
-    .use(mdxAstToMdxHast, options)
+  fn.use(toMDXAST, options).use(mdxAstToMdxHast, options)
 
   return fn
 }
@@ -31,7 +29,9 @@ async function compile(mdx, options = {}) {
   // api change isn't breaking until v1.
   const hastPlugins = options.hastPlugins || options.plugins || []
   if (options.plugins) {
-    console.log('MDX DEPRECATION: options.plugins is no longer supported please see the latest plugin api docs')
+    console.log(
+      'MDX DEPRECATION: options.plugins is no longer supported please see the latest plugin api docs'
+    )
     console.log('https://github.com/mdx-js/mdx#options')
   }
 

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -29,6 +29,8 @@
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.42",
     "@babel/plugin-syntax-jsx": "^7.0.0-beta.42",
-    "jest": "^22.4.3"
+    "hast-util-select": "^1.0.1",
+    "jest": "^22.4.3",
+    "request-image-size": "^2.1.0"
   }
 }

--- a/packages/mdx/test/__snapshots__/index.test.js.snap
+++ b/packages/mdx/test/__snapshots__/index.test.js.snap
@@ -1,12 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should compile fine to snapshot 1`] = `
-"
+exports[`Should await and render async plugins 1`] = `
+"import { Baz } from './Fixture'
+import { Buz } from './Fixture'
 
-export default ({components}) => <MDXTag name=\\"wrapper\\"><MDXTag name=\\"p\\" components={components}>Hello World</MDXTag></MDXTag>"
+export default ({components}) => <MDXTag name=\\"wrapper\\">
+<MDXTag name=\\"h1\\" components={components}>Hello, world!</MDXTag>
+<MDXTag name=\\"p\\" components={components}>I'm an awesome paragraph.</MDXTag>
+<Foo bg='red'>
+  <Bar>hi</Bar>
+    {hello}
+</Foo>
+<MDXTag name=\\"p\\" components={components}><MDXTag name=\\"a\\" components={components} parentName=\\"p\\" props={{\\"href\\":\\"https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno.png\\"}}><MDXTag name=\\"img\\" components={components} parentName=\\"a\\" props={{\\"src\\":\\"https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno.png\\",\\"width\\":440,\\"height\\":440}}></MDXTag></MDXTag></MDXTag>
+<MDXTag name=\\"p\\" components={components}><MDXTag name=\\"a\\" components={components} parentName=\\"p\\" props={{\\"href\\":\\"https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno\\"}}>https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno</MDXTag></MDXTag>
+<MDXTag name=\\"pre\\" components={components}><MDXTag name=\\"code\\" components={components} parentName=\\"pre\\">{\`test codeblock
+\`}</MDXTag></MDXTag>
+<MDXTag name=\\"pre\\" components={components}><MDXTag name=\\"code\\" components={components} parentName=\\"pre\\" props={{\\"className\\":[\\"language-js\\"]}}>{\`module.exports = 'test'
+\`}</MDXTag></MDXTag>
+<MDXTag name=\\"pre\\" components={components}><MDXTag name=\\"code\\" components={components} parentName=\\"pre\\" props={{\\"className\\":[\\"language-sh\\"]}}>{\`npm i -g foo
+\`}</MDXTag></MDXTag></MDXTag>"
 `;
 
-exports[`Should compile sample blogpost to snapshot 1`] = `
+exports[`Should compile sample blog post to snapshot 1`] = `
 "import { Baz } from './Fixture'
 import { Buz } from './Fixture'
 
@@ -25,6 +40,12 @@ export default ({components}) => <MDXTag name=\\"wrapper\\">
 \`}</MDXTag></MDXTag>
 <MDXTag name=\\"pre\\" components={components}><MDXTag name=\\"code\\" components={components} parentName=\\"pre\\" props={{\\"className\\":[\\"language-sh\\"]}}>{\`npm i -g foo
 \`}</MDXTag></MDXTag></MDXTag>"
+`;
+
+exports[`Should compile to snapshot 1`] = `
+"
+
+export default ({components}) => <MDXTag name=\\"wrapper\\"><MDXTag name=\\"p\\" components={components}>Hello World</MDXTag></MDXTag>"
 `;
 
 exports[`Should render blockquote correctly 1`] = `

--- a/packages/mdx/test/__snapshots__/index.test.js.snap
+++ b/packages/mdx/test/__snapshots__/index.test.js.snap
@@ -26,3 +26,10 @@ export default ({components}) => <MDXTag name=\\"wrapper\\">
 <MDXTag name=\\"pre\\" components={components}><MDXTag name=\\"code\\" components={components} parentName=\\"pre\\" props={{\\"className\\":[\\"language-sh\\"]}}>{\`npm i -g foo
 \`}</MDXTag></MDXTag></MDXTag>"
 `;
+
+exports[`Should render blockquote correctly 1`] = `
+"<MDXTag name=\\"blockquote\\" components={components}>
+<MDXTag name=\\"p\\" components={components} parentName=\\"blockquote\\">test</MDXTag>
+<MDXTag name=\\"p\\" components={components} parentName=\\"blockquote\\"><MDXTag name=\\"inlineCode\\" components={components} parentName=\\"p\\">test</MDXTag></MDXTag>
+</MDXTag>"
+`;

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -13,21 +13,25 @@ it('Should output parseable javascript (jsx)', () => {
 
 it('Should compile fine to snapshot', () => {
   const code = mdx('Hello World')
-  expect(code).toMatchSnapshot()  
+  expect(code).toMatchSnapshot()
 })
 
 it('Should compile sample blogpost to snapshot', () => {
   const fixtureBlogPost = fs.readFileSync(path.join(__dirname,'./fixtures/blog-post.md'))
   const code = mdx(fixtureBlogPost)
-  expect(code).toMatchSnapshot()  
+  expect(code).toMatchSnapshot()
 })
 
 it('Should render blockquote correctly', () => {
-  const fn = mdx.createMdxAstCompiler()
-  fn.use(function () {
+  mdx
+    .createMdxAstCompiler()
+    .use(testResult)
+    .processSync('> test\n\n> `test`')
+
+  function testResult () {
     this.Compiler = (tree) => {
-      console.log(mdxHastToJsx.toJSX(tree.children[0]))
+      const result = mdxHastToJsx.toJSX(tree.children[0])
+      expect(result).toMatchSnapshot()
     }
-  })
-  const result = fn.processSync('> test\n\n> `test`').contents
+  }
 })

--- a/packages/mdx/yarn.lock
+++ b/packages/mdx/yarn.lock
@@ -488,6 +488,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -579,6 +583,10 @@ callsites@^2.0.0:
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+
+camelcase@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
 camelcase@^4.1.0:
   version "4.1.0"
@@ -689,6 +697,12 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+comma-separated-tokens@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.4.tgz#72083e58d4a462f01866f6617f4d98a3cd3b8a46"
+  dependencies:
+    trim "0.0.1"
+
 compare-versions@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.1.0.tgz#43310256a5c555aaed4193c04d8f154cf9c6efd5"
@@ -740,6 +754,10 @@ cryptiles@3.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
   dependencies:
     boom "5.x.x"
+
+css-selector-parser@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-1.3.0.tgz#5f1ad43e2d8eefbfdc304fcd39a521664943e3eb"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
@@ -1312,6 +1330,34 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+hast-util-has-property@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-has-property/-/hast-util-has-property-1.0.1.tgz#ac08c40bcbf27b80a85aaae91e4f6250a53e802f"
+
+hast-util-is-element@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-1.0.0.tgz#3f7216978b2ae14d98749878782675f33be3ce00"
+
+hast-util-select@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-select/-/hast-util-select-1.0.1.tgz#9f1591efa62ba0bdf5ea4298b301aaae1dad612d"
+  dependencies:
+    camelcase "^3.0.0"
+    comma-separated-tokens "^1.0.2"
+    css-selector-parser "^1.3.0"
+    hast-util-has-property "^1.0.0"
+    hast-util-is-element "^1.0.0"
+    hast-util-whitespace "^1.0.0"
+    not "^0.1.0"
+    nth-check "^1.0.1"
+    property-information "^3.1.0"
+    space-separated-tokens "^1.1.0"
+    zwitch "^1.0.0"
+
+hast-util-whitespace@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.0.tgz#bd096919625d2936e1ff17bc4df7fd727f17ece9"
+
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -1374,6 +1420,10 @@ http-signature@~1.2.0:
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+image-size@^0.6.1:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.2.tgz#8ee316d4298b028b965091b673d5f1537adee5b4"
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -2386,6 +2436,10 @@ normalize-path@^2.0.1, normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+not@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/not/-/not-0.1.0.tgz#c9691c1746c55dcfbe54cbd8bd4ff041bc2b519d"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -2400,6 +2454,12 @@ npmlog@^4.0.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+nth-check@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -2645,6 +2705,10 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
+property-information@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-3.2.0.tgz#fd1483c8fbac61808f5fe359e7693a1f48a58331"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -2786,6 +2850,14 @@ replace-ext@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
+request-image-size@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/request-image-size/-/request-image-size-2.1.0.tgz#6085be6face6ab18cff829875e9e8923850f2dbb"
+  dependencies:
+    image-size "^0.6.1"
+    request "^2.54.0"
+    standard-http-error "^2.0.1"
+
 request-promise-core@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
@@ -2827,7 +2899,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.83.0:
+request@^2.54.0, request@^2.83.0:
   version "2.85.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
   dependencies:
@@ -3057,6 +3129,12 @@ source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
+space-separated-tokens@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.1.tgz#9695b9df9e65aec1811d4c3f9ce52520bc2f7e4d"
+  dependencies:
+    trim "0.0.1"
+
 spdx-correct@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
@@ -3106,6 +3184,16 @@ sshpk@^1.7.0:
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+
+"standard-error@>= 1.1.0 < 2":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/standard-error/-/standard-error-1.1.0.tgz#23e5168fa1c0820189e5812701a79058510d0d34"
+
+standard-http-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/standard-http-error/-/standard-http-error-2.0.1.tgz#f8ae9172e3cef9cb38d2e7084a1925f57a7c34bd"
+  dependencies:
+    standard-error ">= 1.1.0 < 2"
 
 state-toggle@^1.0.0:
   version "1.0.0"
@@ -3626,3 +3714,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+zwitch@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.2.tgz#9b059541bfa844799fe2d903bde609de2503a041"


### PR DESCRIPTION
In order to allow async plugins we need to use
the async unified api. This will allow plugins
to return promises that are awaited before moving
on to the next.

This is pretty powerful because we can use it at
compile time to do pretty much anything. The example
test checks images for their size and adds that as
props.

This approach can also be used to use image recognition
in order to dynamically populate alt attributes at
compile time.