### PR TITLE
Improve parsing for imports and exports

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -9,7 +9,8 @@ const {
   isImport,
   isExport,
   isExportDefault,
-  BLOCKS_REGEX
+  BLOCKS_REGEX,
+  EMPTY_NEWLINE
 } = require('./util')
 
 const DEFAULT_OPTIONS = {
@@ -19,8 +20,6 @@ const DEFAULT_OPTIONS = {
   compilers: [],
   blocks: [BLOCKS_REGEX]
 }
-
-const EMPTY_NEWLINE = '\n\n'
 
 const tokenizeEsSyntax = (eat, value) => {
   const index = value.indexOf(EMPTY_NEWLINE)

--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -1,11 +1,9 @@
 const unified = require('unified')
 const toMDAST = require('remark-parse')
 const squeeze = require('remark-squeeze-paragraphs')
-const toMDXAST = require('@mdx-js/mdxast')
 const mdxAstToMdxHast = require('./mdx-ast-to-mdx-hast')
 const mdxHastToJsx = require('./mdx-hast-to-jsx')
 
-const BLOCKS_REGEX = '[a-z\\.]+(\\.){0,1}[a-z\\.]'
 const DEFAULT_OPTIONS = {
   footnotes: true,
   mdPlugins: [],
@@ -14,16 +12,71 @@ const DEFAULT_OPTIONS = {
   blocks: [BLOCKS_REGEX]
 }
 
+const BLOCKS_REGEX = '[a-z\\.]+(\\.){0,1}[a-z\\.]'
+const IMPORT_REGEX = /^import/
+const EXPORT_REGEX = /^export/
+const EXPORT_DEFAULT_REGEX = /^export default/
+const isImport = text => IMPORT_REGEX.test(text)
+const isExport = text => EXPORT_REGEX.test(text)
+const isExportDefault = text => EXPORT_DEFAULT_REGEX.test(text)
+
+const locateImport = (value, fromIndex) =>
+  fromIndex !== 1 || !isImport(value) ? -1 : 1
+
+function tokenizeImports(eat, value) {
+  if (isImport(value)) {
+    return eat(value)({ type: 'html', value })
+  }
+}
+
+tokenizeImports.locator = locateImport
+tokenizeImports.notInBlock = true
+tokenizeImports.notInLink = true
+tokenizeImports.notInList = true
+
+const locateExport = (value, fromIndex) =>
+  fromIndex !== 1 || !isExport(value) ? -1 : 1
+
+function tokenizeExports(eat, value, silent) {
+  if (isExport(value)) {
+    return eat(value)({
+      type: 'html',
+      default: isExportDefault(value),
+      value
+    })
+
+    return ret
+  }
+}
+
+tokenizeExports.locator = locateExport
+tokenizeExports.notInBlock = true
+tokenizeExports.notInLink = true
+tokenizeExports.notInList = true
+
+function esSyntax() {
+  var Parser = this.Parser
+  var tokenizers = Parser.prototype.inlineTokenizers
+  var methods = Parser.prototype.inlineMethods
+
+  tokenizers.imports = tokenizeImports
+  tokenizers.exports = tokenizeExports
+
+  methods.splice(methods.indexOf('text'), 0, 'imports')
+  methods.splice(methods.indexOf('text'), 0, 'exports')
+}
+
 function createMdxAstCompiler(options) {
   const mdPlugins = options.mdPlugins
 
   const fn = unified()
     .use(toMDAST, options)
+    .use(esSyntax)
     .use(squeeze, options)
 
   mdPlugins.forEach(plugin => fn.use(plugin, options))
 
-  fn.use(toMDXAST, options).use(mdxAstToMdxHast, options)
+  fn.use(mdxAstToMdxHast, options)
 
   return fn
 }

--- a/packages/mdx/md-ast-to-mdx-ast.js
+++ b/packages/mdx/md-ast-to-mdx-ast.js
@@ -1,0 +1,9 @@
+const visit = require('unist-util-visit')
+
+module.exports = options => tree => {
+  visit(tree, 'html', node => {
+    node.type = node.mdxType || 'jsx'
+  })
+
+  return tree
+}

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -57,7 +57,7 @@ function toJSX(node, parentNode = {}) {
     if (Object.keys(node.properties).length > 0) {
       props = JSON.stringify(node.properties)
     }
-    
+
     return `<MDXTag name="${node.tagName}" components={components}${
       parentNode.tagName ? ` parentName="${parentNode.tagName}"` : ''
     }${props ? ` props={${props}}` : ''}>${children}</MDXTag>`

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -6,6 +6,8 @@
   "description": "Parse MDX and transpile to JSX",
   "files": [
     "index.js",
+    "util.js",
+    "md-ast-to-mdx-ast.js",
     "mdx-ast-to-mdx-hast.js",
     "mdx-hast-to-jsx.js"
   ],
@@ -20,7 +22,6 @@
     "mdx"
   ],
   "dependencies": {
-    "@mdx-js/mdxast": "^0.10.0",
     "mdast-util-to-hast": "^3.0.0",
     "remark-parse": "^5.0.0",
     "remark-squeeze-paragraphs": "^3.0.1",

--- a/packages/mdx/test/fixtures/blog-post.md
+++ b/packages/mdx/test/fixtures/blog-post.md
@@ -2,7 +2,11 @@ import { Baz } from './Fixture'
 import { Buz } from './Fixture'
 
 export const foo = {
-  hi: `Fudge ${Baz.displayName || 'Baz'}`
+  hi: `Fudge ${Baz.displayName || 'Baz'}`,
+  authors: [
+    'fred',
+    'sally'
+  ]
 }
 
 # Hello, world!

--- a/packages/mdx/test/fixtures/blog-post.md
+++ b/packages/mdx/test/fixtures/blog-post.md
@@ -1,6 +1,10 @@
 import { Baz } from './Fixture'
 import { Buz } from './Fixture'
 
+export const foo = {
+  hi: `Fudge ${Baz.displayName || 'Baz'}`
+}
+
 # Hello, world!
 
 

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -131,7 +131,5 @@ test('Should parse and render footnotes', async () => {
 test('Should expose a sync compiler', async () => {
   const result = mdx.sync(fixtureBlogPost)
 
-  console.log(result)
-
   expect(result).toMatch(/Hello, world!/)
 })

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -10,40 +10,41 @@ const fixtureBlogPost = fs.readFileSync(
   path.join(__dirname, './fixtures/blog-post.md')
 )
 
+const parse = code => babel.parse(code, {
+  plugins: ['@babel/plugin-syntax-jsx']
+})
+
 it('Should output parseable JSX', async () => {
-  const code = await mdx('Hello World')
-  babel.parse(code, {
-    plugins: ['@babel/plugin-syntax-jsx']
-  })
+  const result = await mdx('Hello World')
+
+  parse(result)
 })
 
 it('Should output parseable JSX when using < or >', async () => {
-  const code = await mdx(`
+  const result = await mdx(`
   # Hello, MDX
 
   I <3 Markdown and JSX
   `)
-  babel.parse(code, {
-    plugins: ['@babel/plugin-syntax-jsx']
-  })
+
+  parse(result)
 })
 
 it('Should compile sample blog post', async () => {
-  const code = await mdx(fixtureBlogPost)
-  babel.parse(code, {
-    plugins: ['@babel/plugin-syntax-jsx']
-  })
+  const result = await mdx(fixtureBlogPost)
+
+  parse(result)
 })
 
 it('Should render blockquote correctly', async () => {
-  const code = await mdx('> test\n\n> `test`')
-  babel.parse(code, {
-    plugins: ['@babel/plugin-syntax-jsx']
-  })
+  const result = await mdx('> test\n\n> `test`')
+
+  parse(result)
 })
 
 it('Should render HTML inside inlineCode correctly', async () => {
   const result = await mdx('`<div>`')
+
   expect(
     result.includes(
       '<MDXTag name="inlineCode" components={components} parentName="p">{`<div>`}</MDXTag>'
@@ -98,8 +99,7 @@ it('Should render elements without wrapping blank new lines', async () => {
 test('Should await and render async plugins', async () => {
   const result = await mdx(fixtureBlogPost, {
     hastPlugins: [
-      (options) => tree => {
-        // Returning a promise here will suffice for the test
+      options => tree => {
         return (async () => {
           const headingNode = select('h1', tree)
           const textNode = headingNode.children[0]
@@ -130,6 +130,8 @@ test('Should parse and render footnotes', async () => {
 
 test('Should expose a sync compiler', async () => {
   const result = mdx.sync(fixtureBlogPost)
+
+  console.log(result)
 
   expect(result).toMatch(/Hello, world!/)
 })

--- a/packages/mdx/util.js
+++ b/packages/mdx/util.js
@@ -2,7 +2,9 @@ const IMPORT_REGEX = /^import/
 const EXPORT_REGEX = /^export/
 const EXPORT_DEFAULT_REGEX = /^export default/
 const BLOCKS_REGEX = '[a-z\\.]+(\\.){0,1}[a-z\\.]'
+const EMPTY_NEWLINE = '\n\n'
 
+module.exports.EMPTY_NEWLINE = EMPTY_NEWLINE
 module.exports.BLOCKS_REGEX = BLOCKS_REGEX
 module.exports.isImport = text => IMPORT_REGEX.test(text)
 module.exports.isExport = text => EXPORT_REGEX.test(text)

--- a/packages/mdx/util.js
+++ b/packages/mdx/util.js
@@ -1,0 +1,9 @@
+const IMPORT_REGEX = /^import/
+const EXPORT_REGEX = /^export/
+const EXPORT_DEFAULT_REGEX = /^export default/
+const BLOCKS_REGEX = '[a-z\\.]+(\\.){0,1}[a-z\\.]'
+
+module.exports.BLOCKS_REGEX = BLOCKS_REGEX
+module.exports.isImport = text => IMPORT_REGEX.test(text)
+module.exports.isExport = text => EXPORT_REGEX.test(text)
+module.exports.isExportDefault = text => EXPORT_DEFAULT_REGEX.test(text)

--- a/packages/mdxast/index.js
+++ b/packages/mdxast/index.js
@@ -1,64 +1,7 @@
 const visit = require('unist-util-visit')
 
-const IMPORT_REGEX = /^import/
-const EXPORT_REGEX = /^export/
-const EXPORT_DEFAULT_REGEX = /^export default/
-const isImport = text => IMPORT_REGEX.test(text)
-const isExport = text => EXPORT_REGEX.test(text)
-const isExportDefault = text => EXPORT_DEFAULT_REGEX.test(text)
-const restringify = node => {
-  if (node.type === 'link') {
-    return node.url
-  } else if (node.type === 'linkReference') {
-    return `[${node.children.map(n => n.value)}]`
-  } else {
-    return node.value
-  }
-}
-
-const modules = tree => {
-  return visit(tree, 'paragraph', (node, _i, parent) => {
-    // `import` must be defined at the top level to be a real import
-    if (parent.type !== 'root') {
-      return node
-    }
-
-    // Get the text from the text node
-    const { value } = node.children[0] || ''
-
-    // Sets type to `export` in the AST if it's an export
-    if (isExport(value)) {
-      node.type = 'export'
-      node.default = isExportDefault(value)
-      // Exports can have urls which remark-parse will turn into a child link node.
-      node.value = node.children.map(restringify).join(' ')
-      delete node.children
-      return node
-    }
-
-    // Import paragraphs only have text in 1 node
-    if (node.children.length !== 1) {
-      return node
-    }
-
-    // Sets type to `import` in the AST if it's an import
-    if (isImport(value)) {
-      node.type = 'import'
-      node.value = value
-      delete node.children
-      return node
-    }
-
-    return node
-  })
-}
-
-// turns `html` nodes into `jsx` nodes
-const jsx = tree => visit(tree, 'html', node => (node.type = 'jsx'))
-
 module.exports = options => tree => {
-  modules(tree)
-  jsx(tree)
+  visit(tree, 'html', node => (node.type = 'jsx'))
 
   return tree
 }

--- a/packages/mdxast/index.js
+++ b/packages/mdxast/index.js
@@ -1,7 +1,64 @@
 const visit = require('unist-util-visit')
 
+const IMPORT_REGEX = /^import/
+const EXPORT_REGEX = /^export/
+const EXPORT_DEFAULT_REGEX = /^export default/
+const isImport = text => IMPORT_REGEX.test(text)
+const isExport = text => EXPORT_REGEX.test(text)
+const isExportDefault = text => EXPORT_DEFAULT_REGEX.test(text)
+const restringify = node => {
+  if (node.type === 'link') {
+    return node.url
+  } else if (node.type === 'linkReference') {
+    return `[${node.children.map(n => n.value)}]`
+  } else {
+    return node.value
+  }
+}
+
+const modules = tree => {
+  return visit(tree, 'paragraph', (node, _i, parent) => {
+    // `import` must be defined at the top level to be a real import
+    if (parent.type !== 'root') {
+      return node
+    }
+
+    // Get the text from the text node
+    const { value } = node.children[0] || ''
+
+    // Sets type to `export` in the AST if it's an export
+    if (isExport(value)) {
+      node.type = 'export'
+      node.default = isExportDefault(value)
+      // Exports can have urls which remark-parse will turn into a child link node.
+      node.value = node.children.map(restringify).join(' ')
+      delete node.children
+      return node
+    }
+
+    // Import paragraphs only have text in 1 node
+    if (node.children.length !== 1) {
+      return node
+    }
+
+    // Sets type to `import` in the AST if it's an import
+    if (isImport(value)) {
+      node.type = 'import'
+      node.value = value
+      delete node.children
+      return node
+    }
+
+    return node
+  })
+}
+
+// turns `html` nodes into `jsx` nodes
+const jsx = tree => visit(tree, 'html', node => (node.type = 'jsx'))
+
 module.exports = options => tree => {
-  visit(tree, 'html', node => (node.type = 'jsx'))
+  modules(tree)
+  jsx(tree)
 
   return tree
 }

--- a/packages/mdxast/package.json
+++ b/packages/mdxast/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "jest": "^22.4.3",
     "rehype-stringify": "^3.0.0",
-    "remark-frontmatter": "^1.2.0",
     "remark-parse": "^5.0.0",
     "remark-rehype": "^3.0.0",
     "unified": "^6.1.6",

--- a/packages/mdxast/readme.md
+++ b/packages/mdxast/readme.md
@@ -1,4 +1,8 @@
-# @mdx-js/mdxast
+# [Deprecated] @mdx-js/mdxast
+
+**This library has been pulled into `@mdx-js/mdx` and is no longer maintained.**
+
+---
 
 Transforms MDAST to MDXAST.
 

--- a/packages/mdxast/test/fixture.md
+++ b/packages/mdxast/test/fixture.md
@@ -1,7 +1,3 @@
----
-hello: frontmatter
----
-
 import {
   Foo,
   Bar
@@ -16,6 +12,7 @@ I'm an awesome paragraph.
 
 <Foo bg='red'>
   <Bar />
+
   {props.hello}
 </Foo>
 

--- a/packages/mdxast/test/fixture.md
+++ b/packages/mdxast/test/fixture.md
@@ -12,7 +12,6 @@ I'm an awesome paragraph.
 
 <Foo bg='red'>
   <Bar />
-
   {props.hello}
 </Foo>
 

--- a/packages/mdxast/test/test.js
+++ b/packages/mdxast/test/test.js
@@ -2,27 +2,16 @@ const fs = require('fs')
 const unified = require('unified')
 const remark = require('remark-parse')
 const rehype = require('remark-rehype')
-const matter = require('remark-frontmatter')
 const html = require('rehype-stringify')
-const blocks = require('remark-parse/lib/block-elements.json')
 
 const toMdx = require('..')
 
 const fixture = fs.readFileSync('test/fixture.md', 'utf8')
 
 const parseFixture = str => {
-  const options = {
-    blocks: blocks,
-    matter: {
-      type: 'yaml',
-      marker: '-'
-    }
-  }
-
   const parser = unified()
-    .use(remark, options)
-    .use(matter, options.matter)
-    .use(toMdx, options)
+    .use(remark)
+    .use(toMdx)
     .use(rehype)
     .use(html)
 


### PR DESCRIPTION
Before we relied 100% on remark's default parser which got us to an MVP but doesn't quite cut it due to the added syntax that imports, exports, and JSX. In many areas that syntax directly conflicts with MD syntax.

For example, consider the following export:

```js
export const frontMatter = {
  heroImg: `${process.env.ASSET_PATH}/space-cats.png`,
  editUrl: 'https://github.com/mdx-js/mdx/edit/master/readme.md',
  authors: [
    'Wilma Flintstone',
    'Fred Flintstone'
  ]
}
```

The template string, url, _and_ array conflict with Markdown parsing. This expected/intended behavior from an MD perspective, but not from an ES export. This occurs because the paragraph tokenizer then passes the parsed paragraph text on to inline tokenizers in order to parse links, inline code, emphasis, etc.

So we're now introducing our own [block parsers](https://github.com/remarkjs/remark/tree/master/packages/remark-parse#parserblocktokenizers) that inject themselves before the HTML/paragraph block tokenizers that skip inline tokenization and pass along the raw values for imports/exports. Note that this is still a WIP

Also, I'd like to explicitly thank @wooorm for providing a wonderfully extensible library that allows us to do whacky things 💟.