### PR TITLE
docs: fix missing link in specification.md

### DIFF
--- a/docs/advanced/specification.md
+++ b/docs/advanced/specification.md
@@ -2,7 +2,7 @@
 
 MDX includes a [specification][spec] to define the syntax and transpilation.
 This can be leveraged by code formatters, linters, and implementations in other languages created by the community.
-It's based on the [remark][remark]/[unist][unist] ecosystem to ensure robust parsing and the ability to leverage plugins from within your MDX.
+It's based on the [remark][]/[unified][] ecosystem to ensure robust parsing and the ability to leverage plugins from within your MDX.
 
 [See the specification][spec]
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2344137/44938132-db5b5a00-ad31-11e8-800b-ab14643854b0.png)

After:

![image](https://user-images.githubusercontent.com/2344137/44938571-ac92b300-ad34-11e8-8397-6eeea06a87a0.png)
