### PR TITLE
Layout props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 bundle.js
 .next
 *-error.log
+*-debug.log

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -36,7 +36,7 @@ function toJSX(node, parentNode = {}) {
       '\n' +
       exportNodes.map(childNode => toJSX(childNode, node)).join('\n') +
       '\n' +
-      `export default ({components}) => <MDXTag name="wrapper" ${layout ? `Layout={${layout}}` : ''} components={components}>${jsxNodes
+      `export default ({components, ...props}) => <MDXTag name="wrapper" ${layout ? `Layout={${layout}} layoutProps={props}` : ''} components={components}>${jsxNodes
         .map(childNode => toJSX(childNode, node))
         .join('')}</MDXTag>`
     )

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.44",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.44",
     "@babel/plugin-syntax-jsx": "^7.0.0-beta.44",
     "hast-util-select": "^1.0.1",
     "jest": "^22.4.3",

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -11,7 +11,10 @@ const fixtureBlogPost = fs.readFileSync(
 )
 
 const parse = code => babel.parse(code, {
-  plugins: ['@babel/plugin-syntax-jsx']
+  plugins: [
+    '@babel/plugin-syntax-jsx',
+    '@babel/plugin-proposal-object-rest-spread'
+  ]
 })
 
 it('Should output parseable JSX', async () => {
@@ -79,7 +82,7 @@ A paragraph
 })
 
 it('Should recognize components as properties', async () => {
-  const result = await mdx('# Hello\n\n<MDX.Foo />')  
+  const result = await mdx('# Hello\n\n<MDX.Foo />')
   expect(
     result.includes(
       '<MDXTag name="h1" components={components}>{`Hello`}</MDXTag>\n<MDX.Foo />'
@@ -91,8 +94,8 @@ it('Should render elements without wrapping blank new lines', async () => {
   const result = await mdx(`
   | Test | Table |
   | :--- | :---- |
-  | Col1 | Col2  |`)    
-    
+  | Col1 | Col2  |`)
+
   expect(result.includes('{`\n`}')).toBe(false)
 })
 

--- a/packages/mdx/yarn.lock
+++ b/packages/mdx/yarn.lock
@@ -62,6 +62,10 @@
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.44.tgz#9f590bc3ae6daa8a10b853233baa3e25d263751d"
 
+"@babel/helper-plugin-utils@7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.54.tgz#61d2a9a0f9a3e31838a458debb9eebd7bdd249b4"
+
 "@babel/helper-split-export-declaration@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz#c0b351735e0fbcb3822c8ad8db4e583b05ebd9dc"
@@ -92,11 +96,24 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/plugin-proposal-object-rest-spread@^7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.54.tgz#5481269a020dd0d38715a8094fed015d30ef4c2a"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.54"
+    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.54"
+
 "@babel/plugin-syntax-jsx@^7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.44.tgz#b3475f0e6ea797634f0ba823273d76e93727e52f"
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.44"
+
+"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.54.tgz#e0f445612081ab573e2535adbabc7b710d17940c"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.54"
 
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"

--- a/packages/runtime/src/index.js
+++ b/packages/runtime/src/index.js
@@ -3,16 +3,18 @@ import { transform } from 'buble'
 import mdx from '@mdx-js/mdx'
 import { MDXTag } from '@mdx-js/tag'
 
