### PR TITLE
fix SyntaxError: Unexpected token at runtime

### DIFF
--- a/packages/runtime/src/index.js
+++ b/packages/runtime/src/index.js
@@ -13,7 +13,13 @@ export default ({ scope = {}, components = {}, children, ...props }) => {
 
   const jsx = mdx.sync(children, { skipExport: true }).trim()
 
-  const { code } = transform(jsx)
+  let code = null;
+
+  try {
+    code = transform(jsx).code
+  } catch(error) {
+    console.log(error);
+  }
 
   const keys = Object.keys(fullScope)
   const values = keys.map(key => fullScope[key])


### PR DESCRIPTION
Hello,

I'm trying to implement a Markdown Editor with MDX-support.

When an user will enter some invalid HTML, there is an error (SyntaxError: Unexpected token) that I can't catch (not with componentDidCatch or a regular try/catch).

With this change, the error is just logged but is probably not the best fix for this.

- Node version: v10.8.0
- npm version: 6.4.1

**MarkdownRenderer.js** 

```js
import React, { Component } from 'react';

import MDX from '@mdx-js/runtime';

class MarkdownRenderer extends Component {
  state = {
    hasError: false
  };

  componentDidCatch() {
    console.log('Error!');

    this.setState({ error: true });
  }

  render() {
    if (this.state.hasError) {
      return <div>Error!</div>;
    }

    return <MDX>{this.props.content}</MDX>;
  }
}

export default MarkdownRenderer;
```

**MarkdownEditor.js**

```js
import React, { Component } from 'react';
import debounce from 'lodash.debounce';
import MarkdownRenderer from '../MarkdownRenderer';

class MarkdownEditor extends Component {
  state = {
    content: '# Hello, world!'
  };

  onChange = debounce(content => {
    // This try/catch doesn't work.
    try {
      this.setState(() => ({
        content
      }));
    } catch (error) {
      console.log('error', error);
    }
  }, 1000);

  render() {
    return (
      <div className="MarkdownEditor">
        <textarea
          defaultValue={this.state.content}
          onChange={event => this.onChange(event.target.value)}
        />
        <MarkdownRenderer content={this.state.content} />
      </div>
    );
  }
}

export default MarkdownEditor;
```

**How to trigger the error?**
```md
# Hello, world!

<img 
```

**Sandbox URL**
https://codesandbox.io/s/6lk28zpx1z?expanddevtools=1
