### PR TITLE
Preserve whitespace in code blocks

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -1,4 +1,9 @@
 function toJSX(node, parentNode = {}, options = {}) {
+  const {
+    // default options
+    skipExport = false,
+    preserveNewlines = false,
+  } = options
   let children = ''
 
   if (node.type === 'root') {
@@ -36,7 +41,7 @@ function toJSX(node, parentNode = {}, options = {}) {
       '\n' +
       exportNodes.map(childNode => toJSX(childNode, node)).join('\n') +
       '\n' +
-      (options.skipExport ? '' : 'export default ({components, ...props}) => ') +
+      (skipExport ? '' : 'export default ({components, ...props}) => ') +
       `<MDXTag name="wrapper" ${
         layout ? `Layout={${layout}} layoutProps={props}` : ''
       } components={components}>${jsxNodes
@@ -47,7 +52,14 @@ function toJSX(node, parentNode = {}, options = {}) {
 
   // recursively walk through children
   if (node.children) {
-    children = node.children.map(childNode => toJSX(childNode, node)).join('')
+    children = node.children.map(childNode => {
+      const childOptions = {
+        ...options,
+        // tell all children inside <pre> tags to preserve newlines as text nodes
+        preserveNewlines: preserveNewlines || node.tagName === 'pre',
+      }
+      return toJSX(childNode, node, childOptions)
+    }).join('')
   }
 
   if (node.type === 'element') {
@@ -66,11 +78,14 @@ function toJSX(node, parentNode = {}, options = {}) {
     }${props ? ` props={${props}}` : ''}>${children}</MDXTag>`
   }
 
-  // Wraps all text nodes except new lines inside template string, so that we don't run into escaping issues.
+  // Wraps text nodes inside template string, so that we don't run into escaping issues.
   if (node.type === 'text') {
-    return node.value === '\n'
-      ? node.value
-      : '{`' + node.value.replace(/`/g, '\\`').replace(/\$/g, '\\$') + '`}'
+    // Don't wrap newlines unless specifically instructed to by the flag,
+    // to avoid issues like React warnings caused by text nodes in tables.
+    if (node.value === '\n' && !preserveNewlines) {
+      return node.value
+    }
+    return '{`' + node.value.replace(/`/g, '\\`').replace(/\$/g, '\\$') + '`}'
   }
 
   if (node.type === 'import' || node.type === 'export' || node.type === 'jsx') {

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -32,6 +32,7 @@
     "@babel/core": "^7.0.0-beta.44",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.44",
     "@babel/plugin-syntax-jsx": "^7.0.0-beta.44",
+    "@mapbox/rehype-prism": "^0.2.0",
     "hast-util-select": "^1.0.1",
     "jest": "^22.4.3",
     "request-image-size": "^2.1.0"

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -49,11 +49,9 @@ it('Should render blockquote correctly', async () => {
 it('Should render HTML inside inlineCode correctly', async () => {
   const result = await mdx('`<div>`')
 
-  expect(
-    result.includes(
-      '<MDXTag name="inlineCode" components={components} parentName="p">{`<div>`}</MDXTag>'
-    )
-  ).toBeTruthy()
+  expect(result).toContain(
+    '<MDXTag name="inlineCode" components={components} parentName="p">{`<div>`}</MDXTag>'
+  )
 })
 
 it('Should support comments', async () => {
@@ -68,29 +66,23 @@ A paragraph
   <!-- a nested Markdown comment -->
 </div>
   `)
-  expect(result.includes('{/* a Markdown comment */}')).toBeTruthy()
-  expect(result.includes('<!-- a code block Markdown comment -->')).toBeTruthy()
-  expect(result.includes('{/* a nested JSX comment */}')).toBeTruthy()
-  expect(result.includes('{/* a nested Markdown comment */}')).toBeTruthy()
+  expect(result).toContain('{/* a Markdown comment */}')
+  expect(result).toContain('<!-- a code block Markdown comment -->')
+  expect(result).toContain('{/* a nested JSX comment */}')
+  expect(result).toContain('{/* a nested Markdown comment */}')
 })
 
 it('Should not include export wrapper if skipExport is true', async () => {
   const result = await mdx('> test\n\n> `test`', { skipExport: true })
 
-  expect(
-    result.includes(
-      'export default ({components, ...props}) =>'
-    )
-  ).toBeFalsy()
+  expect(result).not.toContain('export default ({components, ...props}) =>')
 })
 
 it('Should recognize components as properties', async () => {
   const result = await mdx('# Hello\n\n<MDX.Foo />')
-  expect(
-    result.includes(
-      '<MDXTag name="h1" components={components}>{`Hello`}</MDXTag>\n<MDX.Foo />'
-    )
-  ).toBeTruthy()
+  expect(result).toContain(
+    '<MDXTag name="h1" components={components}>{`Hello`}</MDXTag>\n<MDX.Foo />'
+  )
 })
 
 it('Should render elements without wrapping blank new lines', async () => {
@@ -99,7 +91,7 @@ it('Should render elements without wrapping blank new lines', async () => {
   | :--- | :---- |
   | Col1 | Col2  |`)
 
-  expect(result.includes('{`\n`}')).toBe(false)
+  expect(result).not.toContain('{`\n`}')
 })
 
 test('Should await and render async plugins', async () => {
@@ -125,16 +117,12 @@ test(
       'This is a paragraph with a [^footnote]\n\n[^footnote]: Here is the footnote'
     )
 
-    expect(
-      result.includes(
-        '<MDXTag name="sup" components={components} parentName="p" props={{"id":"fnref-footnote"}}>'
-      )
+    expect(result).toContain(
+      '<MDXTag name="sup" components={components} parentName="p" props={{"id":"fnref-footnote"}}>'
     )
 
-    expect(
-      result.includes(
-        '<MDXTag name="li" components={components} parentName="ol" props={{"id":"fn-footnote"}}>'
-      )
+    expect(result).toContain(
+      '<MDXTag name="li" components={components} parentName="ol" props={{"id":"fn-footnote"}}>'
     )
   },
   10000

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const { select } = require('hast-util-select')
 const requestImageSize = require('request-image-size')
+const prism = require('@mapbox/rehype-prism')
 
 const fixtureBlogPost = fs.readFileSync(
   path.join(__dirname, './fixtures/blog-post.md')
@@ -52,6 +53,17 @@ it('Should render HTML inside inlineCode correctly', async () => {
   expect(result).toContain(
     '<MDXTag name="inlineCode" components={components} parentName="p">{`<div>`}</MDXTag>'
   )
+})
+
+it('Should preserve newlines in code blocks', async () => {
+  const result = await mdx(`
+\`\`\`dockerfile
+# Add main script
+COPY start.sh /home/start.sh
+\`\`\`
+  `, { hastPlugins: [prism] })
+
+  expect(result).toContain('{`# Add main script`}</MDXTag>{`\n`}')
 })
 
 it('Should support comments', async () => {

--- a/packages/mdx/yarn.lock
+++ b/packages/mdx/yarn.lock
@@ -62,9 +62,9 @@
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.44.tgz#9f590bc3ae6daa8a10b853233baa3e25d263751d"
 
-"@babel/helper-plugin-utils@7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.54.tgz#61d2a9a0f9a3e31838a458debb9eebd7bdd249b4"
+"@babel/helper-plugin-utils@7.0.0-rc.3":
+  version "7.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.3.tgz#f68392896f4f3b90bdf7e72e5cc7127cdd5441fd"
 
 "@babel/helper-split-export-declaration@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -96,12 +96,12 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/plugin-proposal-object-rest-spread@^7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.54.tgz#5481269a020dd0d38715a8094fed015d30ef4c2a"
+"@babel/plugin-proposal-object-rest-spread@^7.0.0-beta.44":
+  version "7.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-rc.3.tgz#c51a93b86d59eb35ea4f123c5f18f0953a25d761"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.54"
-    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.54"
+    "@babel/helper-plugin-utils" "7.0.0-rc.3"
+    "@babel/plugin-syntax-object-rest-spread" "7.0.0-rc.3"
 
 "@babel/plugin-syntax-jsx@^7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -109,11 +109,11 @@
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.54.tgz#e0f445612081ab573e2535adbabc7b710d17940c"
+"@babel/plugin-syntax-object-rest-spread@7.0.0-rc.3":
+  version "7.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-rc.3.tgz#4458bb8b61849a81de4a90f98f4cb4f87d1d95c5"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.54"
+    "@babel/helper-plugin-utils" "7.0.0-rc.3"
 
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -146,6 +146,14 @@
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
+
+"@mapbox/rehype-prism@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/rehype-prism/-/rehype-prism-0.2.0.tgz#c3e6a241487715cfc2d277975c672a0727c5f726"
+  dependencies:
+    hast-util-to-string "^1.0.0"
+    refractor "^2.3.0"
+    unist-util-visit "^1.1.3"
 
 abab@^1.0.4:
   version "1.0.4"
@@ -671,6 +679,14 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+clipboard@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.1.tgz#a12481e1c13d8a50f5f036b0560fe5d16d74e46a"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -721,6 +737,12 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz#b13793131d9ea2d2431cf5b507ddec258f0ce0db"
+  dependencies:
+    trim "0.0.1"
 
 comma-separated-tokens@^1.0.2:
   version "1.0.4"
@@ -871,6 +893,10 @@ define-property@^2.0.2:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -1264,6 +1290,12 @@ globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  dependencies:
+    delegate "^3.1.2"
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
@@ -1363,6 +1395,10 @@ hast-util-is-element@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-1.0.0.tgz#3f7216978b2ae14d98749878782675f33be3ce00"
 
+hast-util-parse-selector@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.0.tgz#2175f18cdd697308fc3431d5c29a9e48dfa4817a"
+
 hast-util-select@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hast-util-select/-/hast-util-select-1.0.1.tgz#9f1591efa62ba0bdf5ea4298b301aaae1dad612d"
@@ -1379,9 +1415,22 @@ hast-util-select@^1.0.1:
     space-separated-tokens "^1.1.0"
     zwitch "^1.0.0"
 
+hast-util-to-string@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-to-string/-/hast-util-to-string-1.0.1.tgz#b28055cdca012d3c8fd048757c8483d0de0d002c"
+
 hast-util-whitespace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.0.tgz#bd096919625d2936e1ff17bc4df7fd727f17ece9"
+
+hastscript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-4.0.0.tgz#653f7f4f7aedb9e6c629af8c13707553f5671c77"
+  dependencies:
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.2.0"
+    property-information "^4.0.0"
+    space-separated-tokens "^1.0.0"
 
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
@@ -2614,6 +2663,17 @@ parse-entities@^1.1.0:
     is-decimal "^1.0.0"
     is-hexadecimal "^1.0.0"
 
+parse-entities@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -2718,6 +2778,12 @@ pretty-format@^22.4.3:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+prismjs@~1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.15.0.tgz#8801d332e472091ba8def94976c8877ad60398d9"
+  optionalDependencies:
+    clipboard "^2.0.0"
+
 private@^0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -2729,6 +2795,12 @@ process-nextick-args@~2.0.0:
 property-information@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-3.2.0.tgz#fd1483c8fbac61808f5fe359e7693a1f48a58331"
+
+property-information@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-4.1.0.tgz#16f817d8c087f3018b91877c193d730570487bb2"
+  dependencies:
+    xtend "^4.0.1"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -2798,6 +2870,14 @@ realpath-native@^1.0.0:
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
   dependencies:
     util.promisify "^1.0.0"
+
+refractor@^2.3.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-2.6.0.tgz#6b0d88f654c8534eefed3329a35bc7bb74ae0979"
+  dependencies:
+    hastscript "^4.0.0"
+    parse-entities "^1.1.2"
+    prismjs "~1.15.0"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -3016,6 +3096,10 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
@@ -3142,6 +3226,12 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, sour
 source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+space-separated-tokens@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz#e95ab9d19ae841e200808cd96bc7bd0adbbb3412"
+  dependencies:
+    trim "0.0.1"
 
 space-separated-tokens@^1.1.0:
   version "1.1.1"
@@ -3341,6 +3431,10 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
+tiny-emitter@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -3482,6 +3576,10 @@ unist-util-is@^2.0.0, unist-util-is@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.1.tgz#0c312629e3f960c66e931e812d3d80e77010947b"
 
+unist-util-is@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
+
 unist-util-position@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.0.0.tgz#e6e1e03eeeb81c5e1afe553e8d4adfbd7c0d8f82"
@@ -3502,11 +3600,23 @@ unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz#3ccbdc53679eed6ecf3777dd7f5e3229c1b6aa3c"
 
+unist-util-visit-parents@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz#63fffc8929027bee04bfef7d2cce474f71cb6217"
+  dependencies:
+    unist-util-is "^2.1.2"
+
 unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.0.tgz#41ca7c82981fd1ce6c762aac397fc24e35711444"
   dependencies:
     unist-util-is "^2.1.1"
+
+unist-util-visit@^1.1.3:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.0.tgz#1cb763647186dc26f5e1df5db6bd1e48b3cc2fb1"
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
I'm trying to write a test that reproduces #221. The idea is to mount the component exported by the fixture and use `textContent` to check if whitespace in the code block is preserved.

I'm having difficulties trying to load the module compiled by webpack as a React component and mounting it. Webpack gives me an object with a source text, but I'm not sure how to parse it as a Node module. If someone has an idea, let me know. 😅 

P. S. I'm not 100% certain that this is really an MDX issue, but the fact that I can't reproduce it without it suggests that it is.