### PR TITLE
Work towards issue #166

### DIFF
--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -7,6 +7,10 @@ module.exports = async function(content) {
 
   const result = await mdx(content, options || {})
 
+  if(typeof options !== "undefined" && typeof options.process !== "undefined")
+    if(typeof options.process == "function")
+      return callback(null, options.process(result))
+
   const code = `
   import React from 'react'
   import { MDXTag } from '@mdx-js/tag'


### PR DESCRIPTION
This allows you to change out imports for the mdx-loader.

It doesn't fix everything, as it still forces you to reimplement @mdx-js/tag to get a version that works without React, but it's a step towards that goal.