### PR TITLE
fix(mdx): add "components" prop to wrapper

### DIFF
--- a/packages/loader/test/__snapshots__/index.test.js.snap
+++ b/packages/loader/test/__snapshots__/index.test.js.snap
@@ -19,7 +19,7 @@ exports.default = function (_ref) {
   var components = _ref.components;
   return _react2.default.createElement(
     _tag.MDXTag,
-    { name: 'wrapper' },
+    { name: 'wrapper', components: components },
     _react2.default.createElement(
       _tag.MDXTag,
       { name: 'h1', components: components },

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -24,7 +24,7 @@ function toJSX(node, parentNode = {}) {
       '\n' +
       exportNodes.map(childNode => toJSX(childNode, node)).join('\n') +
       '\n' +
-      `export default ({components}) => <MDXTag name="wrapper">${jsxNodes
+      `export default ({components}) => <MDXTag name="wrapper" components={components}>${jsxNodes
         .map(childNode => toJSX(childNode, node))
         .join('')}</MDXTag>`
     )

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -51,6 +51,16 @@ it('Should render HTML inside inlineCode correctly', async () => {
   ).toBeTruthy()
 })
 
+it('Should add the "components" prop to the wrapper', async () => {
+  const jsx = await mdx('# Hello World')
+  const { code } = babel.transform(jsx, {
+    plugins: ['@babel/plugin-syntax-jsx']
+  })
+  expect(jsx).toEqual(
+    expect.stringContaining('<MDXTag name="wrapper" components={components}')
+  )
+})
+
 test('Should await and render async plugins', async () => {
   const result = await mdx(fixtureBlogPost, {
     hastPlugins: [

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",

--- a/packages/tag/test/test.js
+++ b/packages/tag/test/test.js
@@ -1,8 +1,11 @@
 import fs from 'fs'
 import test from 'ava'
 import React from 'react'
-import { renderToString } from 'react-dom/server'
+import { renderToString, renderToStaticMarkup } from 'react-dom/server'
+import vm from 'vm'
+import * as babel from 'babel-core'
 
+import mdx from '../../mdx'
 import { MDXTag } from '../src'
 
 const H1 = props => <h1 style={{ color: 'tomato' }} {...props} />
@@ -13,4 +16,19 @@ test('renders the desired component', t => {
   )
 
   t.snapshot(result)
+})
+
+test('renders the desired component (wrapper)', t => {
+  const jsx = mdx.sync('# Hello')
+  const { code } = babel.transform(jsx, {
+    presets: ['react']
+  })
+  const Markdown = vm.runInContext(
+    code.replace(/export default/, ''),
+    vm.createContext({ React, MDXTag })
+  )
+  const html = renderToStaticMarkup(
+    <Markdown components={{ wrapper: React.Fragment }} />
+  )
+  t.is(html, '<h1>Hello</h1>')
 })

--- a/packages/tag/yarn.lock
+++ b/packages/tag/yarn.lock
@@ -347,6 +347,30 @@ babel-core@^6.17.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
+babel-core@^6.26.3:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
+
 babel-generator@^6.1.0, babel-generator@^6.26.0:
   version "6.26.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
@@ -1362,7 +1386,7 @@ date-time@^2.1.0:
   dependencies:
     time-zone "^1.0.0"
 
-debug@^2.2.0, debug@^2.6.8:
+debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -2680,7 +2704,7 @@ pretty-ms@^3.0.0:
     parse-ms "^1.0.0"
     plur "^2.1.2"
 
-private@^0.1.6, private@^0.1.7:
+private@^0.1.6, private@^0.1.7, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 


### PR DESCRIPTION
Currently, the "wrapper" element does not get the "components" prop which prevents it from being customized.

https://github.com/mdx-js/mdx/blob/master/packages/mdx/mdx-hast-to-jsx.js#L27