### PR TITLE
Convert array of class names to a string

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -46,6 +46,10 @@ function toJSX(node, parentNode = {}) {
     if (Object.keys(node.properties).length > 0) {
       props = JSON.stringify(node.properties)
     }
+    
+    if (Array.isArray(node.properties.className)) {
+      node.properties.className = node.properties.className.join(' ');
+    }
 
     return `<MDXTag name="${node.tagName}" components={components}${
       parentNode.tagName ? ` parentName="${parentNode.tagName}"` : ''


### PR DESCRIPTION
For example, when using `@mapbox/rehype-prism`, the `className` property is an array instead of a string, which meant the classes were stringified with commas between them instead of spaces.