### PR TITLE
Add support for comments

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -22,6 +22,12 @@ function toJSX(node, parentNode = {}) {
         continue
       }
 
+      if (childNode.type === 'jsx') {
+        childNode.value = childNode.value
+          .replace('<!--', '{/*')
+          .replace('-->', '*/}')
+      }
+
       jsxNodes.push(childNode)
     }
 

--- a/packages/mdx/test/fixtures/blog-post.md
+++ b/packages/mdx/test/fixtures/blog-post.md
@@ -6,9 +6,13 @@ import { Buz } from './Fixture'
 
 I'm an awesome paragraph.
 
+<!-- I'm a comment -->
+
 <Foo bg='red'>
   <Bar>hi</Bar>
     {hello}
+    {/* another commment */}
+    <!-- one more comment -->
 </Foo>
 
 ```

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -51,6 +51,32 @@ it('Should render HTML inside inlineCode correctly', async () => {
   ).toBeTruthy()
 })
 
+it('Should support comments', async () => {
+  const result = await mdx(`
+A paragraph
+<!-- a Markdown comment -->
+\`\`\`md
+<!-- a code block Markdown comment -->
+\`\`\`
+<div>
+  {/* a nested JSX comment */}
+  <!-- a nested Markdown comment -->
+</div>
+  `)
+  expect(result.includes(
+    '{/* a Markdown comment */}'
+  )).toBeTruthy()
+  expect(result.includes(
+    '<!-- a code block Markdown comment -->'
+  )).toBeTruthy()
+  expect(result.includes(
+    '{/* a nested JSX comment */}'
+  )).toBeTruthy()
+  expect(result.includes(
+    '{/* a nested Markdown comment */}'
+  )).toBeTruthy()
+})
+
 it('Should recognize components as properties', async () => {
   const result = await mdx('# Hello\n\n<MDX.Foo />')  
   expect(


### PR DESCRIPTION
Translate Markdown comments:

```md
<!-- this is a comment -->
```

into JSX comments:

```jsx
{/* this is a comment */}
```