### PR TITLE
Add unist-builder in package.json

### DIFF
--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -29,6 +29,7 @@
     "remark-squeeze-paragraphs": "^3.0.1",
     "to-style": "^1.3.3",
     "unified": "^6.1.6",
+    "unist-builder": "^1.0.1",
     "unist-util-visit": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I haven't install the project, I'm doing the modification on github directly, you may need to relaunch yarn to update the yarn.lock

Related to #297 

It seems to be the last dependency that isn't mentioned in the package.json.
