### PR TITLE
enable infostring props

### DIFF
--- a/packages/mdx/mdx-ast-to-mdx-hast.js
+++ b/packages/mdx/mdx-ast-to-mdx-hast.js
@@ -1,4 +1,6 @@
 const toHAST = require('mdast-util-to-hast')
+const detab = require('detab')
+const u = require('unist-builder')
 
 module.exports = function mdxAstToMdxHast() {
   return (tree, file) => {
@@ -17,6 +19,38 @@ module.exports = function mdxAstToMdxHast() {
             }
           ]
         })
+      },
+      code(h, node) {
+        var value = node.value ? detab(node.value + '\n') : ''
+        var lang = node.lang && node.lang.match(/^[^ \t]+(?=[ \t]|$)/)
+        var props = {}
+
+        if (lang) {
+          props.className = ['language-' + lang]
+        }
+
+        props.metaString =
+          node.lang && node.lang.replace(/^[^ \t]+(?=[ \t]|$)/, '').trim()
+
+        const meta =
+          props.metaString &&
+          props.metaString.split(' ').reduce((acc, cur) => {
+            if (cur.split('=').length > 1) {
+              const t = cur.split('=')
+              acc[t[0]] = t[1]
+              return acc
+            } else {
+              acc[cur] = true
+              return acc
+            }
+          }, {})
+
+        meta &&
+          Object.entries(meta).forEach(([key, value]) => (props[key] = value))
+
+        return h(node.position, 'pre', [
+          h(node, 'code', props, [u('text', value)])
+        ])
       },
       import(h, node) {
         return Object.assign({}, node, {

--- a/packages/mdx/mdx-ast-to-mdx-hast.js
+++ b/packages/mdx/mdx-ast-to-mdx-hast.js
@@ -21,16 +21,16 @@ module.exports = function mdxAstToMdxHast() {
         })
       },
       code(h, node) {
-        var value = node.value ? detab(node.value + '\n') : ''
-        var lang = node.lang && node.lang.match(/^[^ \t]+(?=[ \t]|$)/)
-        var props = {}
+        const langRegex = /^[^ \t]+(?=[ \t]|$)/
+        const value = node.value ? detab(node.value + '\n') : ''
+        const lang = node.lang && node.lang.match(langRegex)
+        const props = {}
 
         if (lang) {
           props.className = ['language-' + lang]
         }
 
-        props.metaString =
-          node.lang && node.lang.replace(/^[^ \t]+(?=[ \t]|$)/, '').trim()
+        props.metaString = node.lang && node.lang.replace(langRegex, '').trim()
 
         const meta =
           props.metaString &&
@@ -45,8 +45,7 @@ module.exports = function mdxAstToMdxHast() {
             }
           }, {})
 
-        meta &&
-          Object.entries(meta).forEach(([key, value]) => (props[key] = value))
+        meta && Object.keys(meta).forEach(key => (props[key] = meta[key]))
 
         return h(node.position, 'pre', [
           h(node, 'code', props, [u('text', value)])

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -56,14 +56,32 @@ it('Should render HTML inside inlineCode correctly', async () => {
 })
 
 it('Should preserve newlines in code blocks', async () => {
-  const result = await mdx(`
+  const result = await mdx(
+    `
 \`\`\`dockerfile
 # Add main script
 COPY start.sh /home/start.sh
 \`\`\`
-  `, { hastPlugins: [prism] })
+  `,
+    { hastPlugins: [prism] }
+  )
 
   expect(result).toContain('{`# Add main script`}</MDXTag>{`\n`}')
+})
+
+it('Should preserve infostring in code blocks', async () => {
+  const result = await mdx(
+    `
+\`\`\`dockerfile exec registry=something.com
+# Add main script
+COPY start.sh /home/start.sh
+\`\`\`
+  `
+  )
+
+  expect(result).toContain(
+    `props={{"className":"language-dockerfile","metaString":"exec registry=something.com","exec":true,"registry":"something.com"}}`
+  )
 })
 
 it('Should support comments', async () => {


### PR DESCRIPTION
This PR enables the passing of the full infostring content as props to react components, enabling things like repls to be enabled as such:

![carbon 2](https://user-images.githubusercontent.com/551247/45446852-c7ddb680-b682-11e8-89a4-124fe2be3572.png)


The PR mostly copies from the underlying [mdast handler](https://github.com/syntax-tree/mdast-util-to-hast/blob/1f8591e0b6163c437999e842774f66c9027cfc47/lib/handlers/code.js), but adds basic handling for potential meta strings. I think the handling is "good enough" right now even though it has some quirks like requiring a single space between infostring parameters. We can expand the algorithm in the future if things like array support are desired.

based on the conversation in https://github.com/syntax-tree/mdast-util-to-hast/issues/24

closes https://github.com/mdx-js/mdx/issues/141 and https://github.com/ChristopherBiscardi/gatsby-mdx/issues/76