### PR TITLE
fix create-react-app example

### DIFF
--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -2,13 +2,15 @@
   "private": true,
   "name": "mdx-create-react-app",
   "dependencies": {
-    "@mdx-js/loader": "^0.7.0",
-    "@mdx-js/mdx": "^0.7.1",
+    "@mdx-js/loader": "^0.15.0-2",
+    "@mdx-js/mdx": "^0.15.0-2",
     "@rebass/markdown": "^1.0.0-1",
-    "react": "^16.3.2",
-    "react-app-rewired": "^1.5.0",
-    "react-dom": "^16.3.2",
-    "react-scripts": "1.1.4"
+    "react": "^16.4.2",
+    "react-app-rewired": "^1.5.2",
+    "react-dom": "^16.4.2",
+    "react-scripts": "1.1.4",
+    "rebass": "^2.1.0",
+    "styled-components": "^3.4.1"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/examples/create-react-app/src/hello.md
+++ b/examples/create-react-app/src/hello.md
@@ -1,7 +1,26 @@
-import { Donut } from 'rebass'
+import {
+  Card,
+  Box,
+  BackgroundImage,
+  Subhead,
+  Small
+} from 'rebass'
 
 # Hello, world!
 
 This is MDX!
 
-<Donut value={1/3} />
+<Box width={300}>
+  <Card>
+    <BackgroundImage src="https://images.unsplash.com/photo-1533529318682-0c3e2fc1e225" />
+    <Box p={2}>
+      <Subhead>
+        <a href="https://unsplash.com/photos/e3hDxz86IxI">Alone but Powerful</a>
+      </Subhead>
+      <Small>
+        Photo by <a href="https://unsplash.com/@tentides">Jeremy Bishop</a> on{' '}
+        <a href="https://unsplash.com">Unsplash</a>
+      </Small>
+    </Box>
+  </Card>
+</Box>


### PR DESCRIPTION
I tried this out in a devtip video: https://www.youtube.com/watch?v=d2sQiI5NFAM&list=PLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u

Some deps were outdated/missing so I added those to make it work. I also made the example cooler :)

<img width="338" alt="screen shot 2018-08-06 at 9 43 32 am" src="https://user-images.githubusercontent.com/1500684/43726741-338f9b7a-995d-11e8-9558-605643aeccfd.png">
