### PR TITLE
Implement option to opt out of export wrapper

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -1,4 +1,4 @@
-function toJSX(node, parentNode = {}) {
+function toJSX(node, parentNode = {}, options = {}) {
   let children = ''
 
   if (node.type === 'root') {
@@ -36,7 +36,8 @@ function toJSX(node, parentNode = {}) {
       '\n' +
       exportNodes.map(childNode => toJSX(childNode, node)).join('\n') +
       '\n' +
-      `export default ({components, ...props}) => <MDXTag name="wrapper" ${
+      (options.skipExport ? '' : 'export default ({components, ...props}) => ') +
+      `<MDXTag name="wrapper" ${
         layout ? `Layout={${layout}} layoutProps={props}` : ''
       } components={components}>${jsxNodes
         .map(childNode => toJSX(childNode, node))
@@ -77,9 +78,9 @@ function toJSX(node, parentNode = {}) {
   }
 }
 
-function compile() {
+function compile(options = {}) {
   this.Compiler = tree => {
-    return toJSX(tree)
+    return toJSX(tree, {}, options)
   }
 }
 

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -74,6 +74,16 @@ A paragraph
   expect(result.includes('{/* a nested Markdown comment */}')).toBeTruthy()
 })
 
+it('Should not include export wrapper if skipExport is true', async () => {
+  const result = await mdx('> test\n\n> `test`', { skipExport: true })
+
+  expect(
+    result.includes(
+      'export default ({components, ...props}) =>'
+    )
+  ).toBeFalsy()
+})
+
 it('Should recognize components as properties', async () => {
   const result = await mdx('# Hello\n\n<MDX.Foo />')
   expect(

--- a/readme.md
+++ b/readme.md
@@ -284,6 +284,7 @@ Name | Type | Required | Description
 ---- | ---- | -------- | -----------
 `mdPlugins` | Array[] | `false` | Array of remark plugins to manipulate the MDXAST
 `hastPlugins` | Array[] | `false` | Array of rehype plugins to manipulate the MDXHAST
+`skipExport` | Boolean | `false` | Skip `export default` wrapper on transpiled JSX
 
 #### Specifying plugins
 


### PR DESCRIPTION
In certain cases, like mdx-js/runtime or mdx-deck
we want to avoid the wrapping export default so that
it doesn't need to be manually stripped off.