### PR TITLE
updated dependencies for Parcel example

### DIFF
--- a/examples/parcel/package.json
+++ b/examples/parcel/package.json
@@ -6,12 +6,16 @@
   },
   "dependencies": {
     "@mdx-js/tag": "^0.14.1-0",
-    "react": "16.4.1",
-    "react-dom": "16.4.1"
+    "@rebass/markdown": "^1.0.0",
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2",
+    "rebass": "^2.3.4",
+    "styled-components": "^3.4.9"
   },
   "devDependencies": {
     "@mdx-js/parcel-plugin-mdx": "^0.15.0-2",
+    "babel-core": "^6.26.3",
     "babel-preset-react-app": "^3.1.2",
-    "parcel-bundler": "1.9.0"
+    "parcel-bundler": "^1.10.0"
   }
 }


### PR DESCRIPTION
Parcel installs stuff on the fly and adds missing dependencies to package.json, so adding these to the example.