### PR TITLE
Adds ability to render absolute or relative image paths to remark-images.

### DIFF
--- a/packages/remark-images/index.js
+++ b/packages/remark-images/index.js
@@ -1,18 +1,19 @@
 const isUrl = require('is-url')
 const visit = require('unist-util-visit')
 
-const isImgUrl = str => /\.(svg|png|jpg|jpeg)$/.test(str)
+const isImgExt = str => /\.(svg|png|jpg|jpeg)$/.test(str)
+const isAbsolutePath = str => str.startsWith('/')
+const isRelativePath = str => str.startsWith('./') || str.startsWith('../')
+const isImgPath = str => isAbsolutePath(str) || isRelativePath(str)
 
-module.exports = () => (tree, file) =>
+module.exports = () => (tree) =>
   visit(tree, 'text', node => {
     const text = node.value ? node.value.trim() : ''
 
-    if (!isUrl(text) || !isImgUrl(text)) {
-      return
+    if ((isUrl(text) || isImgPath(text)) && isImgExt(text)) {
+      node.type = 'image'
+      node.url = text
+
+      delete node.value
     }
-
-    node.type = 'image'
-    node.url = text
-
-    delete node.value
   })

--- a/readme.md
+++ b/readme.md
@@ -148,7 +148,7 @@ export default () =>
 
 #### Images
 
-Embedding images is easier to remember, you can simply link a url.
+Embedding images is easier to remember, you can simply link a url or uri.
 
 ```md
 #### A url
@@ -157,6 +157,13 @@ Below will render an image:
 
 https://c8r-x0.s3.amazonaws.com/lab-components-macbook.jpg
 ```
+
+Supported urls / uris:
+
+- `http://example.com/image.jpg`
+- `/image.jpg`
+- `./image.jpg`
+- `../image.jpg`
 
 Supported file types:
 


### PR DESCRIPTION
This is an attempt to fix #110.

I've test this locally with the following test cases. 

* Red means it will render as text. 
* Green means it will render as an `<img>` tag.

```diff
+ http://localhost:3000/images/image.jpg
+ http://example.com/images/image.jpg
- http://example.com/images/image.tiff
+ /images/image.jpg
- /images/image.tiff
+ ./images/image.jpg
+ ../images/image.jpg
- image.svg
- /image/image.svg.tiff
```