### PR TITLE
Don't pass `metaString` prop to <pre> DOM element

### DIFF
--- a/packages/mdx/mdx-ast-to-mdx-hast.js
+++ b/packages/mdx/mdx-ast-to-mdx-hast.js
@@ -29,12 +29,12 @@ module.exports = function mdxAstToMdxHast() {
         if (lang) {
           props.className = ['language-' + lang]
         }
-
-        props.metaString = node.lang && node.lang.replace(langRegex, '').trim()
+        
+        const metaString = node.lang && node.lang.replace(langRegex, '').trim()
 
         const meta =
-          props.metaString &&
-          props.metaString.split(' ').reduce((acc, cur) => {
+          metaString &&
+          metaString.split(' ').reduce((acc, cur) => {
             if (cur.split('=').length > 1) {
               const t = cur.split('=')
               acc[t[0]] = t[1]

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -82,7 +82,7 @@ COPY start.sh /home/start.sh
   )
 
   expect(result).toContain(
-    `props={{"className":"language-dockerfile","metaString":"exec registry=something.com","exec":true,"registry":"something.com"}}`
+    `props={{"className":"language-dockerfile","exec":true,"registry":"something.com"}}`
   )
 })
 


### PR DESCRIPTION
Currently, whenever a code block (`pre > code`) is rendered by MDX to the DOM, React prints this warning:

```
index.js:2178 Warning: React does not recognize the `metaString` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `metastring` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in code (created by MDXTag)
    in MDXTag (created by Context.Consumer)
    in Unknown (at this-is-the-slug.mdx:17)
    in pre (created by MDXTag)
    in MDXTag (created by Context.Consumer)
    in Unknown (at this-is-the-slug.mdx:17)
    in main (at Layout.js:11)
    in div (at Layout.js:6)
    in Layout (at BlogLayout.js:4)
    in BlogLayout (at this-is-the-slug.mdx:14)
    in div (created by MDXTag)
    in MDXTag (created by Context.Consumer)
    in Unknown (at this-is-the-slug.mdx:12)
    in Unknown (at _app.js:15)
    in Container (at _app.js:14)
    in MyApp
```

I couldn't find any other usages of this prop besides a test that checked for it. Does any rehast plugin depend on this prop?

Fixes https://github.com/zeit/next-plugins/issues/307