### PR TITLE
Docs: add eslint-plugin-mdx

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -45,6 +45,7 @@ These projects define the syntax which MDX blends together (MD and JSX).
 - [markdown-in-js](https://github.com/threepointone/markdown-in-js)
 - [remark-jsx](https://github.com/fazouane-marouane/remark-jsx)
 - [remark-react](https://github.com/mapbox/remark-react)
+- [eslint-plugin-mdx](https://github.com/azz/eslint-plugin-mdx)
 
 ### Other
 


### PR DESCRIPTION
Really loving MDX, but I was missing ESLint for unused imports, etc. So I put together [eslint-plugin-mdx](https://github.com/azz/eslint-plugin-mdx) to allow ESLint to run on `.mdx` files.

https://mdx-rmlsfynkvg.now.sh/about#libraries