### PR TITLE
Add support for components as properties

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -8,7 +8,7 @@ const mdxHastToJsx = require('./mdx-hast-to-jsx')
 function createMdxAstCompiler(options = {}) {
   const mdPlugins = options.mdPlugins || []
 
-  options.blocks = options.blocks || ['[a-z]+(\\.){0,1}[a-z]']
+  options.blocks = options.blocks || ['[a-z\\.]+(\\.){0,1}[a-z\\.]']
 
   const fn = unified()
     .use(toMDAST, options)

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -51,10 +51,20 @@ it('Should render HTML inside inlineCode correctly', async () => {
   ).toBeTruthy()
 })
 
+it('Should recognize components as propertiess', async () => {
+  const result = await mdx('# Hello\n\n<MDX.Foo />')
+
+  expect(
+    result.includes(
+      '<MDXTag name="h1" components={components}>{`Hello`}</MDXTag>{`\n`}<MDX.Foo />'
+    )
+  ).toBeTruthy()
+})
+
 test('Should await and render async plugins', async () => {
   const result = await mdx(fixtureBlogPost, {
     hastPlugins: [
-      (options) => tree => {        
+      (options) => tree => {
         // Returning a promise here will suffice for the test
         return (async () => {
           const headingNode = select('h1', tree)


### PR DESCRIPTION
Component names like Foo.Bar aren't currently matched
though they should be since they're valid JSX.