### PR TITLE
Fix multiline default export statement edge case

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -23,7 +23,7 @@ const DEFAULT_OPTIONS = {
 
 const tokenizeEsSyntax = (eat, value) => {
   const index = value.indexOf(EMPTY_NEWLINE)
-  const subvalue = value.slice(0, index)
+  const subvalue = index !== -1 ? value.slice(0, index) : value
 
   if (isExport(subvalue) || isImport(subvalue)) {
     return eat(subvalue)({

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -129,6 +129,15 @@ $$
   expect(result).toContain('"aria-hidden":"true"')
 })
 
+it('Should support multiline default export statement', async () => {
+  const result = await mdx(`export default ({ children }) => (
+  <Layout>
+    {children}
+  </Layout>
+)`)
+  expect(() => parse(result)).not.toThrow()
+})
+
 it('Should not include export wrapper if skipExport is true', async () => {
   const result = await mdx('> test\n\n> `test`', { skipExport: true })
 


### PR DESCRIPTION
Multiline export default statements worked only when followed by an empty line (two newlines), otherwise the last character was being eaten, which caused a syntax error.