### PR TITLE
Don't include metaString in code props

### DIFF
--- a/packages/mdx/mdx-ast-to-mdx-hast.js
+++ b/packages/mdx/mdx-ast-to-mdx-hast.js
@@ -30,11 +30,11 @@ module.exports = function mdxAstToMdxHast() {
           props.className = ['language-' + lang]
         }
 
-        props.metaString = node.lang && node.lang.replace(langRegex, '').trim()
+        const metaString = node.lang && node.lang.replace(langRegex, '').trim()
 
         const meta =
-          props.metaString &&
-          props.metaString.split(' ').reduce((acc, cur) => {
+          metaString &&
+          metaString.split(' ').reduce((acc, cur) => {
             if (cur.split('=').length > 1) {
               const t = cur.split('=')
               acc[t[0]] = t[1]


### PR DESCRIPTION
React throws a warning:
`Warning: React does not recognize the metaString prop on a DOM element.`

<img width="1087" alt="pasted_image_10_2_18__1_22_pm" src="https://user-images.githubusercontent.com/1364795/46365367-6d62c500-c646-11e8-9db4-4d5811dd9212.png">
