### PR TITLE
Fix importing .md files.

### DIFF
--- a/packages/parcel-plugin-mdx/src/index.js
+++ b/packages/parcel-plugin-mdx/src/index.js
@@ -1,3 +1,5 @@
 module.exports = function(bundler) {
-  bundler.addAssetType('mdx', require.resolve('./MDXAsset.js'))
+  const assetTypePath = require.resolve('./MDXAsset.js')
+  bundler.addAssetType('md', assetTypePath)
+  bundler.addAssetType('mdx', assetTypePath)
 }

--- a/packages/parcel-plugin-mdx/test/index.test.js
+++ b/packages/parcel-plugin-mdx/test/index.test.js
@@ -1,7 +1,24 @@
 const path = require('path')
+const index = require('../src');
 const MDXAsset = require('../src/MDXAsset')
 
 let value
+
+describe('index', () => {
+  it('should add asset types', () => {
+    const bundler = { addAssetType: jest.fn() }
+    const { calls } = bundler.addAssetType.mock
+    const mdxAssetPath = require.resolve('../src/MDXAsset')
+
+    index(bundler)
+
+    expect(calls.length).toEqual(2)
+    expect(calls[0][0]).toBe('md')
+    expect(calls[0][1]).toBe(mdxAssetPath)
+    expect(calls[1][0]).toEqual('mdx')
+    expect(calls[1][1]).toEqual(mdxAssetPath)
+  })
+})
 
 describe('MDXAsset', async () => {
   beforeEach(async () => {


### PR DESCRIPTION
In the README under [markdown file transclusion](https://github.com/mdx-js/mdx#markdown-file-transclusion) it says:

> You can transclude Markdown files by importing one .md file into another:

This doesn't work, though, because you need to add the extension and asset type handler, explicitly, to the Parcel bundler instance.