### PR TITLE
Stabilize UserLayout

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -95,18 +95,29 @@ function toJSX(node, parentNode = {}, options = {}) {
 
       jsxNodes.push(childNode)
     }
-
     return (
       importNodes.map(childNode => toJSX(childNode, node)).join('\n') +
       '\n' +
       exportNodes.map(childNode => toJSX(childNode, node)).join('\n') +
       '\n' +
-      (skipExport ? '' : 'export default ({components, ...props}) => ') +
-      `<MDXTag name="wrapper" ${
-        layout ? `Layout={${layout}} layoutProps={props}` : ''
-      } components={components}>${jsxNodes
-        .map(childNode => toJSX(childNode, node))
-        .join('')}</MDXTag>`
+      (skipExport
+        ? ''
+        : `export default class MDXContent extends React.Component {
+  constructor() {
+    this.layout = ${layout}
+  }
+  render() {
+    const {components, ...props} = this.props;`) +
+      `${skipExport ? '' : 'return '}<MDXTag 
+  name="wrapper" ${
+    layout
+      ? `Layout={${skipExport ? layout : 'this.layout'}} layoutProps={props}`
+      : ''
+  }
+  components={components}>${jsxNodes
+    .map(childNode => toJSX(childNode, node))
+    .join('')}</MDXTag>
+${skipExport ? '' : '}}'}`
     )
   }
 

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -100,27 +100,24 @@ function toJSX(node, parentNode = {}, options = {}) {
       '\n' +
       exportNodes.map(childNode => toJSX(childNode, node)).join('\n') +
       '\n' +
-      (skipExport
-        ? ''
-        : `export default class MDXContent extends React.Component {
+      `${
+        skipExport ? '' : 'export default'
+      } class MDXContent extends React.Component {
   constructor() {
     this.layout = ${layout}
   }
   render() {
-    const {components, ...props} = this.props;`) +
-      `${skipExport ? '' : 'return '}<MDXTag 
-  name="wrapper" ${
-    layout
-      ? `Layout={${skipExport ? layout : 'this.layout'}} layoutProps={props}`
-      : ''
+    return <MDXTag
+             name="wrapper"
+             ${layout ? `Layout={this.layout} layoutProps={props}` : ''}
+             components={components}>${jsxNodes
+               .map(childNode => toJSX(childNode, node))
+               .join('')}
+           </MDXTag>
   }
-  components={components}>${jsxNodes
-    .map(childNode => toJSX(childNode, node))
-    .join('')}</MDXTag>
-${skipExport ? '' : '}}'}`
+}`
     )
   }
-
   // Recursively walk through children
   if (node.children) {
     children = node.children

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -45,7 +45,8 @@
     "@babel/plugin-syntax-jsx": "^7.0.0",
     "@mapbox/rehype-prism": "^0.3.0",
     "hast-util-select": "^3.0.0",
-    "jest": "^23.0.0",
+    "jest": "^23.6.0",
+    "prettier": "^1.14.2",
     "rehype-katex": "^1.1.1",
     "remark-math": "^1.0.4"
   },

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -7,6 +7,7 @@ const {select} = require('hast-util-select')
 const prism = require('@mapbox/rehype-prism')
 const math = require('remark-math')
 const katex = require('rehype-katex')
+const prettier = require('prettier')
 
 const fixtureBlogPost = fs.readFileSync(
   path.join(__dirname, './fixtures/blog-post.md')
@@ -40,6 +41,108 @@ it('Should compile sample blog post', async () => {
   const result = await mdx(fixtureBlogPost)
 
   parse(result)
+})
+
+it('Should match sample blog post snapshot', async () => {
+  const result = await mdx(fixtureBlogPost)
+
+  expect(prettier.format(result, {parser: 'babylon'})).toMatchInlineSnapshot(`
+"import { Baz } from \\"./Fixture\\";
+import { Buz } from \\"./Fixture\\";
+export const foo = {
+  hi: \`Fudge \${Baz.displayName || \\"Baz\\"}\`,
+  authors: [\\"fred\\", \\"sally\\"]
+};
+export default class MDXContent extends React.Component {
+  constructor() {
+    this.layout = ({ children }) => <div>{children}</div>;
+  }
+  render() {
+    return (
+      <MDXTag
+        name=\\"wrapper\\"
+        Layout={this.layout}
+        layoutProps={props}
+        components={components}
+      >
+        <MDXTag name=\\"h1\\" components={components}>{\`Hello, world!\`}</MDXTag>
+        <MDXTag
+          name=\\"p\\"
+          components={components}
+        >{\`I'm an awesome paragraph.\`}</MDXTag>
+        {/* I'm a comment */}
+        <Foo bg=\\"red\\">
+          <Bar>hi</Bar>
+          {hello}
+          {/* another commment */}
+        </Foo>
+        <MDXTag name=\\"pre\\" components={components}>
+          <MDXTag
+            name=\\"code\\"
+            components={components}
+            parentName=\\"pre\\"
+            props={{ metastring: null }}
+          >{\`test codeblock
+\`}</MDXTag>
+        </MDXTag>
+        <MDXTag name=\\"pre\\" components={components}>
+          <MDXTag
+            name=\\"code\\"
+            components={components}
+            parentName=\\"pre\\"
+            props={{ className: \\"language-js\\", metastring: \\"\\" }}
+          >{\`module.exports = 'test'
+\`}</MDXTag>
+        </MDXTag>
+        <MDXTag name=\\"pre\\" components={components}>
+          <MDXTag
+            name=\\"code\\"
+            components={components}
+            parentName=\\"pre\\"
+            props={{ className: \\"language-sh\\", metastring: \\"\\" }}
+          >{\`npm i -g foo
+\`}</MDXTag>
+        </MDXTag>
+        <MDXTag name=\\"table\\" components={components}>
+          <MDXTag name=\\"thead\\" components={components} parentName=\\"table\\">
+            <MDXTag name=\\"tr\\" components={components} parentName=\\"thead\\">
+              <MDXTag
+                name=\\"th\\"
+                components={components}
+                parentName=\\"tr\\"
+                props={{ align: \\"left\\" }}
+              >{\`Test\`}</MDXTag>
+              <MDXTag
+                name=\\"th\\"
+                components={components}
+                parentName=\\"tr\\"
+                props={{ align: \\"left\\" }}
+              >{\`Table\`}</MDXTag>
+            </MDXTag>
+          </MDXTag>
+          <MDXTag name=\\"tbody\\" components={components} parentName=\\"table\\">
+            <MDXTag name=\\"tr\\" components={components} parentName=\\"tbody\\">
+              <MDXTag
+                name=\\"td\\"
+                components={components}
+                parentName=\\"tr\\"
+                props={{ align: \\"left\\" }}
+              >{\`Col1\`}</MDXTag>
+              <MDXTag
+                name=\\"td\\"
+                components={components}
+                parentName=\\"tr\\"
+                props={{ align: \\"left\\" }}
+              >{\`Col2\`}</MDXTag>
+            </MDXTag>
+          </MDXTag>
+        </MDXTag>
+      </MDXTag>
+    );
+  }
+}
+"
+`)
 })
 
 it('Should render blockquote correctly', async () => {

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -44,99 +44,17 @@ it('Should compile sample blog post', async () => {
 })
 
 it('Should match sample blog post snapshot', async () => {
-  const result = await mdx(fixtureBlogPost)
+  const result = await mdx(`# Hello World`)
 
   expect(prettier.format(result, {parser: 'babylon'})).toMatchInlineSnapshot(`
-"import { Baz } from \\"./Fixture\\";
-import { Buz } from \\"./Fixture\\";
-export const foo = {
-  hi: \`Fudge \${Baz.displayName || \\"Baz\\"}\`,
-  authors: [\\"fred\\", \\"sally\\"]
-};
-export default class MDXContent extends React.Component {
+"export default class MDXContent extends React.Component {
   constructor() {
-    this.layout = ({ children }) => <div>{children}</div>;
+    this.layout = undefined;
   }
   render() {
     return (
-      <MDXTag
-        name=\\"wrapper\\"
-        Layout={this.layout}
-        layoutProps={props}
-        components={components}
-      >
-        <MDXTag name=\\"h1\\" components={components}>{\`Hello, world!\`}</MDXTag>
-        <MDXTag
-          name=\\"p\\"
-          components={components}
-        >{\`I'm an awesome paragraph.\`}</MDXTag>
-        {/* I'm a comment */}
-        <Foo bg=\\"red\\">
-          <Bar>hi</Bar>
-          {hello}
-          {/* another commment */}
-        </Foo>
-        <MDXTag name=\\"pre\\" components={components}>
-          <MDXTag
-            name=\\"code\\"
-            components={components}
-            parentName=\\"pre\\"
-            props={{ metastring: null }}
-          >{\`test codeblock
-\`}</MDXTag>
-        </MDXTag>
-        <MDXTag name=\\"pre\\" components={components}>
-          <MDXTag
-            name=\\"code\\"
-            components={components}
-            parentName=\\"pre\\"
-            props={{ className: \\"language-js\\", metastring: \\"\\" }}
-          >{\`module.exports = 'test'
-\`}</MDXTag>
-        </MDXTag>
-        <MDXTag name=\\"pre\\" components={components}>
-          <MDXTag
-            name=\\"code\\"
-            components={components}
-            parentName=\\"pre\\"
-            props={{ className: \\"language-sh\\", metastring: \\"\\" }}
-          >{\`npm i -g foo
-\`}</MDXTag>
-        </MDXTag>
-        <MDXTag name=\\"table\\" components={components}>
-          <MDXTag name=\\"thead\\" components={components} parentName=\\"table\\">
-            <MDXTag name=\\"tr\\" components={components} parentName=\\"thead\\">
-              <MDXTag
-                name=\\"th\\"
-                components={components}
-                parentName=\\"tr\\"
-                props={{ align: \\"left\\" }}
-              >{\`Test\`}</MDXTag>
-              <MDXTag
-                name=\\"th\\"
-                components={components}
-                parentName=\\"tr\\"
-                props={{ align: \\"left\\" }}
-              >{\`Table\`}</MDXTag>
-            </MDXTag>
-          </MDXTag>
-          <MDXTag name=\\"tbody\\" components={components} parentName=\\"table\\">
-            <MDXTag name=\\"tr\\" components={components} parentName=\\"tbody\\">
-              <MDXTag
-                name=\\"td\\"
-                components={components}
-                parentName=\\"tr\\"
-                props={{ align: \\"left\\" }}
-              >{\`Col1\`}</MDXTag>
-              <MDXTag
-                name=\\"td\\"
-                components={components}
-                parentName=\\"tr\\"
-                props={{ align: \\"left\\" }}
-              >{\`Col2\`}</MDXTag>
-            </MDXTag>
-          </MDXTag>
-        </MDXTag>
+      <MDXTag name=\\"wrapper\\" components={components}>
+        <MDXTag name=\\"h1\\" components={components}>{\`Hello World\`}</MDXTag>
       </MDXTag>
     );
   }

--- a/packages/runtime/src/index.js
+++ b/packages/runtime/src/index.js
@@ -31,7 +31,14 @@ export default ({
   const keys = Object.keys(fullScope)
   const values = keys.map(key => fullScope[key])
   // eslint-disable-next-line no-new-func
-  const fn = new Function('_fn', 'React', ...keys, `return ${code}`)
+  const fn = new Function(
+    '_fn',
+    'React',
+    ...keys,
+    `${code}
+
+  return React.createElement(MDXContent);`
+  )
 
   return fn({}, React, ...values)
 }


### PR DESCRIPTION
Fixes https://github.com/mdx-js/mdx/issues/307

Pulls the layout for an MDX file into a reference that will be stable
across renders. Previously, a layout defined in MDX content as an
inline arrow function:

```js
export default ({ children, ...props }) => <div {...props}>{children}</div>
```

would result in function defined inline in render, causing the
reference to be created each time resulting in a remounting.

This PR stablizes the reference by pulling the layout outside of
render, resulting in no remount.