-export default ({ scope = {}, components = {}, children }) => {
+export default ({ scope = {}, components = {}, children, ...props }) => {
   const fullScope = {
     MDXTag,
     components,
+    props,
     ...scope
   }
 
   // We should add this as an output option to mdx core so we don't
   // need to do hacky regexing.
-  const jsx = mdx.sync(children).replace(/^(\s)*export default \({components}\) =>/, '')
+  const jsx = mdx.sync(children).replace(/^(\s)*export default \({components, ...props}\) =>/, '')
+
   const { code } = transform(jsx)
 
   const keys = Object.keys(fullScope)

--- a/packages/runtime/test/index.test.js
+++ b/packages/runtime/test/index.test.js
@@ -18,15 +18,40 @@ const mdx = `
 <Foo />
 `
 
-it('renders MDX with the proper components', () => {
-  const result = render(
-    <MDX
-      components={components}
-      scope={scope}
-      children={mdx}
-    />
-  )
+const mdxLayout = `
+# Hello, world
 
-  expect(result).toMatch(/style="color:tomato"/)
-  expect(result).toMatch(/Foobarbaz/)
+<Foo />
+
+export default ({ children, id }) => <div id={id}>{children}</div>
+`
+
+describe('renders MDX with the proper components', () => {
+  it('default layout', () => {
+    const result = render(
+      <MDX
+        components={components}
+        scope={scope}
+        children={mdx}
+      />
+    )
+
+    expect(result).toMatch(/style="color:tomato"/)
+    expect(result).toMatch(/Foobarbaz/)
+  })
+
+  it('custom layout', () => {
+    const result = render(
+      <MDX
+        components={components}
+        scope={scope}
+        children={mdxLayout}
+        id="layout"
+      />
+    )
+
+    expect(result).toMatch(/style="color:tomato"/)
+    expect(result).toMatch(/Foobarbaz/)
+    expect(result).toMatch(/id="layout"/)
+  })
 })

--- a/packages/tag/src/mdx-tag.js
+++ b/packages/tag/src/mdx-tag.js
@@ -16,7 +16,8 @@ class MDXTag extends Component {
       props: childProps = {},
       children,
       components = {},
-      Layout
+      Layout,
+      layoutProps
     } = this.props
 
     const Component =
@@ -28,7 +29,7 @@ class MDXTag extends Component {
     if (Layout) {
       hoistStatics(this, Layout)
 
-      return <Layout components={components}>
+      return <Layout components={components} {...layoutProps}>
         <Component {...childProps}>{children}</Component>
       </Layout>
     }

--- a/packages/tag/test/mdx-tag.test.js
+++ b/packages/tag/test/mdx-tag.test.js
@@ -15,10 +15,10 @@ it('Should render the desired component', async () => {
 })
 
 it('Should render the layout component', async () => {
-  const Layout = ({children}) => <div id="layout">{children}</div>
+  const Layout = ({children, id}) => <div id={id}>{children}</div>
   const components = { h1: H1 }
   const result = renderToString(
-    <MDXTag Layout={Layout} name="wrapper" components={components}>
+    <MDXTag Layout={Layout} name="wrapper" components={components} layoutProps={{ id: 'layout' }}>
       <MDXTag name="h1" components={{ h1: H1 }} />
     </MDXTag>
   )

--- a/readme.md
+++ b/readme.md
@@ -210,6 +210,25 @@ export default Layout
 # Hello, world!
 ```
 
+Any additional props passed to the imported MDX component will be passed to its default export:
+
+```jsx
+// index.js
+import Mdx from './posts/post.mdx'
+
+export default () => (
+  <Mdx someProp="value" />
+)
+```
+```js
+// posts/post.mdx
+import Layout from '../components/blog-layout'
+
+# Hello, world!
+
+export default ({ children, someProp }) => <Layout someProp={someProp}>{children}</Layout>
+```
+
 ### Component customization
 
 You can pass in components for any `html` element that Markdown compiles to.


### PR DESCRIPTION
I'm sure that this solution for layout props isn't ideal, but it's a crucial piece of the puzzle for integrating MDX into some tools. The API can always be changed later. Also, this is a breaking change to anyone who decided to use the `components` prop in their MDX file, because now that should become `props.components`.

With this change we'll be able to do stuff like this:

`posts/layout-props.mdx`:
```
import Layout from '../layouts/post'

# Layout Props!

Passing additional props to custom layouts now works!

export default ({ children, timeStamp }) => <Layout timeStamp={timeStamp}>{children}</Layout>
```
`pages/index.js`:
```jsx
import Post from '../posts/layout-props.mdx'

export default () => (
  <Post
    comonents={{}}
    timeStamp={Date.now()}
  />
)
```

Would resolve:

- gatsbyjs/gatsby#312
- nhducit/gatsby-plugin-mdx#13
- nhducit/gatsby-plugin-mdx#14
- nhducit/gatsby-plugin-mdx#19
- silvenon/gatsby-transformer-mdx#1