### PR TITLE
🐛 FIX: link for projects/libs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ npm init mdx
 
 - [Documentation](https://mdxjs.com)
   - [Syntax](https://mdxjs.com/syntax)
-  - [Getting Started](https://mdxjs.com/getting-started)
+  - [Getting Started](https://mdxjs.com/getting-started/)
   - [Plugins](https://mdxjs.com/plugins)
   - [Contributing](https://mdxjs.com/advanced/contributing)
 


### PR DESCRIPTION
If you go to https://mdxjs.com/getting-started#projects-libraries-and-frameworks without the trailing slash then links in there don't work.

❌ `https://mdxjs.com/getting-started`
— Click on webpack leads to https://mdxjs.com/webpack


✅ `https://mdxjs.com/getting-started/`
— Click on webpack leads to https://mdxjs.com/getting-started/webpack

Peace! ✌️
