### PR TITLE
Add filename info to mdx loader

### DIFF
--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -3,9 +3,9 @@ const mdx = require('@mdx-js/mdx')
 
 module.exports = async function(content) {
   const callback = this.async()
-  const options = getOptions(this)
+  const options = Object.assign({}, getOptions(this), {filepath: this.resourcePath});
 
-  const result = await mdx(content, options || {})
+  const result = await mdx(content, options)
 
   const code = `
   import React from 'react'

--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -103,7 +103,12 @@ function sync(mdx, options) {
   const opts = Object.assign({}, DEFAULT_OPTIONS, options)
   const compiler = createCompiler(opts)
 
-  const { contents } = compiler.processSync(mdx)
+  const fileOpts = { contents: mdx };
+  if (opts.filepath) {
+    fileOpts.path = opts.filepath;
+  }
+
+  const { contents } = compiler.processSync(fileOpts)
 
   return contents
 }
@@ -112,7 +117,12 @@ async function compile(mdx, options = {}) {
   const opts = Object.assign({}, DEFAULT_OPTIONS, options)
   const compiler = createCompiler(opts)
 
-  const { contents } = await compiler.process(mdx)
+  const fileOpts = { contents: mdx };
+  if (opts.filepath) {
+    fileOpts.path = opts.filepath;
+  }
+
+  const { contents } = await compiler.process(fileOpts)
 
   return contents
 }

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -122,6 +122,22 @@ test('Should await and render async plugins', async () => {
   expect(result).toMatch(/HELLO, WORLD!/)
 })
 
+test('Should process filepath and pass it to the plugins', async () => {
+  const result = await mdx(fixtureBlogPost, {
+    filepath: 'hello.mdx',
+    hastPlugins: [
+      options => (tree, fileInfo) => {
+        expect(fileInfo.path).toBe('hello.mdx')
+        const headingNode = select('h1', tree)
+        const textNode = headingNode.children[0]
+        textNode.value = textNode.value.toUpperCase()
+      }
+    ]
+  })
+
+  expect(result).toMatch(/HELLO, WORLD!/)
+})
+
 test(
   'Should parse and render footnotes',
   async () => {


### PR DESCRIPTION
For a rehype plugin I'm working on I need the path of the current file being transpiled, I use it to resolve imports. This adds the filename info to the `process` function which allows plugins to access it.