### PR TITLE
Make remark-images optional

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -1,7 +1,6 @@
 const unified = require('unified')
 const toMDAST = require('remark-parse')
 const squeeze = require('remark-squeeze-paragraphs')
-const images = require('remark-images')
 const toMDXAST = require('@mdx-js/mdxast')
 const mdxAstToMdxHast = require('./mdx-ast-to-mdx-hast')
 const mdxHastToJsx = require('./mdx-hast-to-jsx')
@@ -13,7 +12,6 @@ function createMdxAstCompiler(options = {}) {
 
   const fn = unified()
     .use(toMDAST, options)
-    .use(images, options)
     .use(squeeze, options)
 
   mdPlugins.forEach(plugin => fn.use(plugin, options))

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@mdx-js/mdxast": "^0.7.2",
     "mdast-util-to-hast": "^3.0.0",
-    "remark-images": "^0.7.4",
     "remark-parse": "^5.0.0",
     "remark-squeeze-paragraphs": "^3.0.1",
     "unified": "^6.1.6",

--- a/packages/mdx/test/__snapshots__/index.test.js.snap
+++ b/packages/mdx/test/__snapshots__/index.test.js.snap
@@ -11,8 +11,6 @@ export default ({components}) => <MDXTag name=\\"wrapper\\">
   <Bar>hi</Bar>
     {hello}
 </Foo>
-<MDXTag name=\\"p\\" components={components}><MDXTag name=\\"a\\" components={components} parentName=\\"p\\" props={{\\"href\\":\\"https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno.png\\"}}><MDXTag name=\\"img\\" components={components} parentName=\\"a\\" props={{\\"src\\":\\"https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno.png\\",\\"width\\":440,\\"height\\":440}}></MDXTag></MDXTag></MDXTag>
-<MDXTag name=\\"p\\" components={components}><MDXTag name=\\"a\\" components={components} parentName=\\"p\\" props={{\\"href\\":\\"https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno\\"}}>https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno</MDXTag></MDXTag>
 <MDXTag name=\\"pre\\" components={components}><MDXTag name=\\"code\\" components={components} parentName=\\"pre\\">{\`test codeblock
 \`}</MDXTag></MDXTag>
 <MDXTag name=\\"pre\\" components={components}><MDXTag name=\\"code\\" components={components} parentName=\\"pre\\" props={{\\"className\\":[\\"language-js\\"]}}>{\`module.exports = 'test'
@@ -32,8 +30,6 @@ export default ({components}) => <MDXTag name=\\"wrapper\\">
   <Bar>hi</Bar>
     {hello}
 </Foo>
-<MDXTag name=\\"p\\" components={components}><MDXTag name=\\"a\\" components={components} parentName=\\"p\\" props={{\\"href\\":\\"https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno.png\\"}}><MDXTag name=\\"img\\" components={components} parentName=\\"a\\" props={{\\"src\\":\\"https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno.png\\"}}></MDXTag></MDXTag></MDXTag>
-<MDXTag name=\\"p\\" components={components}><MDXTag name=\\"a\\" components={components} parentName=\\"p\\" props={{\\"href\\":\\"https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno\\"}}>https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno</MDXTag></MDXTag>
 <MDXTag name=\\"pre\\" components={components}><MDXTag name=\\"code\\" components={components} parentName=\\"pre\\">{\`test codeblock
 \`}</MDXTag></MDXTag>
 <MDXTag name=\\"pre\\" components={components}><MDXTag name=\\"code\\" components={components} parentName=\\"pre\\" props={{\\"className\\":[\\"language-js\\"]}}>{\`module.exports = 'test'

--- a/packages/mdx/test/fixtures/blog-post.md
+++ b/packages/mdx/test/fixtures/blog-post.md
@@ -11,10 +11,6 @@ I'm an awesome paragraph.
     {hello}
 </Foo>
 
-https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno.png
-
-https://c8r.imgix.net/028ab8c85da415103cb3b1eb/johno
-
 ```
 test codeblock
 ```

--- a/packages/mdx/yarn.lock
+++ b/packages/mdx/yarn.lock
@@ -130,9 +130,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@mdx-js/mdxast@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@mdx-js/mdxast/-/mdxast-0.7.0.tgz#93636a0156228d84afbffeb6590cd0d68b9aa698"
+"@mdx-js/mdxast@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@mdx-js/mdxast/-/mdxast-0.7.2.tgz#588e3ad617465ca4b67a50c0079f222fb2d65614"
   dependencies:
     unist-util-visit "^1.3.0"
 
@@ -1670,10 +1670,6 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
-is-url@^1.2.2:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
-
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -2808,13 +2804,6 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
-
-remark-images@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/remark-images/-/remark-images-0.7.1.tgz#8a9f69314eda0b5b9a13959b5b3117da0a108397"
-  dependencies:
-    is-url "^1.2.2"
-    unist-util-visit "^1.3.0"
 
 remark-parse@^5.0.0:
   version "5.0.0"

--- a/packages/remark-images/readme.md
+++ b/packages/remark-images/readme.md
@@ -1,3 +1,51 @@
 # remark-images
 
-https://github.com/mdx-js/mdx
+Remark plugin to turn image urls into rendered images.
+
+## Installation
+
+```
+npm i -s remark-images
+```
+
+## Usage
+
+```
+const remark = require('remark')
+const images = require('remark-images')
+const html = require('remark-html')
+
+remark()
+  .use(images)
+  .use(html)
+  .process(markdownString, function (err, file) {
+    if (err) { throw err }
+
+    console.log(String(file))
+  })
+```
+
+### Example
+
+```md
+#### A url
+
+Below will render an image:
+
+https://c8r-x0.s3.amazonaws.com/lab-components-macbook.jpg
+```
+
+Supported urls / uris:
+
+- `http://example.com/image.jpg`
+- `/image.jpg`
+- `./image.jpg`
+- `../image.jpg`
+
+Supported file types:
+
+- `png`
+- `svg`
+- `jpg`
+- `jpeg`
+- `gif`

--- a/readme.md
+++ b/readme.md
@@ -147,34 +147,11 @@ export default () =>
   />
 ```
 
-#### Images
+## Plugins
 
-Embedding images is easier to remember, you can simply link a url or uri.
+Since MDX uses the [remark](https://github.com/remarkjs/remark)/[rehype](https://github.com/rehypejs/rehype) ecosystems, you can use plugins to modify the AST at different stages of the transpilation process.
 
-```md
-#### A url
-
-Below will render an image:
-
-https://c8r-x0.s3.amazonaws.com/lab-components-macbook.jpg
-```
-
-Supported urls / uris:
-
-- `http://example.com/image.jpg`
-- `/image.jpg`
-- `./image.jpg`
-- `../image.jpg`
-
-Supported file types:
-
-- `png`
-- `svg`
-- `jpg`
-- `jpeg`
-- `gif`
-
-## Options
+### Options
 
 Name | Type | Required | Description
 ---- | ---- | -------- | -----------


### PR DESCRIPTION
Since this can be handled in userland via a plugin, we should
remove the image url handling from the spec.