### PR TITLE
handle [plugin, pluginOptions] syntax for mdPlugins and hastPlugins

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -56,7 +56,14 @@ function createMdxAstCompiler(options) {
     .use(esSyntax)
     .use(squeeze, options)
 
-  mdPlugins.forEach(plugin => fn.use(plugin, options))
+  mdPlugins.forEach(plugin => {
+    // handle [plugin, pluginOptions] syntax
+    if (Array.isArray(plugin) && plugin.length > 1) {
+      fn.use(plugin[0], plugin[1])
+    } else {
+      fn.use(plugin, options)
+    }
+  })
 
   fn.use(toMDXAST, options).use(mdxAstToMdxHast, options)
 
@@ -67,9 +74,14 @@ function applyHastPluginsAndCompilers(compiler, options) {
   const hastPlugins = options.hastPlugins
   const compilers = options.compilers
 
-  for(const hastPlugin of hastPlugins) {
-    compiler.use(hastPlugin, options)
-  }
+  hastPlugins.forEach(plugin => {
+    // handle [plugin, pluginOptions] syntax
+    if (Array.isArray(plugin) && plugin.length > 1) {
+      compiler.use(plugin[0], plugin[1])
+    } else {
+      compiler.use(plugin, options)
+    }
+  })
 
   compiler.use(mdxHastToJsx, options)
 

--- a/readme.md
+++ b/readme.md
@@ -270,9 +270,12 @@ Name | Type | Required | Description
 
 Plugins need to be passed to the MDX loader via webpack options.
 
+If a plugin needs specific options, use the `[plugin, pluginOptions]` syntax.
+
 ```js
 const images = require('remark-images')
 const emoji = require('remark-emoji')
+const toc = require('remark-toc')
 
 module.exports = {
   module: {
@@ -286,7 +289,7 @@ module.exports = {
           {
             loader: '@mdx-js/loader',
             options: {
-              mdPlugins: [images, emoji]
+              mdPlugins: [images, emoji, [toc, {heading: 'intro'}]]
             }
           }
         ]


### PR DESCRIPTION
Hi,

this handle `[plugin, pluginOptions]` syntax for mdPlugins and hastPlugins

related to https://github.com/mdx-js/mdx/issues/143

```js
const options = {
  mdPlugins: [
    [remark.toc, { heading: "Sommaire" }],
    [
       remark.frontmatter,
       {
         type: "yaml",
         marker: "-"
       }
    ],
    remark.emoji,
    remark.autolinkHeadings,
    remark.slug
  ]
}
```