### PR TITLE
Fix "Getting Started" typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ The possibilities are endless when you combine components (that can even be dyna
 ## Getting started
 
 ```
-npx init mdx
+npm init mdx
 ```
 
 - [Documentation](https://mdxjs.com)


### PR DESCRIPTION
Fixes #223

Resolves issue #223, updating the README to say `npm init mdx` instead of `npx init mdx`
