### PR TITLE
Update to prettier@1.14

### DIFF
--- a/examples/x0/pages/_app.js
+++ b/examples/x0/pages/_app.js
@@ -10,4 +10,3 @@ export default ({ Component, pageProps }) => (
     </RebassProvider>
   </MDXProvider>
 )
-

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@compositor/x0": "^6.0.5",
     "lerna": "^2.11.0",
-    "prettier": "^1.13.7"
+    "prettier": "^1.14.2"
   },
   "dependencies": {
     "@rebass/mdx": "^1.0.0-1",

--- a/packages/create-mdx/cli.js
+++ b/packages/create-mdx/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const init = require('initit')
 
-const [ example = 'next', name = 'next-mdx' ] = process.argv.slice(2, 3)
+const [example = 'next', name = 'next-mdx'] = process.argv.slice(2, 3)
 const template = `mdx-js/mdx/examples/${example}`
 
 init({ name, template })

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -36,7 +36,9 @@ function toJSX(node, parentNode = {}, options = {}) {
       '\n' +
       exportNodes.map(childNode => toJSX(childNode, node)).join('\n') +
       '\n' +
-      (options.skipExport ? '' : 'export default ({components, ...props}) => ') +
+      (options.skipExport
+        ? ''
+        : 'export default ({components, ...props}) => ') +
       `<MDXTag name="wrapper" ${
         layout ? `Layout={${layout}} layoutProps={props}` : ''
       } components={components}>${jsxNodes

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -78,9 +78,7 @@ it('Should not include export wrapper if skipExport is true', async () => {
   const result = await mdx('> test\n\n> `test`', { skipExport: true })
 
   expect(
-    result.includes(
-      'export default ({components, ...props}) =>'
-    )
+    result.includes('export default ({components, ...props}) =>')
   ).toBeFalsy()
 })
 

--- a/packages/parcel-plugin-mdx/test/index.test.js
+++ b/packages/parcel-plugin-mdx/test/index.test.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const index = require('../src');
+const index = require('../src')
 const MDXAsset = require('../src/MDXAsset')
 
 let value


### PR DESCRIPTION
This PR updates to prettier@^1.14. After installing, I ran `npm run format` to format all files with the latest version of Prettier.