### PR TITLE
Absolute path to the @mdx-js/tag

### DIFF
--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -3,13 +3,19 @@ const mdx = require('@mdx-js/mdx')
 
 module.exports = async function(content) {
   const callback = this.async()
-  const options = getOptions(this)
+  const options = getOptions(this) || {}
 
-  const result = await mdx(content, options || {})
+  const result = await mdx(content, options)
+
+  let modulePath = '@mdx-js/tag'
+
+  if (options.absolutePath) {
+    modulePath = require.resolve(modulePath)
+  }
 
   const code = `
   import React from 'react'
-  import { MDXTag } from '@mdx-js/tag'
+  import { MDXTag } from '${modulePath}'
   ${result}
   `
 

--- a/packages/loader/readme.md
+++ b/packages/loader/readme.md
@@ -27,3 +27,7 @@ module: {
   ]
 }
 ```
+
+## Options
+
+`absolutePath` - use absolute path to `@mdx-js/tag` instead relative 

--- a/packages/loader/test/index.test.js
+++ b/packages/loader/test/index.test.js
@@ -27,7 +27,8 @@ const testFixture = (fixture, options = {}) => {
               }
             },
             {
-              loader: path.resolve(__dirname, '..')
+              loader: path.resolve(__dirname, '..'),
+              options
             }
           ]
         }
@@ -51,4 +52,8 @@ const testFixture = (fixture, options = {}) => {
 
 test('it loads markdown and returns a component', async () => {
   await testFixture('fixture.md')
+})
+
+test('it loads markdown with adsolute path to the @mdx-js/tag', async () => {
+  await testFixture('fixture.md', { absolutePath: true })
 })


### PR DESCRIPTION
The `@mdx-js/tag` dependency is not resolving if loader used with such builders as `razzle`, `next` etc.
I've added the `absolutePath` option to loader to make it able to resolve `@mdx-js/tag` in this case.