### PR TITLE
Fix support for comments

### DIFF
--- a/packages/mdx/md-ast-to-mdx-ast.js
+++ b/packages/mdx/md-ast-to-mdx-ast.js
@@ -2,7 +2,14 @@ const visit = require('unist-util-visit')
 
 module.exports = options => tree => {
   visit(tree, 'html', node => {
-    node.type = node.mdxType || 'jsx'
+    if (
+      node.value.startsWith('<!--') &&
+      node.value.endsWith('-->')
+    ) {
+      node.type = 'comment'
+    } else {
+      node.type = node.mdxType || 'jsx'
+    }
   })
 
   return tree

--- a/packages/mdx/mdx-ast-to-mdx-hast.js
+++ b/packages/mdx/mdx-ast-to-mdx-hast.js
@@ -61,6 +61,11 @@ module.exports = function mdxAstToMdxHast() {
           type: 'export'
         })
       },
+      comment(h, node) {
+        return Object.assign({}, node, {
+          type: 'comment'
+        })
+      },
       jsx(h, node) {
         return Object.assign({}, node, {
           type: 'jsx'

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -27,12 +27,6 @@ function toJSX(node, parentNode = {}, options = {}) {
         continue
       }
 
-      if (childNode.type === 'jsx') {
-        childNode.value = childNode.value
-          .replace('<!--', '{/*')
-          .replace('-->', '*/}')
-      }
-
       jsxNodes.push(childNode)
     }
 
@@ -88,6 +82,12 @@ function toJSX(node, parentNode = {}, options = {}) {
       return node.value
     }
     return '{`' + node.value.replace(/`/g, '\\`').replace(/\$/g, '\\$') + '`}'
+  }
+
+  if (node.type === 'comment') {
+    return node.value
+      .replace('<!--', '{/*')
+      .replace('-->', '*/}')
   }
 
   if (node.type === 'import' || node.type === 'export' || node.type === 'jsx') {

--- a/packages/mdx/test/fixtures/blog-post.md
+++ b/packages/mdx/test/fixtures/blog-post.md
@@ -20,7 +20,6 @@ I'm an awesome paragraph.
   <Bar>hi</Bar>
     {hello}
     {/* another commment */}
-    <!-- one more comment -->
 </Foo>
 
 ```

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -86,20 +86,39 @@ COPY start.sh /home/start.sh
 
 it('Should support comments', async () => {
   const result = await mdx(`
-A paragraph
 <!-- a Markdown comment -->
+A paragraph
+
+Some text <!-- an inline comment -->
+
 \`\`\`md
-<!-- a code block Markdown comment -->
+<!-- a code block string -->
 \`\`\`
+
 <div>
   {/* a nested JSX comment */}
-  <!-- a nested Markdown comment -->
+  <!-- div content -->
 </div>
+
+<!-- a comment above -->
+- list item
+<!-- a comment below -->
+
+--> should be as-is
+
+<MyComp content={\`
+  <!-- a template literal -->
+\`}
   `)
   expect(result).toContain('{/* a Markdown comment */}')
-  expect(result).toContain('<!-- a code block Markdown comment -->')
+  expect(result).toContain('{/* an inline comment */}')
+  expect(result).toContain('<!-- a code block string -->')
   expect(result).toContain('{/* a nested JSX comment */}')
-  expect(result).toContain('{/* a nested Markdown comment */}')
+  expect(result).toContain('<!-- div content -->')
+  expect(result).toContain('{/* a comment above */}')
+  expect(result).toContain('{/* a comment below */}')
+  expect(result).toContain('--> should be as-is')
+  expect(result).toContain('<!-- a template literal -->')
 })
 
 it('Should not include export wrapper if skipExport is true', async () => {


### PR DESCRIPTION
Previous implementation of comments was simply converting all `<!--` and
`-->` to `{/*` and `*/}`. This was very naive and caused a lot of edge
cases. It also supported nesting Markdown comments in JSX, which isn't
how regular Markdown works; nesting comments inside regular HTML doesn't
work, so it doesn't make sense that it works here. So that part is a breaking change.

This fix simply takes advantage of remark's support for comments, which
takes care of all of the edge cases and doesn't reinvent the wheel.