### PR TITLE
Fixes export documentation.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ It works similarly to frontmatter, but uses ES2015 syntax.
 import { fred, sue } from '../data/authors'
 import Layout from '../components/with-blog-layout'
 
-export {
+export const meta = {
   authors: [fred, sue],
   layout: Layout
 }


### PR DESCRIPTION
The documentation was missing the complete ES6 syntax necessary to properly export metadata from mdx.

h/t for @timneutkens for helping me connect the dots on what was going wrong.