### PR TITLE
Markdown style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org
 root = true
 
 [*]

--- a/.remarkignore
+++ b/.remarkignore
@@ -1,0 +1,1 @@
+packages/**/test

--- a/contributing.md
+++ b/contributing.md
@@ -5,8 +5,9 @@ We’re excited that you’re interested in contributing!
 Take a moment to read the following guidelines.
 And thanks for contributing to **mdx**!  👏👌✨
 
-If you’re raising an issue, please understand that people involved with this project often do so for fun,
-next to their day job; you are not entitled to free customer service.
+If you’re raising an issue, please understand that people involved with this
+project often do so for fun, next to their day job; you are not entitled to
+free customer service.
 
 ## Table of Contents
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -2,56 +2,88 @@ import { Avatar } from 'rebass'
 
 # About
 
-MDX is based on the [original `.mdx` proposal](https://spectrum.chat/thread/1021be59-2738-4511-aceb-c66921050b9a) by Guillermo Rauch ([@rauchg](https://twitter.com/rauchg)).
+MDX is based on the [original `.mdx` proposal][idea] by Guillermo Rauch
+([@rauchg][rauchg]).
 
-The source code for MDX is available on [GitHub](https://github.com/mdx-js/mdx).
+The source code for MDX is available on [GitHub][].
 
 ## Design
 
-[Logo designs](https://github.com/mdx-js/design) were created by [Evil Rabbit](https://twitter.com/evilrabbit_) of [ZEIT](https://zeit.co).
+[Logo designs][design] were created by [Evil Rabbit][]) of [ZEIT][].
 
-[See logo resources](https://github.com/mdx-js/design)
+[See logo resources][design]
 
 ## Authors
 
-- [John Otander](https://johno.com) ([@4lpine](https://twitter.com/4lpine)) – [Compositor](https://compositor.io) + [Clearbit](https://clearbit.com)
-- Tim Neutkens ([@timneutkens](https://github.com/timneutkens)) – [ZEIT](https://zeit.co)
-- [Guillermo Rauch](https://rauchg.com) ([@rauchg](https://twitter.com/rauchg)) – [ZEIT](https://zeit.co)
-- [Brent Jackson](https://jxnblk.com) ([@jxnblk](https://twitter.com/jxnblk)) – [Compositor](https://compositor.io)
+*   [John Otander][john] ([@4lpine][4lpine]) – [Compositor][] + [Clearbit][]
+*   [Tim Neutkens][tim] ([@timneutkens][timneutkens]) – [ZEIT][]
+*   [Guillermo Rauch][guillermo] ([@rauchg][rauchg]) – [ZEIT][]
+*   [Brent Jackson][brent] ([@jxnblk][jxnblk]) – [Compositor][]
 
 ## Related
 
-The following projects, languages, and articles helped to shape MDX either in implementation or inspiration.
+The following projects, languages, and articles helped to shape MDX either in
+implementation or inspiration.
+
+Is your work missing?
+If you have related work or prior art we’ve failed to reference, please open a
+PR!
 
 ### Syntax
 
 These projects define the syntax which MDX blends together (MD and JSX).
 
-- [Markdown](https://daringfireball.net/projects/markdown/syntax)
-- [JSX](https://reactjs.org/docs/introducing-jsx.html)
-- [React](https://reactjs.org/)
+*   [Markdown](https://daringfireball.net/projects/markdown/syntax)
+*   [JSX](https://reactjs.org/docs/introducing-jsx.html)
+*   [React](https://reactjs.org/)
 
 ### Parsing and implementation
 
-- [Remark](http://remark.js.org)
-- [Unified](https://github.com/unifiedjs/unified)
-- [Webpack](https://webpack.js.org)
-- [Parcel](https://parceljs.com)
+*   [remark](https://remark.js.org)
+*   [unified](https://unified.js.org)
+*   [Webpack](https://webpack.js.org)
+*   [Parcel](https://parceljs.com)
 
 ### Libraries
 
-- [MDXC](https://github.com/jamesknelson/mdxc)
-- [Markdown Component Loader](https://github.com/ticky/markdown-component-loader)
-- [markdown-in-js](https://github.com/threepointone/markdown-in-js)
-- [remark-jsx](https://github.com/fazouane-marouane/remark-jsx)
-- [remark-react](https://github.com/mapbox/remark-react)
-- [eslint-plugin-mdx](https://github.com/azz/eslint-plugin-mdx)
+*   [MDXC](https://github.com/jamesknelson/mdxc)
+*   [Markdown Component Loader](https://github.com/ticky/markdown-component-loader)
+*   [markdown-in-js](https://github.com/threepointone/markdown-in-js)
+*   [remark-jsx](https://github.com/fazouane-marouane/remark-jsx)
+*   [remark-react](https://github.com/mapbox/remark-react)
+*   [eslint-plugin-mdx](https://github.com/azz/eslint-plugin-mdx)
 
 ### Other
 
-- [IA Markdown Content Blocks](https://github.com/iainc/Markdown-Content-Blocks)
-- [Idyll: Markup language for interactive documents](https://idyll-lang.org)
+*   [IA Markdown Content Blocks](https://github.com/iainc/Markdown-Content-Blocks)
+*   [Idyll: Markup language for interactive documents](https://idyll-lang.org)
 
-### Is your work missing?
+[github]: https://github.com/mdx-js/mdx
 
-If you have related work or prior art we've failed to reference, please open a PR!
+[design]: https://github.com/mdx-js/design
+
+[idea]: https://spectrum.chat/thread/1021be59-2738-4511-aceb-c66921050b9a
+
+[john]: https://johno.com
+
+[tim]: https://github.com/timneutkens
+
+[guillermo]: https://rauchg.com
+
+[brent]: https://jxnblk.com
+
+[4lpine]: https://twitter.com/4lpine
+
+[rauchg]: https://twitter.com/rauchg
+
+[timneutkens]: https://twitter.com/timneutkens
+
+[jxnblk]: https://twitter.com/jxnblk
+
+[evil rabbit]: https://twitter.com/evilrabbit_
+
+[compositor]: https://compositor.io
+
+[zeit]: https://zeit.co
+
+[clearbit]: https://clearbit.com

--- a/docs/advanced/ast.md
+++ b/docs/advanced/ast.md
@@ -85,8 +85,8 @@ Yields:
 
 ```json
 {
-  "type": "jsx",
-  "value": "<Heading hi='there'>\n  Hello, world!\n</Heading>"
+  "type": "comment",
+  "value": "<!--hidden-->"
 }
 ```
 

--- a/docs/advanced/ast.md
+++ b/docs/advanced/ast.md
@@ -1,38 +1,52 @@
 # AST
 
-The majority of the MDXAST specification is defined by [MDAST][].
-MDXAST is a superset of MDAST, with three additional node types:
+This document defines two syntax trees:
 
-- `jsx` (in place of `html`)
-- `import`
-- `export`
+*   [MDXAST][], a superset of [mdast][], to represent markdown with embedded JSX
+*   [MDXHAST][], a superset of [hast][], to represent HTML with embedded JSX
 
-It's also important to note that an MDX document that contains no JSX or imports is a valid MDAST.
+## MDXAST
 
-### Differences to MDAST
+The majority of the MDXAST specification is defined by [mdast][].
+MDXAST is a superset with the following additional node types:
 
-The `import` type is used to provide the necessary block elements to the Remark HTML block parser and for the execution context/implementation.
-For example, a webpack [loader][] might want to transform an MDX import by appending those imports.
+*   `jsx` (instead of `html`)
+*   `comment` (instead of `html` comments)
+*   `import`
+*   `export`
 
-An `export` is used to emit data from MDX, similarly to traditional markdown frontmatter.
+It’s important to note that any MDX document without those nodes is valid
+[mdast][].
+
+### Differences to mdast
+
+The `import` type is used to provide the necessary block elements to the remark
+HTML block parser and for the execution context/implementation.
+For example, a webpack [loader][] might want to transform an MDX import by
+appending those imports.
+
+An `export` is used to emit data from MDX, similarly to traditional markdown
+frontmatter.
 
 The `jsx` node would most likely be passed to Babel to create functions.
 
-This will also differ a bit in parsing because the remark parser is built to handle particular HTML element types, whereas JSX support will require the ability to parse any tag, and those that self close.
+This will also differ a bit in parsing because the remark parser is built to
+handle particular HTML element types, whereas JSX support will require the
+ability to parse any tag, and those that self close.
 
-The `jsx`, `import`, and `export` node types are defined below.
+The `jsx`, `comment`, `import`, and `export` node types are defined below.
+
+### Nodes
 
 #### JSX
 
-The `JSX` ([`ElementNode`](#elementnode)) which contains embedded JSX as a string and `children` ([`ElementNode`](#elementnode)).
-
 ```idl
-interface JSX <: Element {
-  type: "jsx";
-  value: "string";
-  children: [ElementNode]
+interface JSX <: Literal {
+  type: "jsx"
 }
 ```
+
+**JSX** (**[Literal][]**) represents embedded JSX.
 
 For example, the following MDX:
 
@@ -51,15 +65,40 @@ Yields:
 }
 ```
 
-#### Import
-
-The `import` ([`Textnode`](#textnode)) contains the raw import as a string.
+#### Comment
 
 ```idl
-interface JSX <: Text {
-  type: "import";
+interface Comment <: Literal {
+  type: "comment"
 }
 ```
+
+**Comment** (**[Literal][]**) represents an embedded comment.
+
+For example, the following MDX:
+
+```markdown
+<!--hidden-->
+```
+
+Yields:
+
+```json
+{
+  "type": "jsx",
+  "value": "<Heading hi='there'>\n  Hello, world!\n</Heading>"
+}
+```
+
+#### Import
+
+```idl
+interface Import <: Literal {
+  type: "import"
+}
+```
+
+**Import** (**[Literal][]**) represents an ECMAScript import statement.
 
 For example, the following MDX:
 
@@ -78,13 +117,18 @@ Yields:
 
 #### Export
 
-The `export` ([`Textnode`](#textnode)) contains the raw export as a string.
-
 ```idl
-interface JSX <: Text {
-  type: "export";
+interface Export <: Literal {
+  type: "import"
+  default: boolean?
 }
 ```
+
+**Export** (**[Literal][]**) represents an ECMAScript export statement.
+
+An `default` field can be present.
+It represents that the export statement is a default export (when true) or not
+(when false or not present).
 
 For example, the following MDX:
 
@@ -97,22 +141,27 @@ Yields:
 ```json
 {
   "type": "export",
+  "default": false,
   "value": "export { foo: 'bar' }"
 }
 ```
 
 ## MDXHAST
 
-The majority of the MDXHAST specification is defined by [HAST][].
-MDXHAST is a superset of HAST, with four additional node types:
+The majority of the MDXHAST specification is defined by [hast][].
+MDXHAST includes all nodes defined by [MDXAST][], except for [Comment][], as
+it’s defined by [hast][] already.
 
-- `jsx`
-- `import`
-- `export`
-- `inlineCode`
+[mdxast]: #mdxast
 
-It's also important to note that an MDX document that contains no JSX or imports results in a valid HAST.
+[mdxhast]: #mdxhast
 
-[MDAST]: https://github.com/syntax-tree/mdast
-[HAST]: https://github.com/syntax-tree/hast
+[mdast]: https://github.com/syntax-tree/mdast
+
+[hast]: https://github.com/syntax-tree/hast
+
 [loader]: https://github.com/mdx-js/mdx/tree/master/packages/loader
+
+[literal]: https://github.com/syntax-tree/mdast#literal
+
+[comment]: #comment

--- a/docs/advanced/components.md
+++ b/docs/advanced/components.md
@@ -4,10 +4,12 @@ The MDX core library accepts a string and exports a JSX string.
 
 ## MDXTag
 
-MDXTag is an internal component that MDX uses to map components to an HTML element based on the Markdown syntax.
+MDXTag is an internal component that MDX uses to map components to an HTML
+element based on the Markdown syntax.
+
 Consider the following MDX:
 
-```
+```markdown
 import MyComponent from './my-component'
 
 # Title
@@ -37,5 +39,8 @@ export default ({ components }) => (
 )
 ```
 
-If the component mapping contains a `p` key, that will be used for "Lorem ipsum dolor sit amet.", otherwise a standard `p` tag is rendered (`<p>Lorem ipsum dolor sit amet.</p>`).
-This is what allows you to pull in existing components to style your MDX documents.
+If the component mapping contains a `p` key, that will be used for
+`Lorem ipsum dolor sit amet.`.
+Otherwise a standard `p` tag is rendered (`<p>Lorem ipsum dolor sit amet.</p>`).
+This is what allows you to pull in existing components to style your MDX
+documents.

--- a/docs/advanced/contributing.md
+++ b/docs/advanced/contributing.md
@@ -4,7 +4,7 @@
 
 To get started, after cloning the repo:
 
-```
+```shell
 yarn
 yarn bootstrap
 ```
@@ -13,20 +13,21 @@ yarn bootstrap
 
 MDX is a monorepo that uses [lerna][].
 
-- All packages are found in `./packages`
-- All documentation is found in `./docs` and can be viewed with `yarn docs -- -o`
-- There's an `./examples` directory where examples for different tools and frameworks
+*   All packages are found in `./packages`
+*   All documentation is found in `./docs` and can be viewed with `yarn docs -- -o`
+*   There’s an `./examples` directory where examples for different tools and
+    frameworks
 
 ## Releases
 
 In order to release a new version you can follow these steps:
 
-- Draft a release for the next version (vX.X.X)
-- Release a prerelease
-  - `yarn lerna publish`
-  - Select prepatch/preminor/premajor
-  - Sanity check in a project or two with the prerelease
-- `yarn lerna publish`
-- Publish release on GitHub
+*   Draft a release for the next version (vX.X.X)
+*   Release a prerelease
+    *   `yarn lerna publish`
+    *   Select prepatch/preminor/premajor
+    *   Sanity check in a project or two with the prerelease
+*   `yarn lerna publish`
+*   Publish release on GitHub
 
 [lerna]: https://lernajs.io

--- a/docs/advanced/retext-plugins.md
+++ b/docs/advanced/retext-plugins.md
@@ -1,8 +1,12 @@
-# Using Retext Plugins
+# Using retext Plugins
 
-[Retext][] plugins are really useful, but MDX can't convert the syntax tree to retext because it wouldn't be possible to convert it back to remark. This means that we can't use retext plugins directly. [remarkjs/remark#224][]
+[retext][] plugins are really useful, but MDX can’t convert the syntax tree to
+retext because it wouldn’t be possible to convert it back to [remark][].
+This means that we can’t use retext plugins directly, see
+[remarkjs/remark#224][] for more info.
 
-Luckily, it's possible to build a custom plugin that visits all text nodes using [unist-util-visit][] and process them using retext:
+Luckily, it’s possible to build a custom plugin that visits all text nodes using
+[`unist-util-visit`][visit] and process them using retext:
 
 ```js
 const visit = require('unist-util-visit')
@@ -35,6 +39,10 @@ mdx.sync(mdxText, {
 })
 ```
 
-[Retext]: https://github.com/retextjs/retext
+[retext]: https://github.com/retextjs/retext
+
+[remark]: https://github.com/remarkjs/remark
+
 [remarkjs/remark#224]: https://github.com/remarkjs/remark/issues/224
-[unist-util-visit]: https://github.com/syntax-tree/unist-util-visit
+
+[visit]: https://github.com/syntax-tree/unist-util-visit

--- a/docs/advanced/specification.md
+++ b/docs/advanced/specification.md
@@ -1,11 +1,15 @@
 # MDX Specification
 
 MDX includes a [specification][spec] to define the syntax and transpilation.
-This can be leveraged by code formatters, linters, and implementations in other languages created by the community.
-It's based on the [remark][]/[unified][] ecosystem to ensure robust parsing and the ability to leverage plugins from within your MDX.
+This can be leveraged by code formatters, linters, and implementations in other
+languages created by the community.
+It’s based on the [remark][]/[unified][] ecosystem to ensure robust parsing and
+the ability to leverage plugins from within your MDX.
 
 [See the specification][spec]
 
 [spec]: https://github.com/mdx-js/specification
+
 [remark]: https://github.com/remarkjs
+
 [unified]: https://github.com/unifiedjs

--- a/docs/advanced/sync-api.md
+++ b/docs/advanced/sync-api.md
@@ -5,8 +5,9 @@ import { Message } from 'rebass'
 MDX processes everything asynchronously by default.
 In certain cases this behavior might not be desirable.
 
-If you're using the MDX library directly, you might want to process an MDX string synchronously.
-It's important to note that if you have any async plugins, they will be ignored.
+If you’re using the MDX library directly, you might want to process an MDX
+string synchronously.
+It’s important to note that if you have any async plugins, they will be ignored.
 
 ```js
 const fs = require('fs')
@@ -17,7 +18,8 @@ const mdxText = fs.readFileSync('hello.mdx', 'utf8')
 const jsx = mdx.sync(mdxText)
 ```
 
-MDX's [runtime][] package has [example][] usage.
+MDX’s [runtime][] package has [example][] usage.
 
 [runtime]: https://github.com/mdx-js/mdx/tree/master/packages/runtime
+
 [example]: https://github.com/mdx-js/mdx/blob/d5a5189e715dc28370de13f6cc0fd18a06f0f122/packages/runtime/src/index.js#L16-L18

--- a/docs/getting-started/create-react-app.md
+++ b/docs/getting-started/create-react-app.md
@@ -6,10 +6,12 @@ import { Message } from 'rebass'
   This docs page is a WIP
 </Message>
 
-With Create React App you will need to use [`create-react-app-rewired`][cra-rewired] and add a `config-overrides.js`.
+With Create React App you will need to use
+[`create-react-app-rewired`][cra-rewired] and add a `config-overrides.js`.
 
 ```js
 const { getBabelLoader } = require('react-app-rewired')
+
 module.exports = (config, env) => {
   const babelLoader = getBabelLoader(config.module.rules)
   config.module.rules.map(rule => {
@@ -30,12 +32,13 @@ module.exports = (config, env) => {
 
     return rule
   })
+
   return config
 }
 ```
 
 [See the full example][cra-example]
 
-[cra]: https://github.com/facebook/create-react-app
 [cra-rewired]: https://github.com/timarney/react-app-rewired
+
 [cra-example]: https://github.com/mdx-js/mdx/tree/master/examples/create-react-app

--- a/docs/getting-started/gatsby.md
+++ b/docs/getting-started/gatsby.md
@@ -1,8 +1,9 @@
 # Gatsby
 
-In order to use MDX with [Gatsby][gatsby] you can use the [gatsby-mdx][] package.
+In order to use MDX with [Gatsby][] you can use the [gatsby-mdx][] package.
 
-First, scaffold a new Gatsby 2.0 or greater site and install the `gatsby-mdx` plugin.
+First, scaffold a new Gatsby 2.0 or greater site and install the `gatsby-mdx`
+plugin.
 
 ```shell
 gatsby new gatsby-site https://github.com/gatsbyjs/gatsby-starter-default#v2
@@ -21,15 +22,18 @@ module.exports = {
 }
 ```
 
-Finally, add an `.mdx` file in the `src/pages` directory. It "Just Works".
+Finally, add an `.mdx` file in the `src/pages` directory.
+It “Just Works”.
 
-```
+```markdown
 # My first MDX Page
 
 some awesome content
 ```
 
-For more documentation on programmatically creating pages with Gatsby, see the [gatsby-mdx docs][gatsby-mdx].
+For more documentation on programmatically creating pages with Gatsby, see
+the [gatsby-mdx docs][gatsby-mdx].
 
 [gatsby]: https://gatsbyjs.org
+
 [gatsby-mdx]: https://github.com/ChristopherBiscardi/gatsby-mdx

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -5,7 +5,7 @@ import { Text } from 'rebass'
 To get started quickly with an example project you can use `npm init`.
 It will scaffold out a [Next.js][next] app with MDX configured.
 
-```
+```shell
 npm init mdx
 ```
 
@@ -16,9 +16,11 @@ npm init mdx
 ## Components
 
 You can pass in components for any HTML element that Markdown compiles to.
-This allows you to use your existing components and even CSS-in-JS like `styled-components`.
+This allows you to use your existing components and even CSS-in-JS like
+`styled-components`.
 
-The components object is a mapping between the HTML element and your desired component you'd like to render.
+The components object is a mapping between the HTML element and your desired
+component you’d like to render.
 
 ```jsx
 const MyH1 = props => <h1 style={{ color: 'tomato' }} {...props} />
@@ -54,14 +56,16 @@ export default () =>
   />
 ```
 
-With the above, the Heading component will be rendered for any h1, Text for p tags, and so on.
+With the above, the `Heading` component will be rendered for any `h1`, `Text`
+for `p` elements, and so on.
 
-In addition to HTML elements, there's an `inlineCode`.
+In addition to HTML elements, there’s an `inlineCode`.
 This is what remark uses for code elements within paragraphs, tables, etc.
 
 ## MDXProvider
 
-If you're using an app layout that wraps your JSX, you can use the `MDXProvider` to only pass your components in one place:
+If you’re using an app layout that wraps your JSX, you can use the `MDXProvider`
+to only pass your components in one place:
 
 ```jsx
 import React from 'react'
@@ -87,21 +91,23 @@ export default props =>
 This allows you to remove duplicated component imports and passing.
 It will typically go in layout files.
 
-#### How does it work?
+#### How it works
 
 MDXProvider uses React [context][] to provide the component mapping to MDXTag.
 MDXTag knows to use these components when determining which to render.
 
 ## Projects, libraries and frameworks
 
-If you're already working with a particular tool, you can try out MDX with the following commands:
+If you’re already working with a particular tool, you can try out MDX with the
+following commands:
 
-- `npm init mdx` [`webpack`](./webpack)
-- `npm init mdx` [`parcel`](./parcel)
-- `npm init mdx` [`next`](./next)
-- `npm init mdx` [`create-react-app`](./create-react-app)
-- `npm init mdx` [`gatsby`](./gatsby)
-- `npm init mdx` [`x0`](./x0)
+*   `npm init mdx` [`webpack`](./webpack)
+*   `npm init mdx` [`parcel`](./parcel)
+*   `npm init mdx` [`next`](./next)
+*   `npm init mdx` [`create-react-app`](./create-react-app)
+*   `npm init mdx` [`gatsby`](./gatsby)
+*   `npm init mdx` [`x0`](./x0)
 
 [next]: https://github.com/zeit/next.js
+
 [context]: https://reactjs.org/docs/context.html

--- a/docs/getting-started/next.md
+++ b/docs/getting-started/next.md
@@ -1,8 +1,9 @@
 # Next.js
 
-Next.js provides an [official plugin][next-plugin] to simplify MDX importing into your project.
+Next.js provides an [official plugin][next-plugin] to simplify MDX importing
+into your project.
 
-```
+```shell
 npm install --save-dev @zeit/next-mdx
 ```
 

--- a/docs/getting-started/parcel.md
+++ b/docs/getting-started/parcel.md
@@ -6,7 +6,7 @@ import { Message } from 'rebass'
   This docs page is a WIP
 </Message>
 
-You'll need to install the `@mdx-js/parcel-plugin-mdx` plugin to transpile MDX.
+You’ll need to install the `@mdx-js/parcel-plugin-mdx` plugin to transpile MDX.
 
 ```js
 {

--- a/docs/getting-started/typescript.md
+++ b/docs/getting-started/typescript.md
@@ -1,6 +1,8 @@
 # TypeScript
 
-If you're getting errors from TypeScript related to imports with an `*.mdx` extension, create an `mdx.d.ts` file in your types directory and include it inside your `tsconfig.json`.
+If you’re getting errors from TypeScript related to imports with an `*.mdx`
+extension, create an `mdx.d.ts` file in your types directory and include it
+inside your `tsconfig.json`.
 
 ```tsx
 // types/mdx.d.ts

--- a/docs/getting-started/webpack.md
+++ b/docs/getting-started/webpack.md
@@ -1,10 +1,11 @@
 # Webpack
 
-MDX provides a loader that needs to be used in tandem with the [babel-loader][babel-loader].
+MDX provides a loader that needs to be used in tandem with the [babel-loader][].
 
 ## Basic Setup
 
-For webpack projects you can define the following `webpack.config.js` extension handler for `.md`/`.mdx` files:
+For webpack projects you can define the following `webpack.config.js` extension
+handler for `.md`/`.mdx` files:
 
 ```js
 module.exports = {
@@ -19,6 +20,7 @@ module.exports = {
 }
 ```
 
-It's important to note that the MDX loader is followed by the babel-loader so that the JSX can be transpiled to JavaScript.
+It’s important to note that the MDX loader is followed by the babel-loader so
+that the JSX can be transpiled to JavaScript.
 
 [babel-loader]: https://npmjs.com/package/babel-loader

--- a/docs/getting-started/x0.md
+++ b/docs/getting-started/x0.md
@@ -1,12 +1,13 @@
 # x0
 
-```
+```shell
 npm init mdx x0
 ```
 
-[x0][] supports MDX files with either `.md` or `.mdx` file extensions out of the box.
+[x0][] supports MDX files with either `.md` or `.mdx` file extensions out of
+the box.
 For components requiring providers you will need to use customize `_app.js`.
-Here's an example using [Rebass][rebass] components:
+Here’s an example using [Rebass][] components:
 
 ```jsx
 import React from 'react'
@@ -24,4 +25,5 @@ export default ({ route, routes, ...props }) => (
 ```
 
 [x0]: https://compositor.io/x0
+
 [rebass]: https://jxnblk.com/rebass

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,11 @@ import { Border, Blockquote, BlockLink } from 'rebass'
 
 # MDX
 
-### Markdown for the component era.
+### Markdown for the component era
 
 MDX is a format that lets you seamlessly use JSX in your Markdown documents.
-You can import components, like interactive charts or notifs, and export metadata.
+You can import components, like interactive charts or notifs, and export
+metadata.
 This makes writing long-form content with components a blast :rocket:.
 
 #### Try it
@@ -19,44 +20,55 @@ Donut rendered inside an MDX document.
 <Donut value={2/3} />
 ```
 
-__:heart: Powerful__: MDX blends Markdown and JSX syntax to fit perfectly in React/JSX-based projects.
+**:heart: Powerful**: MDX blends Markdown and JSX syntax to fit perfectly in
+React/JSX-based projects.
 
-__:computer: Everything is a component__: Use existing components inside your MDX and import other MDX files as plain components.
+**:computer: Everything is a component**: Use existing components inside your
+MDX and import other MDX files as plain components.
 
-__:wrench: Customizable__: Decide which component is rendered for each Markdown element (`{ h1: MyHeading }`).
+**:wrench: Customizable**: Decide which component is rendered for each Markdown
+element (`{ h1: MyHeading }`).
 
-__:books: Markdown-based__: The simplicity and elegance of Markdown remains, you interleave JSX only when you want to.
+**:books: Markdown-based**: The simplicity and elegance of Markdown remains,
+you interleave JSX only when you want to.
 
-__:fire: Blazingly blazing fast__: MDX has no runtime, all compilation occurs during the build stage.
+**:fire: Blazingly blazing fast**: MDX has no runtime, all compilation occurs
+during the build stage.
 
-> “It's extremely useful for using design system components to render markdown
-and weaving interactive components in with existing markdown.”
+> “It’s extremely useful for using design system components to render markdown
+> and weaving interactive components in with existing markdown.”
 >
-> — [@chrisbiscardi](https://twitter.com/chrisbiscardi/status/1022304288326864896)
+> — [@chrisbiscardi][quote]
 
-## Why?
+## Why
 
-Before MDX, some of the benefits of writing Markdown were lost when integrating with JSX.
-Implementations were often template string-based which required lots of escaping and cumbersome syntax.
+Before MDX, some of the benefits of writing Markdown were lost when integrating
+with JSX.
+Implementations were often template string-based which required lots of escaping
+and cumbersome syntax.
 
-MDX seeks to make writing with Markdown _and_ JSX simpler while being more expressive.
-The possibilities are endless when you combine components (that can even be dynamic or load data) with the simplicity of Markdown for long-form content.
+MDX seeks to make writing with Markdown _and_ JSX simpler while being more
+expressive.
+The possibilities are endless when you combine components (that can even be
+dynamic or load data) with the simplicity of Markdown for long-form content.
 
 ## Features
 
-- Fast
-- No runtime compilation
-- [Pluggable][remark-plugins]
-- Element to React component mapping
-- React component `import`/`export`
-- Customizable layouts
-- Webpack loader
-- Parcel plugin
-- Next.js plugin
-- Gatsby plugin
+*   Fast
+*   No runtime compilation
+*   [Pluggable][remark-plugins]
+*   Element to React component mapping
+*   React component `import`/`export`
+*   Customizable layouts
+*   Webpack loader
+*   Parcel plugin
+*   Next.js plugin
+*   Gatsby plugin
 
-> [Watch some of these features in action](https://www.youtube.com/watch?v=d2sQiI5NFAM&list=PLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u)
+> [Watch some of these features in action][intro]
 
-[md]: http://commonmark.org/
-[jsx]: https://facebook.github.io/jsx/
 [remark-plugins]: https://github.com/remarkjs/remark/blob/master/doc/plugins.md
+
+[quote]: https://twitter.com/chrisbiscardi/status/1022304288326864896
+
+[intro]: https://www.youtube.com/watch?v=d2sQiI5NFAM&list=PLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,28 +1,31 @@
 # Plugins
 
-Since MDX uses the [remark][]/[rehype][] ecosystems, you can use plugins to modify the AST at different stages of the transpilation process.
+Since MDX uses the [remark][]/[rehype][] ecosystems, you can use plugins to
+modify the AST at different stages of the transpilation process.
 
 ## Transpilation
 
-The MDX transpilation flow consists of six steps, ultimately resulting in JSX that can be used in React/Preact/etc.
+The MDX transpilation flow consists of six steps, ultimately resulting in JSX
+that can be used in React/Preact/etc.
 
-1. __Parse__: Text => MDAST
-1. __Transpile__: MDAST => MDXAST
-1. __Transform__: MDX/Remark plugins applied to AST
-1. __Transpile__: MDXAST => MDXHAST
-1. __Transform__: Hyperscript plugins applied to AST
-1. __Transpile__: MDXHAST => JSX
+1.  **Parse**: Text => MDAST
+2.  **Transpile**: MDAST => MDXAST
+3.  **Transform**: MDX/Remark plugins applied to AST
+4.  **Transpile**: MDXAST => MDXHAST
+5.  **Transform**: Hyperscript plugins applied to AST
+6.  **Transpile**: MDXHAST => JSX
 
 ### Options
 
-Name | Type | Required | Description
----- | ---- | -------- | -----------
-`mdPlugins` | Array[] | `false` | Array of remark plugins to manipulate the MDAST
-`hastPlugins` | Array[] | `false` | Array of rehype plugins to manipulate the MDXHAST
+| Name          | Type     | Required | Description                                       |
+| ------------- | -------- | -------- | ------------------------------------------------- |
+| `mdPlugins`   | Array\[] | `false`  | Array of remark plugins to manipulate the MDAST   |
+| `hastPlugins` | Array\[] | `false`  | Array of rehype plugins to manipulate the MDXHAST |
 
 #### Specifying plugins
 
-Plugins need to be passed to MDX core library, this is often as options to your loader:
+Plugins need to be passed to MDX core library, this is often as options to your
+loader:
 
 ```js
 const images = require('remark-images')
@@ -50,7 +53,7 @@ module.exports = {
 }
 ```
 
-Though if you're using MDX directly, they can be passed like so:
+Though if you’re using MDX directly, they can be passed like so:
 
 ```js
 const fs = require('fs')
@@ -76,7 +79,9 @@ mdx.sync(mdxText, {
 })
 ```
 
-The following example ensures that `padSpaceAfter` is only passed as options to the `emoji` plugin.
+The following example ensures that `padSpaceAfter` is only passed as options to
+the `emoji` plugin.
 
 [remark]: https://github.com/remarkjs/remark
+
 [rehype]: https://github.com/rehypejs/rehype

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,25 +1,33 @@
 # Projects using MDX
 
-- [ok-mdx][]: Browser-based MDX editor
-- [docz][]: Documentation framework
-- [mdx-deck][]: MDX-based presentation decks
-- [mdx-docs][]: Next-based documentation framework
-- [spectacle-boilerplate-mdx][]: Boilerplate that facilitates using MDX with Spectacle
+*   [ok-mdx][]: Browser-based MDX editor
+*   [docz][]: Documentation framework
+*   [mdx-deck][]: MDX-based presentation decks
+*   [mdx-docs][]: Next-based documentation framework
+*   [spectacle-boilerplate-mdx][]: Boilerplate that facilitates using MDX with
+    Spectacle
 
 ## Sites using MDX
 
-- [ZEIT Docs][zeit-docs]
-- [Compositor][compositor]
+*   [ZEIT Docs][zeit-docs]
+*   [Compositor][compositor]
 
 ## Other related links
 
-- [awesome-mdx][]
+*   [awesome-mdx][]
 
 [ok-mdx]: https://github.com/jxnblk/ok-mdx
+
 [mdx-deck]: https://github.com/jxnblk/mdx-deck
+
 [mdx-docs]: https://github.com/jxnblk/mdx-docs
+
 [docz]: https://www.docz.site/
+
 [zeit-docs]: https://github.com/zeit/docs
+
 [compositor]: https://compositor.io
+
 [awesome-mdx]: https://github.com/transitive-bullshit/awesome-mdx
+
 [spectacle-boilerplate-mdx]: https://github.com/FormidableLabs/spectacle-boilerplate-mdx

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -1,16 +1,18 @@
 # Syntax
 
 MDX syntax can be boiled down to being JSX in Markdown.
-It's a superset of Markdown syntax that also supports importing, exporting, and JSX.
+It’s a superset of Markdown syntax that also supports importing, exporting, and
+JSX.
 
 ### Markdown
 
 Standard [Markdown syntax][md] is supported.
-It's recommended to learn about Markdown in their [docs][md].
+It’s recommended to learn about Markdown in their [docs][md].
 
 ### JSX
 
-[JSX syntax][jsx] is fully supported, JSX blocks are opened by starting a line with the `<` character.
+[JSX syntax][jsx] is fully supported, JSX blocks are opened by starting a line
+with the `<` character.
 
 ```jsx
 <Box>
@@ -44,7 +46,8 @@ import Palette from './components/palette'
 
 #### Markdown file transclusion
 
-You can [transclude][] Markdown files by importing one `.md` or `.mdx` file into another:
+You can [transclude][] Markdown files by importing one `.md` or `.mdx` file into
+another:
 
 ```jsx
 import License from './license.md'
@@ -62,7 +65,7 @@ import Contributing from './docs/contributing.md'
 ### Exports
 
 You can use exports to export metadata like layout or authors.
-It's a mechanism for an imported MDX file to communicate with its parent.
+It’s a mechanism for an imported MDX file to communicate with its parent.
 It works similarly to frontmatter, but uses ES2015 syntax.
 
 ```js
@@ -97,7 +100,8 @@ export default () => (
 
 #### `export default`
 
-The ES default [export][] is used to provide a layout component which will wrap the transpiled JSX.
+The ES default [export][] is used to provide a layout component which will wrap
+the transpiled JSX.
 
 You can export it as a function:
 
@@ -120,7 +124,11 @@ export default Layout
 ```
 
 [md]: https://daringfireball.net/projects/markdown/syntax
+
 [jsx]: https://reactjs.org/docs/introducing-jsx.html
+
 [import]: https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/import
+
 [export]: https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export
+
 [transclude]: https://en.wikipedia.org/wiki/Transclusion

--- a/examples/create-react-app/readme.md
+++ b/examples/create-react-app/readme.md
@@ -1,6 +1,6 @@
 # MDX + Create React App
 
-```
+```shell
 npm install
 npm start
 ```

--- a/examples/parcel/readme.md
+++ b/examples/parcel/readme.md
@@ -1,6 +1,6 @@
 # MDX + Parcel
 
-```
+```shell
 npm install
 npm start
 ```

--- a/examples/razzle/readme.md
+++ b/examples/razzle/readme.md
@@ -1,6 +1,6 @@
 # MDX + Razzle
 
-```
+```shell
 npm install
 npm start
 ```

--- a/examples/x0/readme.md
+++ b/examples/x0/readme.md
@@ -1,6 +1,6 @@
 # MDX + X0
 
-```
+```shell
 npm install
 npm start
 ```

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       "git add"
     ],
     "*.md": [
-      "remark . -qfo",
+      "remark -qfo",
       "git add"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "docs": "x0 docs",
     "docs:build": "x0 build docs",
     "docs:deploy": "npm run docs:build && now dist --public && now alias",
-    "test": "eslint . && lerna run test",
-    "format": "eslint . --fix",
+    "test": "remark . -qf && eslint . && lerna run test",
+    "format": "remark . -qfo && eslint . --fix",
     "publish": "lerna publish"
   },
   "repository": "mdx-js/mdx",
@@ -24,7 +24,9 @@
     "husky": "^1.1.3",
     "lerna": "^3.4.0",
     "lint-staged": "^8.0.4",
-    "prettier": "^1.14.2"
+    "prettier": "^1.14.2",
+    "remark-cli": "^6.0.1",
+    "remark-preset-wooorm": "^4.0.0"
   },
   "dependencies": {
     "@rebass/mdx": "^1.0.0-1",
@@ -37,6 +39,24 @@
     "bracketSpacing": false,
     "semi": false,
     "trailingComma": "none"
+  },
+  "remarkConfig": {
+    "plugins": [
+      "./packages/remark-mdx",
+      "preset-wooorm",
+      [
+        "lint-no-heading-punctuation",
+        false
+      ],
+      [
+        "lint-maximum-line-length",
+        false
+      ],
+      [
+        "validate-links",
+        false
+      ]
+    ]
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
     "*.js": [
       "eslint --fix",
       "git add"
+    ],
+    "*.md": [
+      "remark . -qfo",
+      "git add"
     ]
   },
   "x0": {

--- a/packages/loader/readme.md
+++ b/packages/loader/readme.md
@@ -1,4 +1,4 @@
-# @mdx-js/loader
+# `@mdx-js/loader`
 
 Webpack loader for [MDX](https://github.com/mdx-js/mdx).
 

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -1,8 +1,8 @@
-# @mdx-js/mdx
+# `@mdx-js/mdx`
 
 MDX implementation using Remark.
 
-https://github.com/mdx-js/mdx
+<https://github.com/mdx-js/mdx>
 
 ## Installation
 

--- a/packages/mdxast/readme.md
+++ b/packages/mdxast/readme.md
@@ -1,8 +1,8 @@
-# [Deprecated] @mdx-js/mdxast
+# \[Deprecated] `@mdx-js/mdxast`
 
 **This library has been pulled into `@mdx-js/mdx` and is no longer maintained.**
 
----
+* * *
 
 Transforms MDAST to MDXAST.
 
@@ -39,7 +39,7 @@ console.log(inspect(mdxast))
 
 #### Output
 
-```
+```text
 root[3] (1:1-7:1, 0-53)
 ├─ import: "import { Foo } from 'bar'" (2:1-2:26, 1-26)
 ├─ heading[1] (4:1-4:16, 28-43) [depth=1]

--- a/packages/parcel-plugin-mdx/readme.md
+++ b/packages/parcel-plugin-mdx/readme.md
@@ -25,8 +25,8 @@ render(<MDXContent />, root);
 
 ### Thanks
 
-I couldn't have written this without the following:
+I couldn’t have written this without the following:
 
-- [MDX](https://github.com/mdx-js/mdx)
-- [Parcel](https://parceljs.org/)
-- [Writing a parcel plugin](https://medium.com/@jasperdemoor/writing-a-parcel-plugin-3936271cbaaa)
+*   [MDX](https://github.com/mdx-js/mdx)
+*   [Parcel](https://parceljs.org/)
+*   [Writing a parcel plugin](https://medium.com/@jasperdemoor/writing-a-parcel-plugin-3936271cbaaa)

--- a/packages/remark-images/readme.md
+++ b/packages/remark-images/readme.md
@@ -4,13 +4,13 @@ Remark plugin to turn image urls into rendered images.
 
 ## Installation
 
-```
+```shell
 npm i -S remark-images
 ```
 
 ## Usage
 
-```
+```javascript
 const remark = require('remark')
 const images = require('remark-images')
 const html = require('remark-html')
@@ -37,15 +37,15 @@ https://c8r-x0.s3.amazonaws.com/lab-components-macbook.jpg
 
 Supported urls / uris:
 
-- `http://example.com/image.jpg`
-- `/image.jpg`
-- `./image.jpg`
-- `../image.jpg`
+*   `https://example.com/image.jpg`
+*   `/image.jpg`
+*   `./image.jpg`
+*   `../image.jpg`
 
 Supported file types:
 
-- `png`
-- `svg`
-- `jpg`
-- `jpeg`
-- `gif`
+*   `png`
+*   `svg`
+*   `jpg`
+*   `jpeg`
+*   `gif`

--- a/packages/remark-mdx/index.js
+++ b/packages/remark-mdx/index.js
@@ -1,0 +1,83 @@
+const unified = require('unified')
+const toMDAST = require('remark-parse')
+
+const IMPORT_REGEX = /^import/
+const EXPORT_REGEX = /^export/
+const EXPORT_DEFAULT_REGEX = /^export default/
+const BLOCKS_REGEX = '[a-z\\.]+(\\.){0,1}[a-z\\.]'
+const EMPTY_NEWLINE = '\n\n'
+
+const isImport = text => IMPORT_REGEX.test(text)
+const isExport = text => EXPORT_REGEX.test(text)
+const isExportDefault = text => EXPORT_DEFAULT_REGEX.test(text)
+
+module.exports = mdx
+
+mdx.default = mdx
+
+tokenizeEsSyntax.locator = tokenizeEsSyntaxLocator
+
+function mdx(options) {
+  const parser = this.Parser
+  const compiler = this.Compiler
+
+  if (parser && parser.prototype && parser.prototype.blockTokenizers) {
+    attachParser(parser)
+  }
+
+  if (compiler && compiler.prototype && compiler.prototype.visitors) {
+    attachCompiler(compiler)
+  }
+}
+
+function attachParser(parser) {
+  const tokenizers = parser.prototype.blockTokenizers
+  const blocks = parser.prototype.blockMethods
+  const html = tokenizers.html
+
+  tokenizers.esSyntax = tokenizeEsSyntax
+  tokenizers.html = tokenizeJsx
+
+  blocks.splice(blocks.indexOf('paragraph'), 0, 'esSyntax')
+
+  function tokenizeJsx() {
+    const node = html.apply(this, arguments)
+
+    if (node) {
+      node.type = 'jsx'
+    }
+
+    return node
+  }
+}
+
+function attachCompiler(compiler) {
+  const proto = compiler.prototype
+
+  proto.visitors = Object.assign({}, proto.visitors, {
+    import: stringifyEsSyntax,
+    export: stringifyEsSyntax,
+    jsx: proto.visitors.html
+  })
+}
+
+function stringifyEsSyntax(node) {
+  return node.value
+}
+
+function tokenizeEsSyntax(eat, value) {
+  const index = value.indexOf(EMPTY_NEWLINE)
+  const subvalue = index !== -1 ? value.slice(0, index) : value
+
+  if (isExport(subvalue) || isImport(subvalue)) {
+    return eat(subvalue)({
+      type: isExport(subvalue) ? 'export' : 'import',
+      default: isExportDefault(subvalue),
+      value: subvalue
+    })
+  }
+}
+
+function tokenizeEsSyntaxLocator(value, fromIndex) {
+  return isExport(value) || isImport(value) ? -1 : 1
+}

--- a/packages/remark-mdx/license
+++ b/packages/remark-mdx/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Titus Wormer.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/remark-mdx/package.json
+++ b/packages/remark-mdx/package.json
@@ -1,0 +1,25 @@
+{
+  "private": true,
+  "name": "@mdx-js/remark-mdx",
+  "version": "0.0.0",
+  "license": "MIT",
+  "repository": "mdx-js/mdx",
+  "description": "Support import, export, and JSX in markdown",
+  "files": [
+    "index.js"
+  ],
+  "scripts": {},
+  "keywords": [
+    "markdown",
+    "remark",
+    "mdx"
+  ],
+  "dependencies": {
+    "remark-parse": "^5.0.0",
+    "unified": "^6.1.6"
+  },
+  "devDependencies": {},
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/remark-mdx/readme.md
+++ b/packages/remark-mdx/readme.md
@@ -1,0 +1,13 @@
+# `@mdx-js/remark-mdx`
+
+[MDX][] syntax support for [remark][].
+
+## Installation
+
+```sh
+npm i -S @mdx-js/remark-mdx
+```
+
+[mdx]: https://github.com/mdx-js/mdx
+
+[remark]: https://github.com/remarkjs/remark

--- a/packages/runtime/readme.md
+++ b/packages/runtime/readme.md
@@ -4,12 +4,13 @@ Parse and render MDX in a runtime environment
 
 ## :warning: Warning
 
-This is not the preferred way to use MDX since it introduces a substantial amount of overhead and dramatically increases bundle sizes.
-It should also not be used with user input that isn't sandboxed.
+This is not the preferred way to use MDX since it introduces a substantial
+amount of overhead and dramatically increases bundle sizes.
+It should also not be used with user input that isn’t sandboxed.
 
 ## Installation
 
-```
+```shell
 npm install --save @mdx-js/runtime
 ```
 
@@ -32,4 +33,4 @@ export default () => (
 
 ## Related
 
-- [MDX Docs](https://github.com/mdx-js/mdx)
+*   [MDX Docs](https://github.com/mdx-js/mdx)

--- a/packages/tag/readme.md
+++ b/packages/tag/readme.md
@@ -1,3 +1,9 @@
-# @mdx-js/tag
+# `@mdx-js/tag`
 
-https://github.com/mdx-js/mdx
+map components to HTML elements based on the Markdown syntax.
+
+## Installation
+
+```sh
+npm i -S @mdx-js/tag
+```

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,14 @@
-![Logo](./.github/repo.png)
+# ![MDX][logo]
 
-[![Build Status](https://travis-ci.org/mdx-js/mdx.svg?branch=master)](https://travis-ci.org/mdx-js/mdx)
-[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
-[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/mdx)
+[![Build Status][build-badge]][build]
+[![lerna][lerna-badge]][lerna]
+[![Join the community on Spectrum][spectrum-badge]][spectrum]
 
 > Markdown for the component era.
 
 MDX is a format that lets you seamlessly use JSX in your Markdown documents.
-You can import components, like interactive charts or notifs, and export metadata.
+You can import components, like interactive charts or notifs, and export
+metadata.
 This makes writing long-form content with components a blast :rocket:.
 
 See it in action
@@ -22,67 +23,118 @@ The chart is rendered inside our MDX document.
 <Chart />
 ```
 
-__:heart: Powerful__: MDX blends Markdown and JSX syntax to fit perfectly in React/JSX-based projects.
+:heart: **Powerful**: MDX blends Markdown and JSX syntax to fit perfectly in
+React/JSX-based projects.
 
-__:computer: Everything is a component__: Use existing components inside your MDX and import other MDX files as plain components.
+:computer: **Everything is a component**: Use existing components inside your
+MDX and import other MDX files as plain components.
 
-__:wrench: Customizable__: Decide which component is rendered for each Markdown element (`{ h1: MyHeading }`).
+:wrench: **Customizable**: Decide which component is rendered for each Markdown
+element (`{ h1: MyHeading }`).
 
-__:books: Markdown-based__: The simplicity and elegance of Markdown remains, you interleave JSX only when you want to.
+:books: **Markdown-based**: The simplicity and elegance of Markdown remains,
+you interleave JSX only when you want to.
 
-__:fire: Blazingly blazing fast__: MDX has no runtime, all compilation occurs during the build stage.
+:fire: **Blazingly blazing fast**: MDX has no runtime, all compilation occurs
+during the build stage.
 
-> [Watch some of these features in action](https://www.youtube.com/watch?v=d2sQiI5NFAM&list=PLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u)
-
-> “It's extremely useful for using design system components to render markdown
-and weaving interactive components in with existing markdown.”
+> [Watch some of these features in action][intro]
 >
-> — [@chrisbiscardi](https://twitter.com/chrisbiscardi/status/1022304288326864896)
+> “It’s extremely useful for using design system components to render markdown
+> and weaving interactive components in with existing markdown.”
+>
+> — [@chrisbiscardi][tweet]
 
 ## Why?
 
-Before MDX, some of the benefits of writing Markdown were lost when integrating with JSX.
-Implementations were often template string-based which required lots of escaping and cumbersome syntax.
+Before MDX, some of the benefits of writing Markdown were lost when integrating
+with JSX.
+Implementations were often template string-based which required lots of escaping
+and cumbersome syntax.
 
-MDX seeks to make writing with Markdown _and_ JSX simpler while being more expressive.
-The possibilities are endless when you combine components (that can even be dynamic or load data) with the simplicity of Markdown for long-form content.
+MDX seeks to make writing with Markdown _and_ JSX simpler while being more
+expressive.
+The possibilities are endless when you combine components (that can even be
+dynamic or load data) with the simplicity of Markdown for long-form content.
 
-- Fast
-- No runtime compilation
-- [Pluggable][remark-plugins]
-- Element to React component mapping
-- React component `import`/`export`
-- Customizable layouts
-- Webpack loader
-- Parcel plugin
-- Next.js plugin
-- Gatsby plugin
+*   Fast
+*   No runtime compilation
+*   [Pluggable][remark-plugins]
+*   Element to React component mapping
+*   React component `import`/`export`
+*   Customizable layouts
+*   Webpack loader
+*   Parcel plugin
+*   Next.js plugin
+*   Gatsby plugin
 
 ## Getting started
 
-```
+```shell
 npm init mdx
 ```
 
-- [Documentation](https://mdxjs.com)
-  - [Syntax](https://mdxjs.com/syntax)
-  - [Getting Started](https://mdxjs.com/getting-started/)
-  - [Plugins](https://mdxjs.com/plugins)
-  - [Contributing](https://mdxjs.com/advanced/contributing)
+*   [Documentation](https://mdxjs.com)
+    *   [Syntax](https://mdxjs.com/syntax)
+    *   [Getting Started](https://mdxjs.com/getting-started/)
+    *   [Plugins](https://mdxjs.com/plugins)
+    *   [Contributing](https://mdxjs.com/advanced/contributing)
 
 ## Related
 
-See related projects in the [MDX specification](https://github.com/mdx-js/specification#related).
+See related projects in the [MDX specification][spec].
 
 ## Authors
 
-- John Otander ([@4lpine](https://twitter.com/4lpine)) – [Compositor](https://compositor.io) + [Clearbit](https://clearbit.com)
-- Tim Neutkens ([@timneutkens](https://github.com/timneutkens)) – [ZEIT](https://zeit.co)
-- Guillermo Rauch ([@rauchg](https://twitter.com/rauchg)) – [ZEIT](https://zeit.co)
-- Brent Jackson ([@jxnblk](https://twitter.com/jxnblk)) – [Compositor](https://compositor.io)
+*   [John Otander][john] ([@4lpine][4lpine]) – [Compositor][] + [Clearbit][]
+*   [Tim Neutkens][tim] ([@timneutkens][timneutkens]) – [ZEIT][]
+*   [Guillermo Rauch][guillermo] ([@rauchg][rauchg]) – [ZEIT][]
+*   [Brent Jackson][brent] ([@jxnblk][jxnblk]) – [Compositor][]
 
----
+* * *
 
 > [MIT](./license) license
 
+[logo]: ./.github/repo.png
+
+[build]: https://travis-ci.org/mdx-js/mdx
+
+[build-badge]: https://travis-ci.org/mdx-js/mdx.svg?branch=master
+
+[lerna]: https://lernajs.io/
+
+[lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
+
+[spectrum]: https://spectrum.chat/mdx
+
+[spectrum-badge]: https://withspectrum.github.io/badge/badge.svg
+
+[intro]: https://www.youtube.com/watch?v=d2sQiI5NFAM&list=PLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u
+
+[tweet]: https://twitter.com/chrisbiscardi/status/1022304288326864896
+
 [remark-plugins]: https://github.com/remarkjs/remark/blob/master/doc/plugins.md
+
+[spec]: https://github.com/mdx-js/specification#related
+
+[john]: https://johno.com
+
+[tim]: https://github.com/timneutkens
+
+[guillermo]: https://rauchg.com
+
+[brent]: https://jxnblk.com
+
+[4lpine]: https://twitter.com/4lpine
+
+[rauchg]: https://twitter.com/rauchg
+
+[timneutkens]: https://twitter.com/timneutkens
+
+[jxnblk]: https://twitter.com/jxnblk
+
+[compositor]: https://compositor.io
+
+[zeit]: https://zeit.co
+
+[clearbit]: https://clearbit.com

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,6 +1434,11 @@ array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
 
+array-iterate@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.2.tgz#f66a57e84426f8097f4197fbb6c051b8e5cdf7d8"
+  integrity sha512-1hWSHTIlG/8wtYD+PPX5AOBtKWngpDFjrsrHgZpe+JdgNGz0udYu6ZIkAa/xuenIUEqFv7DvE2Yr60jxweJSrQ==
+
 array-map@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
@@ -2761,6 +2766,11 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
+camelcase@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+
 caniuse-api@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
@@ -2893,7 +2903,7 @@ chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^2.0.2, chokidar@^2.0.3:
+chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   dependencies:
@@ -3054,6 +3064,11 @@ cmd-shim@^2.0.2:
     graceful-fs "^4.1.2"
     mkdirp "~0.5.0"
 
+co@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-3.1.0.tgz#4ea54ea5a08938153185e15210c68d9092bc1b78"
+  integrity sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -3212,7 +3227,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.0, concat-stream@^1.6.0, concat-stream@~1.6.0:
+concat-stream@^1.5.0, concat-stream@^1.5.1, concat-stream@^1.6.0, concat-stream@~1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -4649,6 +4664,11 @@ extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
+extend@~2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-2.0.2.tgz#1b74985400171b85554894459c978de6ef453ab7"
+  integrity sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ==
+
 external-editor@^2.0.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
@@ -4743,6 +4763,13 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fault@^1.0.0, fault@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.2.tgz#c3d0fec202f172a3a4d414042ad2bb5e2a3ffbaa"
+  integrity sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==
+  dependencies:
+    format "^0.2.2"
 
 faye-websocket@~0.11.0:
   version "0.11.1"
@@ -4901,6 +4928,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+fn-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
+  integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -4926,6 +4958,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
     mime-types "^2.1.12"
+
+format@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -5125,7 +5162,7 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-github-slugger@^1.0.0:
+github-slugger@^1.0.0, github-slugger@^1.1.1, github-slugger@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.2.0.tgz#8ada3286fd046d8951c3c952a8d7854cfd90fd9a"
   dependencies:
@@ -5527,7 +5564,7 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
+hosted-git-info@^2.1.4, hosted-git-info@^2.5.0, hosted-git-info@^2.6.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
@@ -5726,7 +5763,7 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.3.5:
+ignore@^3.2.0, ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
@@ -5874,6 +5911,16 @@ ipaddr.js@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
 
+irregular-plurals@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766"
+  integrity sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=
+
+irregular-plurals@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-2.0.0.tgz#39d40f05b00f656d0b7fa471230dd3b714af2872"
+  integrity sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==
+
 is-absolute-url@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
@@ -5893,6 +5940,11 @@ is-accessor-descriptor@^1.0.0:
 is-alphabetical@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
+
+is-alphanumeric@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
+  integrity sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=
 
 is-alphanumerical@^1.0.0:
   version "1.0.2"
@@ -5918,6 +5970,11 @@ is-binary-path@^1.0.0:
 is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-buffer@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
@@ -6064,6 +6121,11 @@ is-hexadecimal@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
 
+is-hidden@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-hidden/-/is-hidden-1.1.1.tgz#82ee6a93aeef3fb007ad5b9457c0584d45329f38"
+  integrity sha512-175UKecS8+U4hh2PSY0j4xnm2GKYzvSKnbh+naC93JjuBA7LgIo6YxlbcsSo6seFBdQO3RuIcH980yvqqD/2cA==
+
 is-installed-globally@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
@@ -6100,6 +6162,11 @@ is-number@^4.0.0:
 is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+
+is-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+  integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
 
 is-observable@^1.1.0:
   version "1.1.0"
@@ -6902,7 +6969,7 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
+js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -7033,9 +7100,10 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-json5@^1.0.1:
+json5@^1.0.0, json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
 
@@ -7216,6 +7284,11 @@ leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
+levenshtein-edit-distance@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz#895baf478cce8b5c1a0d27e45d7c1d978a661e49"
+  integrity sha1-iVuvR4zOi1waDSfkXXwdl4pmHkk=
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -7335,6 +7408,14 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
+load-plugin@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/load-plugin/-/load-plugin-2.2.2.tgz#ebc7599491ff33e5077719fbe051d5725a9f7a89"
+  integrity sha512-FYzamtURIJefQykZGtiClYuZkJBUKzmx8Tc74y8JGAulDzbzVm/C+w/MbAljHRr+REL0cRzy3WgnHE+T8gce5g==
+  dependencies:
+    npm-prefix "^1.2.0"
+    resolve-from "^4.0.0"
+
 loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
@@ -7451,6 +7532,11 @@ long@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
+longest-streak@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.2.tgz#2421b6ba939a443bb9ffebf596585a50b4c38e2e"
+  integrity sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -7551,9 +7637,24 @@ markdown-escapes@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
 
+markdown-extensions@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-extensions/-/markdown-extensions-1.1.1.tgz#fea03b539faeaee9b4ef02a3769b455b189f7fc3"
+  integrity sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==
+
+markdown-table@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
+  integrity sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==
+
 match-at@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/match-at/-/match-at-0.1.1.tgz#25d040d291777704d5e6556bbb79230ec2de0540"
+
+match-casing@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/match-casing/-/match-casing-1.0.1.tgz#baa22d0b0279b848bf63e7cc33dd19f161377d8e"
+  integrity sha512-zUroBN1AtMqqtIOb2qfwgncEuUAG7b5wQ1J9/D8jYRxbdvUZnpuRIlkqFyrX/1RbWJNzERwHG4BMj2LTtZW48g==
 
 matcher@^1.0.0:
   version "1.1.1"
@@ -7577,17 +7678,34 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+mdast-comment-marker@^1.0.0, mdast-comment-marker@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mdast-comment-marker/-/mdast-comment-marker-1.0.3.tgz#1ead204b73e8759d29785ef3024a1e43510d38e5"
+  integrity sha512-FZXxBBYeJ/R6k9zgyVGygHWka6FDJdzSbP6kcvB+L4Yqz62po57rZlnA2I14LIKsb3XPEky4vgP0Y83tZXTw7Q==
+
 mdast-squeeze-paragraphs@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-3.0.3.tgz#eb40b48b0d63573afad651d2623806090397d5d0"
   dependencies:
     unist-util-remove "^1.0.0"
 
-mdast-util-definitions@^1.2.0:
+mdast-util-compact@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz#c12ebe16fffc84573d3e19767726de226e95f649"
+  integrity sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+mdast-util-definitions@^1.0.0, mdast-util-definitions@^1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-1.2.3.tgz#49f936b09207c45b438db19551652934312f04f0"
   dependencies:
     unist-util-visit "^1.0.0"
+
+mdast-util-heading-style@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mdast-util-heading-style/-/mdast-util-heading-style-1.0.4.tgz#8e796de77f91c141691620ebbb5c9140609e3fd2"
+  integrity sha512-n4fUvwpR5Uj1Ti658KxYDq9gR0UF3FK1UVTVig12imrSOssQU2OpUysje8nps5Cb85b6eau5akpWW7Zkxtv1XA==
 
 mdast-util-to-hast@^3.0.0:
   version "3.0.2"
@@ -7605,9 +7723,28 @@ mdast-util-to-hast@^3.0.0:
     unist-util-visit "^1.1.0"
     xtend "^4.0.1"
 
-mdast-util-to-string@^1.0.0:
+mdast-util-to-nlcst@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-nlcst/-/mdast-util-to-nlcst-3.2.2.tgz#71972eecd64dc03d5cf2713f08555e2d9e2d7d10"
+  integrity sha512-TmJlri8dHt7duRU6jfWBMqf5gW+VZ6o/8GHaWzwdxslseB2lL8bSOiox6c8VwYX5v2E4CzUWm/1GkAYqgbNw9A==
+  dependencies:
+    nlcst-to-string "^2.0.0"
+    repeat-string "^1.5.2"
+    unist-util-position "^3.0.0"
+    vfile-location "^2.0.0"
+
+mdast-util-to-string@^1.0.0, mdast-util-to-string@^1.0.1, mdast-util-to-string@^1.0.2, mdast-util-to-string@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.0.5.tgz#3552b05428af22ceda34f156afe62ec8e6d731ca"
+
+mdast-util-toc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-toc/-/mdast-util-toc-3.0.0.tgz#297e2424fe24a11db054fa9ab65d305fdcfae56d"
+  integrity sha512-rdpar0+u7H8RpsxVagGUG11VEaxkWlDefGMarG+6xDurTnkD14DMTDo9FQ1lCC3oElzwF3+EEsfeAd/wHrIjoQ==
+  dependencies:
+    github-slugger "^1.1.1"
+    mdast-util-to-string "^1.0.2"
+    unist-util-visit "^1.1.0"
 
 mdn-data@~1.1.0:
   version "1.1.4"
@@ -8018,6 +8155,34 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
+nlcst-is-literal@^1.0.0, nlcst-is-literal@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/nlcst-is-literal/-/nlcst-is-literal-1.1.2.tgz#f941989ca46c6dfc635e96df6b25dcebdb2eb89d"
+  integrity sha512-eFdFvG7XE/YwPFbRk3ryzinTVGWpAEBQNH/FWc4sVSHXUumZtdSVaJYsz0axK4uF1pmlIAWgYWhzDuQ8NTf79A==
+  dependencies:
+    nlcst-to-string "^2.0.0"
+
+nlcst-normalize@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/nlcst-normalize/-/nlcst-normalize-2.1.2.tgz#5c7413ab5d0b280e1d66f20433377b83d3c0d04c"
+  integrity sha512-fvXY7r3MsPFoB7nAUxhuBUJ8UC8wzBpWXuPRNL5DYca805CvThsV1wEIbkD9X/t506vvRfL3rRjXnfmbcl7O4Q==
+  dependencies:
+    nlcst-to-string "^2.0.0"
+
+nlcst-search@^1.0.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/nlcst-search/-/nlcst-search-1.5.0.tgz#7769e0adf77b5b0022e98f2dfdf4bebe075ae936"
+  integrity sha512-2OYlim0rafAJRtwhqUxgwyXskQNSiDHrMWXjUaPzzYwWfG3XnM3OAextLxj0i/iObl1mG4ZAGKY6nwtfogJMzQ==
+  dependencies:
+    nlcst-is-literal "^1.1.0"
+    nlcst-normalize "^2.1.0"
+    unist-util-visit "^1.0.0"
+
+nlcst-to-string@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/nlcst-to-string/-/nlcst-to-string-2.0.2.tgz#7125af4d4d369850c697192a658f01f36af9937b"
+  integrity sha512-DV7wVvMcAsmZ5qEwvX1JUNF4lKkAAKbChwNlIH7NLsPR7LWWoeIt53YlZ5CQH5KDXEXQ9Xa3mw0PbPewymrtew==
+
 no-case@^2.2.0, no-case@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -8230,6 +8395,15 @@ npm-pick-manifest@^2.1.0:
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
 
+npm-prefix@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/npm-prefix/-/npm-prefix-1.2.0.tgz#e619455f7074ba54cc66d6d0d37dd9f1be6bcbc0"
+  integrity sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=
+  dependencies:
+    rc "^1.1.0"
+    shellsubstitute "^1.1.0"
+    untildify "^2.1.0"
+
 npm-registry-fetch@^3.0.0, npm-registry-fetch@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-3.8.0.tgz#aa7d9a7c92aff94f48dba0984bdef4bd131c88cc"
@@ -8279,6 +8453,11 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
+number-to-words@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/number-to-words/-/number-to-words-1.2.4.tgz#e0f124de9628f8d86c4eeb89bac6c07699264501"
+  integrity sha512-/fYevVkXRcyBiZDg6yzZbm0RuaD6i0qRfn8yr+6D0KgBMOndFPxuW10qCHpzs50nN8qKuv78k8MuotZhcVX6Pw==
+
 nwmatcher@^1.4.3:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
@@ -8307,7 +8486,7 @@ object-inspect@~1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.4.1.tgz#37ffb10e71adaf3748d05f713b4c9452f402cbc4"
 
-object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.0.6:
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.0.6, object-keys@^1.0.9:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
@@ -8680,6 +8859,28 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
+parse-english@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/parse-english/-/parse-english-4.1.1.tgz#2f75872e617769d857d9b6992dcde2a891f1b2d3"
+  integrity sha512-g7hegR9AFIlGXl5645mG8nQeeWW7SrK7lgmgIWR0KKWvGyZO5mxa4GGoNxRLm6VW2LGpLnn6g4O9yyLJQ4IzQw==
+  dependencies:
+    nlcst-to-string "^2.0.0"
+    parse-latin "^4.0.0"
+    unist-util-modify-children "^1.0.0"
+    unist-util-visit-children "^1.0.0"
+
+parse-entities@^1.0.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.0.tgz#9deac087661b2e36814153cb78d7e54a4c5fd6f4"
+  integrity sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-entities@^1.1.0, parse-entities@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
@@ -8716,6 +8917,15 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
+
+parse-latin@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/parse-latin/-/parse-latin-4.1.1.tgz#3a3edef405b2d5dce417b7157d3d8a5c7cdfab1d"
+  integrity sha512-9fPVvDdw6G8LxL3o/PL6IzSGNGpF+3HEjCzFe0dN83sZPstftyr+McP9dNi3+EnR7ICYOHbHKCZ0l7JD90K5xQ==
+  dependencies:
+    nlcst-to-string "^2.0.0"
+    unist-util-modify-children "^1.0.0"
+    unist-util-visit-children "^1.0.0"
 
 parse-passwd@^1.0.0:
   version "1.0.0"
@@ -8884,6 +9094,20 @@ please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
   integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
   dependencies:
     semver-compare "^1.0.0"
+
+plur@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/plur/-/plur-2.1.2.tgz#7482452c1a0f508e3e344eaec312c91c29dc655a"
+  integrity sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=
+  dependencies:
+    irregular-plurals "^1.0.0"
+
+plur@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/plur/-/plur-3.0.1.tgz#268652d605f816699b42b86248de73c9acd06a7c"
+  integrity sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==
+  dependencies:
+    irregular-plurals "^2.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -9487,6 +9711,13 @@ property-information@^4.0.0:
   dependencies:
     xtend "^4.0.1"
 
+propose@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/propose/-/propose-0.0.5.tgz#48a065d9ec7d4c8667f4050b15c4a2d85dbca56b"
+  integrity sha1-SKBl2ex9TIZn9AULFcSi2F28pWs=
+  dependencies:
+    levenshtein-edit-distance "^1.0.0"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -9595,6 +9826,11 @@ quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
 
+quotation@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/quotation/-/quotation-1.1.1.tgz#b599a2b7361a566086458014fda9d6b00326f169"
+  integrity sha512-bjz7kEsfg6D3uMeed+VbeypnooGlX7enMnDbx0KLYEEM8J1k24jk2pc+1nyQ1sExnERz8xKXRSZ0EYNIwLM83g==
+
 quote-stream@^1.0.1, quote-stream@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/quote-stream/-/quote-stream-1.0.2.tgz#84963f8c9c26b942e153feeb53aae74652b7e0b2"
@@ -9637,7 +9873,7 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
+rc@^1.0.1, rc@^1.1.0, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
@@ -10064,12 +10300,39 @@ remark-autolink-headings@^5.0.0:
   dependencies:
     unist-util-visit "^1.0.1"
 
+remark-cli@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/remark-cli/-/remark-cli-6.0.1.tgz#ace67b94c05df0516b6be8dd70f326b6fa9c3770"
+  integrity sha512-h7Hwnfdcm5J03t2mxhl9BAav+Goqauqfz3LhpE7TP+RIiPnK6njU7qRDD7qlUd/hLyMSB+WBjYc7gVDQT3pv0A==
+  dependencies:
+    markdown-extensions "^1.1.0"
+    remark "^10.0.0"
+    unified-args "^6.0.0"
+
+remark-comment-config@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/remark-comment-config/-/remark-comment-config-5.0.2.tgz#9202e9af2739a4d9a802e254255542a05debf2a4"
+  integrity sha512-oJ9y3ZdfobPgrUHHgSG4WsL/kd8hUN4+ygZjUf+ySiQuW7r2vOP8aN2H+BUu/3xunkR9j9lgO/Uu9IF7FxkxCQ==
+  dependencies:
+    mdast-comment-marker "^1.0.1"
+
 remark-emoji@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/remark-emoji/-/remark-emoji-2.0.1.tgz#6de4be7acb05b8534b6bad679d56eab24fba5e06"
   dependencies:
     node-emoji "^1.4.1"
     unist-util-visit "^1.1.0"
+
+remark-github@^7.0.0:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/remark-github/-/remark-github-7.0.4.tgz#9cd7a4f6e9b3e59e3ce3e91bfd8d2fd028e91a72"
+  integrity sha512-c5QLhKcvtjJKDMe/quOREmgcMPZWjfTenoUtDfY2kNBMouxGTrkk+1Cqi51TBPkcq8woH3tk4vJ7gzK6uGLIbQ==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+    mdast-util-to-string "^1.0.1"
+    unist-util-visit "^1.0.0"
 
 remark-images@^0.8.1:
   version "0.8.1"
@@ -10078,11 +10341,542 @@ remark-images@^0.8.1:
     is-url "^1.2.2"
     unist-util-visit "^1.3.0"
 
+remark-lint-blockquote-indentation@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-blockquote-indentation/-/remark-lint-blockquote-indentation-1.0.2.tgz#e84ab0dc4bf468ca10c53f09e1cb8dd0c2f56a95"
+  integrity sha512-u3ruA+4ZZOpt3YmTCdCOcYiGBMSQ/b/iJvZs/fibF6rwSBmkod48aGGJVoOLMuIuTYYbbXpzigxS+PeJwN0CDQ==
+  dependencies:
+    mdast-util-to-string "^1.0.2"
+    plur "^3.0.0"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-checkbox-character-style@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-checkbox-character-style/-/remark-lint-checkbox-character-style-1.0.2.tgz#0dc33eb1a2753e2c4212799cbf15cd4153aeef55"
+  integrity sha512-8hTvHHGj0Ko5Qx9RjBVj9yPO/pOpSFzWVMvszyhZkuH/uy92bab/bmfUwl0/4f8gqsxqyRS/QC/Sp+KivWvYlw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+    vfile-location "^2.0.1"
+
+remark-lint-checkbox-content-indent@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-checkbox-content-indent/-/remark-lint-checkbox-content-indent-1.0.2.tgz#8e145a0d030254c17a6542c4377b473d621f16d2"
+  integrity sha512-9cPEpd3GpN5ZoAEBTl6qkVOIXpJSms+AC6L/gGLHOcfmSaR5jfgzQWE7GkCj6OvUqjV69zrGGHlWLu7uMujf3g==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+    vfile-location "^2.0.1"
+
+remark-lint-code-block-style@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-code-block-style/-/remark-lint-code-block-style-1.0.2.tgz#f24ef71767d5933ed83de93a54a85faf9e02c197"
+  integrity sha512-fTSCga/lJ710zBaD808NwqzAatVoLQFizvXWpetygKwoAfXCyMYQ9DUdDE5jdDhwOu2JPnKbxY+4t6m4SrKKWA==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-definition-case@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-definition-case/-/remark-lint-definition-case-1.0.2.tgz#f2455a254ed07ff5e742d3d364a7d2f663def5af"
+  integrity sha512-vzL3IufsgYMdoYzgelryjBbNotMSac2VpIQWPbBrOEaMO8YA0OwFmD4ZxZ/IgqExRJs7CYO1v7Vr1/AhIy6RwA==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-definition-spacing@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-definition-spacing/-/remark-lint-definition-spacing-1.0.2.tgz#f2ae34c41a4cf56a2434c2a4a47c5163bb3cdc54"
+  integrity sha512-Yg1BcI/nydXii1B6kiqKIBsqDW7KlOCBMpJO2jMGmNuEuZe8sv1AWNmaCtiSCdPuDiX0CZRidklrkrZwAthPdw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-emphasis-marker@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-emphasis-marker/-/remark-lint-emphasis-marker-1.0.2.tgz#df77c6b62b87a61ddf683e791d13ccfae050c318"
+  integrity sha512-c+uvvnYesMaqy/X0dU62dbI6/rk+4dxMXdnfLC/NKBA8GU+4kljWqluW797S6nBG94QZjKIv8m49zJl38QfImQ==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-fenced-code-flag@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-fenced-code-flag/-/remark-lint-fenced-code-flag-1.0.2.tgz#614232ab7923fc0a3e8694b485bc7ae664c7046b"
+  integrity sha512-6/412zYtz+qKpFJryEPSMurWr6tO5MTVohJF3byFc3+3SSEZLWY3Dg8gbwFlumZ9T4HgmfUm/LT7Idm96zj0nw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-fenced-code-marker@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-fenced-code-marker/-/remark-lint-fenced-code-marker-1.0.2.tgz#07959311cf7b9cbe35ae279ea3cb7823205cb29f"
+  integrity sha512-yAP59Q1JoI1jjOFCn0GoNx4uDji99ROLvdwvmz7+9YR9guDArBcR4i9Wem/wN6apauWPk2DbAZFavHvbZaT8HQ==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-file-extension@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-file-extension/-/remark-lint-file-extension-1.0.2.tgz#c52c6e00c9d1f5e729f515c1bb9c23de9aef4983"
+  integrity sha512-qx0uki74rmALIKE3r5J3neasbXnz6h+l88OngvpwWkELsnJmfk81JdxfEd0tZ++uTj6CN0TZuhMKad9smfNtRw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+
+remark-lint-final-definition@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-final-definition/-/remark-lint-final-definition-1.0.2.tgz#63e013c9f95c9b52197f19c6e0d14b622352e0f3"
+  integrity sha512-F+n8eauYOJGdcSrnD7w2YgQSERx1rAwXTxStaJ2tLmoXlT7eQgpVGHz1U4Y76cg8OANbq8pT0KTNJ85JNqkq4g==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-final-newline@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-final-newline/-/remark-lint-final-newline-1.0.2.tgz#13b9ff6bd3e9c377286b439d8f14b04efde3898f"
+  integrity sha512-hW/lbDwVKtME3jIcJWJ16wBtoJdFPWIiu0fEI93yzNTjeB1g3VSWJp66dHbtCLYwquRS5fr8UlGx7JxIu1kiuA==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+
+remark-lint-first-heading-level@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-first-heading-level/-/remark-lint-first-heading-level-1.1.2.tgz#ae66e6abe4e14a6db58c87f6b13c3f2c69927539"
+  integrity sha512-4LXZmaeQwlkOoK7PVGoI53ohwdaSB54MgQ+FZ353oVxRO1fY+nbNu70/qxvnyu8/23NK4GkCgHvDVb3+unRJNQ==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-hard-break-spaces@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/remark-lint-hard-break-spaces/-/remark-lint-hard-break-spaces-1.0.3.tgz#0485fc09265dcea436f5eb3420a3b6f616c6fad7"
+  integrity sha512-GiC0uXeFwef6/Pfo+EYBN0WIVlEFffh+9TdeJ4uLt89ZweaRVDPCTJQqkkuXoiXSPnZGD7cGHdkWCfXU1PaU7Q==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-heading-style@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-heading-style/-/remark-lint-heading-style-1.0.2.tgz#87bdab061c9d259f50b5c51ce478d1c65bd31ae8"
+  integrity sha512-d0aIbL8PU5LWfZVI8p49vEV5wWIfD/DdUjc+O8j5E0UWUgcRgPGB66xznkOb8AiniXpcaYggRW8hGZsxoYNt1g==
+  dependencies:
+    mdast-util-heading-style "^1.0.2"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-link-title-style@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-link-title-style/-/remark-lint-link-title-style-1.0.2.tgz#f96f424ce90c79a7344e72078ca51f8461f4c3bc"
+  integrity sha512-0yoaSeLek5hWAQM8WETpi7/pY8kAVOOC/G1ZZFKmIQ0LPeWIzbIlPKJVV0vCiW97J3Bpv8PL0TMTwhXeP0KH2w==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+    vfile-location "^2.0.1"
+
+remark-lint-list-item-bullet-indent@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-list-item-bullet-indent/-/remark-lint-list-item-bullet-indent-1.0.2.tgz#82461e7295b9e208e7c41b62d30476a69727b0cb"
+  integrity sha512-zvyQD6mJLRratZjk4Dw7D4vh73L43NXNCcap/6TxcmU9SKO7dXzoh8Ap9tyaFLic0LnHFc3Gx1pqYiPQ7PnL2g==
+  dependencies:
+    plur "^3.0.0"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-list-item-indent@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/remark-lint-list-item-indent/-/remark-lint-list-item-indent-1.0.3.tgz#93dac0cc312ee8dd9c8a0749b44b17b95b765f53"
+  integrity sha512-/IcVUPIxQ2X/oCKzqiAtH85CS8An3xQbcMD0DRBHZjBrIUO0Ot7lBiQedSHwCg9lnh7pDOTvHrmNS3FaWjVQqw==
+  dependencies:
+    plur "^3.0.0"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-maximum-heading-length@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-maximum-heading-length/-/remark-lint-maximum-heading-length-1.0.2.tgz#8588923a480d3f039d6c28ae60a6b03cf864b5c8"
+  integrity sha512-kDdwgRItpVGhxdUC+kbWn5YisCrtF4KggP8z36z26tBmDuPj1ohjQvfMWY0oKL8I0Y6UuXyE0vQx3m4R8Qrj+A==
+  dependencies:
+    mdast-util-to-string "^1.0.2"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-maximum-line-length@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remark-lint-maximum-line-length/-/remark-lint-maximum-line-length-1.1.0.tgz#d56e6d083bbba3b757ed95f4e4d24041df7f405e"
+  integrity sha512-L+jI6+DReoxHyAWRIxABjX8hPDgxB8B5Lzp0/nDYjWbjl7I4vTsdEvejpmP1K8LVvZ7Ew0XcVHd1zt+p2O8tDg==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-auto-link-without-protocol@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-auto-link-without-protocol/-/remark-lint-no-auto-link-without-protocol-1.0.2.tgz#4532087419b1b131b4057ecf0a3a446f0afc2c6e"
+  integrity sha512-3GtkSxOyd6we4b8JdtJsNgt8+3UN+hpw1UiMoE9X96ahc1rqsCFm6miorNUnF/gfPQ1liHBvZUed2SIenDmpkg==
+  dependencies:
+    mdast-util-to-string "^1.0.2"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-blockquote-without-marker@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-blockquote-without-marker/-/remark-lint-no-blockquote-without-marker-2.0.2.tgz#61b6a0a74fbfba8fd168ac0fcc2a673eb47b9880"
+  integrity sha512-jkfZ4hFiviZttEo7Ac7GZWFgMQ/bdVPfSluLeuf+qwL8sQvR4ClklKJ0Xbkk3cLRjvlGsc8U8uZR8qqH5MSLoA==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+    vfile-location "^2.0.1"
+
+remark-lint-no-consecutive-blank-lines@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-consecutive-blank-lines/-/remark-lint-no-consecutive-blank-lines-1.0.2.tgz#ba7c8944335a80e67c811028732f12e521d07d93"
+  integrity sha512-KbOm6EX5Yl9uzRC93soTB+HlqtCzu9XJWsV9CVcoDKtNnpKfyTwQOy6dmUbQrLp4xBdNk4s9S9CsemRaHEkFGA==
+  dependencies:
+    plur "^3.0.0"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-duplicate-definitions@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-duplicate-definitions/-/remark-lint-no-duplicate-definitions-1.0.2.tgz#d27d394ab543f8064a97e2509b49220449f961cb"
+  integrity sha512-e5tSoIBChG3UCz4eJ+JPKV915iNeIeT7uKBKzXBPxnMcEgQaT3V7DBDdN8Wn1oPw9fLp/5AjDN5l9x7iddLsRw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-stringify-position "^1.1.2"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-emphasis-as-heading@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-emphasis-as-heading/-/remark-lint-no-emphasis-as-heading-1.0.2.tgz#a4616ad3f085e4db013132306312973b3fe76ac0"
+  integrity sha512-lKlwiRQOFOoPSwjbZf065RaUr6RZmO82zZYjXhVT9xwMkWXIAQyG0GJuLB2/+rlMEtlgoUD3ePch+Pzf+KrSJQ==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-file-name-articles@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-file-name-articles/-/remark-lint-no-file-name-articles-1.0.2.tgz#a8187e44584e56ccc37fcd7bbc758e940a5b1829"
+  integrity sha512-5FuxJ0Hd2AgVSP1javG51qPbMBWxma1LrCKI6JmBsu/GM7ZYOgemMyH5v4I1ejTPGj7P30xmIjMNSnV8IBMq3g==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+
+remark-lint-no-file-name-consecutive-dashes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-file-name-consecutive-dashes/-/remark-lint-no-file-name-consecutive-dashes-1.0.2.tgz#e8536f4c9f349965d9b4990a75a27857dac72488"
+  integrity sha512-VvCxG3AfRm6ROFNJ8+tdOOkk61mEKj+PytB8xg5WNQypKWhhJ734mJ3GzXD4XEov7Bdd1GVXJFXlLFtfoAewHw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+
+remark-lint-no-file-name-irregular-characters@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-file-name-irregular-characters/-/remark-lint-no-file-name-irregular-characters-1.0.2.tgz#0dffe8f4dc7ffe79f634d4609a8f28261a981552"
+  integrity sha512-8A+DYXsiPBu0q4cvqtYwzRj6SWrKnPh+oI1H1t64pCQiSnLmG9e3mAUXMxH9PiM6y5OW7Vw8Xh4KYsnRwGEuMQ==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+
+remark-lint-no-file-name-mixed-case@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-file-name-mixed-case/-/remark-lint-no-file-name-mixed-case-1.0.2.tgz#965606ac41b53fef8a4c8d0c7bd1bed63e26a357"
+  integrity sha512-OMH2kpjvDAsyyw8ar9h6WI1kUXSpQ2r2c5JZv3NBNYxwzTBfhCR2MSQq+eEI7yUmD2ehqNUY5LwZTQZG6cK4vw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+
+remark-lint-no-file-name-outer-dashes@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-file-name-outer-dashes/-/remark-lint-no-file-name-outer-dashes-1.0.3.tgz#d5b217a8341ac79b4a378770488b3ccc8bc4a5b5"
+  integrity sha512-imUWm8Bi9PxV+IQtQC2/BV1Yj0VboC9hPMZh3sae8pZvCjXquTyYiSFa7hQxX6KWCNUiRPHMSlaSVvfvM2e4pQ==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+
+remark-lint-no-heading-content-indent@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-heading-content-indent/-/remark-lint-no-heading-content-indent-1.0.2.tgz#812c4af2a18491bbf278f15a6f533169203a1b3c"
+  integrity sha512-g2MVmJhHbfFungca5WGWVB9bBY4YTrY6og20U+6DxkdS4ngoc8ezXUt8zV1HHEn0M/GdKr9F7fYhXcekJd/qaw==
+  dependencies:
+    mdast-util-heading-style "^1.0.2"
+    plur "^3.0.0"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-heading-indent@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-heading-indent/-/remark-lint-no-heading-indent-1.0.2.tgz#fdd16a802bbf7f21cdbea8497ef1fd8c7b8718bd"
+  integrity sha512-BJ9mPGIFn6Pv0KN9Qwy27wQGllM6mPCv6VI6khDcURlzdAaX5hfFarGJVGKEgPWoL8zs8fPRoXMpsAHIonnnyA==
+  dependencies:
+    plur "^3.0.0"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-heading-punctuation@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-heading-punctuation/-/remark-lint-no-heading-punctuation-1.0.2.tgz#c520d8614d641b05ac75c25502901df9218b4b5e"
+  integrity sha512-nYc2a0ihQ5cPy7elaM0lRPYKEMpEK6EjyJH6pHYlgG8NQwjKXhsVaek0fmAm12PaYoYOGW1pDxfzxnFUocU20g==
+  dependencies:
+    mdast-util-to-string "^1.0.2"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-html@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-html/-/remark-lint-no-html-1.0.2.tgz#335879bd1ff176d66842af4049b07db8fb23cd2d"
+  integrity sha512-sdatNJIL820AVzTOj8S3AS5jQs89zZlyuB4viyki/kUhZbqmXmznD1bI7PMum5tn0zYl+rpvJaCEBl65wH2hjQ==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-inline-padding@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-inline-padding/-/remark-lint-no-inline-padding-1.0.2.tgz#aa189d88c0d3faa913007c2f04d72b20d84e577e"
+  integrity sha512-SHYqEH27yxzgcXSyaIzvqImvktDhXGltRSOEhAHiL2nJktuPt3nosFfGy4/oKAJMWJ2N3aMudXq/zuw1dAkQSg==
+  dependencies:
+    mdast-util-to-string "^1.0.2"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-literal-urls@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-literal-urls/-/remark-lint-no-literal-urls-1.0.2.tgz#1c60160a76bd9ddacd42819b43dadeb481a530df"
+  integrity sha512-+mWZIJA4yAqpKIclcFP5wRy/6hxcPnfU9Xmgp4fR7OD4JQ4JHkKq9O7MUbda14PLez1aMX+Is0O0hWI7OuqsSw==
+  dependencies:
+    mdast-util-to-string "^1.0.2"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-missing-blank-lines@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-missing-blank-lines/-/remark-lint-no-missing-blank-lines-1.0.2.tgz#5d3ec89b4d117eaadbebbcbf8f265439c4390f0c"
+  integrity sha512-Q/47tKY7fs+hb2avIw8/KkmbtqFg6SHbBGijIpk53wtaAEItCvuGIym7dUapwV3nHtNhkaQ450bQ66yfdf9o7w==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-multiple-toplevel-headings@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-multiple-toplevel-headings/-/remark-lint-no-multiple-toplevel-headings-1.0.2.tgz#65f7288f66a1a14394f6c6f0910d36112f60e3eb"
+  integrity sha512-Zxkw7wIyMOyYQb5C5NTswSttZPCLqm/60Wnt0TEWzXVDkVk5DrxrCCxbMKgpXve1Co5CXPmMixNr/xYBqzxzWg==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-stringify-position "^1.1.2"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-shell-dollars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-shell-dollars/-/remark-lint-no-shell-dollars-1.0.2.tgz#361599631271f7237b2147e692be40e08975330c"
+  integrity sha512-eIjBebX9iOFWbMdjol5JJBXI7ku+7UyJpNrd++rl8QenLLZ76beh+xONCzJw/k5dhEw5voBmQLh7VK9HPU/ang==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-shortcut-reference-image@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-shortcut-reference-image/-/remark-lint-no-shortcut-reference-image-1.0.2.tgz#784011b832173ad9e87d4f40c90f935de0841764"
+  integrity sha512-IVYv5pgyf70jYcrn+BNHVO37BuQJg26rFOLzi2mj+/8EdFpolJiJcTvkChJgz5yip7317DmQQSNLX6gCExuDrQ==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-shortcut-reference-link@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-shortcut-reference-link/-/remark-lint-no-shortcut-reference-link-1.0.3.tgz#4210d37d234b427dd131eb11473a7a2d3719a819"
+  integrity sha512-v5mk4wYQL+YRmlOTqi8avpzhoGZg+P42dDRda2jedysDIx7TJBEXUH6oMFEbo/qV6PMmtr7fr066M3RrOrLpiQ==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-table-indentation@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-table-indentation/-/remark-lint-no-table-indentation-1.0.2.tgz#ee64d30e2c309c04807ef3f22954d4fcda4432a3"
+  integrity sha512-wH0lMGV3DGf7WeDLYGle7SODkXNKqmFtGuh6sG5oa0XgA17rI/L35Vq5tal4DE/5gQG+l4+/0Iy9FPKdBODSDA==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-tabs@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-tabs/-/remark-lint-no-tabs-1.0.2.tgz#a6605c63140b2bb50f6183297cd1e02ac3213455"
+  integrity sha512-jPjRLHyzO4lO6orhOmHd6AN6mVc/uMWvYZ3qD41dniktnLyHEbIG6DpPxixjfpmEe0wi73RXMywKHrWshLJwAg==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    vfile-location "^2.0.1"
+
+remark-lint-no-undefined-references@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-undefined-references/-/remark-lint-no-undefined-references-1.0.2.tgz#56a1a6db75258aa19556147c6bec59c9fbab45cd"
+  integrity sha512-te5rmQvdMg2Qld09Jzh4BlpjGQhbwG0EIlYVX6aE/YnwwrIldOgqLrW8x49XTyEMNOL8j/Bjxd2FX+sRfeldRw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-no-unused-definitions@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-unused-definitions/-/remark-lint-no-unused-definitions-1.0.2.tgz#5b1337f99e83a75d68bc6a0f31c8791dc497e26c"
+  integrity sha512-Qv4J2hI2S0NJdrlFuQhBVOlGNUSBLpe+2VBm/hSJAnBE7FW2ZGkVwwrs9h7HdZ/vW3LqfBrNcTKTVw+5ZzWTiA==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-ordered-list-marker-style@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-ordered-list-marker-style/-/remark-lint-ordered-list-marker-style-1.0.2.tgz#ad7461306a7701fc931245300dfd7dbd9fbb589f"
+  integrity sha512-4EHuHxZqy8IT4k+4Vc8P38I34AiZfgl07fS5/iqGhCdoSMCvvxdOuzTWTgpDFbx/W2QpHelBfJ+FtOp+E0J4Lg==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-ordered-list-marker-value@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-ordered-list-marker-value/-/remark-lint-ordered-list-marker-value-1.0.2.tgz#26f5f1ddfadb7c958f8e2c15cd3aa9f2be985be6"
+  integrity sha512-vIPD07u+FBjTjEETZ+UWUp2nydzvOe5AHIX812JlNXWuHYuCybq8DGnkYUcoiK3HbIE+KdG+e7C5xHkim0PSjw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-rule-style@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-rule-style/-/remark-lint-rule-style-1.0.2.tgz#51f82acb1e6cdf76ea6107bb231d2336615fa98d"
+  integrity sha512-D9mMPKA7rtCe4Yx+ryip6FyfNG9uGOaHxRgJClfte7D66QzxiiWtHYyNCXI4rkv8Ax9PrEdpWCPcIl3D2LrXhw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-strong-marker@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-strong-marker/-/remark-lint-strong-marker-1.0.2.tgz#6ce3670f79bf5978b7518af35e6072c8425f0f46"
+  integrity sha512-oUSKqYJVLgbXe25NmcTOfQ8wsFasc+qhEoGjPEGPuJMV2aZIGuOEbGVqD5B1ckYGBEwbTuet3btvMohz8HaBDQ==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-table-cell-padding@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-1.0.2.tgz#addb6b8575ff6d805474e41dd2e5dc9aed5d4113"
+  integrity sha512-uYm8ia0joAFeK0XLpxVtGW37Ry1XRBDmWH1gDiO2MXWcUip1w1Brvyue4H8JfXB4IM+S5eI/zPR5zN5Wpj9kfA==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-table-pipe-alignment@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-table-pipe-alignment/-/remark-lint-table-pipe-alignment-1.0.2.tgz#3d79927c18b5a5713079a7890a392b740e0bc45a"
+  integrity sha512-gLJwduvBI2soR7Dyf39KGUl3M9ZCK/7pFfWBeOv8J27D7px/1lXooqlX4Y9NQ/+9jc7DyLF9upPxh7UWm7UXGg==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-table-pipes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-table-pipes/-/remark-lint-table-pipes-1.0.2.tgz#a7e95c93d6908c2b515651aa44fc8c922626ad32"
+  integrity sha512-BGKcOviuUC6fILIOPYFe6awqk57ApzNJpK3OYBrweGoFF55nZ/qf3q6JpzA0chd6wKj7VrcfQEd3QSQQ+8Wcrw==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint-unordered-list-marker-style@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-unordered-list-marker-style/-/remark-lint-unordered-list-marker-style-1.0.2.tgz#2d631c3e7e0604e1d45d5586a0bbb21474bb89a4"
+  integrity sha512-qdnF9JuMWzFJzGIfdAWfOHyjad8dqIQSs+cTzqMlNZHOGrrCJdTUWzybzcZMGn1yuwreklZdHKhOglXQFwSD3A==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.1"
+
+remark-lint@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/remark-lint/-/remark-lint-6.0.3.tgz#6387f1123cbc539c577c4c04a5d97520122bdfc8"
+  integrity sha512-PQkF5vQos3iCJ7kXcvGLG/06UoC4cL1h6JORludnClFQYKIeWi9Z6HHLTJl439Q95OLf6ywwOdaKIU5Vul/Thg==
+  dependencies:
+    remark-message-control "^4.0.0"
+
 remark-math@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/remark-math/-/remark-math-1.0.4.tgz#ced46473075ff99e4678a154a1a3d0dde403a9f2"
   dependencies:
     trim-trailing-lines "^1.1.0"
+
+remark-message-control@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/remark-message-control/-/remark-message-control-4.1.0.tgz#60bc7700a87381404c956dc04e688518d3830cff"
+  integrity sha512-e1dszks4YKY7hLAkhS2367jBjBpAfvi+kVgSN/tOFrdp3qxITjiNR5fOFnyYF8vvorkQ9uxlKJoZUOW8T7rKDg==
+  dependencies:
+    mdast-comment-marker "^1.0.0"
+    unified-message-control "^1.0.0"
+    xtend "^4.0.1"
 
 remark-parse@^5.0.0:
   version "5.0.0"
@@ -10104,11 +10898,116 @@ remark-parse@^5.0.0:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
+remark-parse@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-6.0.3.tgz#c99131052809da482108413f87b0ee7f52180a3a"
+  integrity sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
+remark-preset-lint-recommended@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/remark-preset-lint-recommended/-/remark-preset-lint-recommended-3.0.2.tgz#5ce675678895ce7131326c12b6df9105a5d0632c"
+  integrity sha512-os4YNWLbkorjvDHVB4o+zCCufZLzGoD4Iwdk7SV7bSIZurUTrMp/ZrpNytyetN9ugIMXuHbWJUE+dF0ND+WorQ==
+  dependencies:
+    remark-lint "^6.0.0"
+    remark-lint-final-newline "^1.0.0"
+    remark-lint-hard-break-spaces "^1.0.0"
+    remark-lint-list-item-bullet-indent "^1.0.0"
+    remark-lint-list-item-indent "^1.0.0"
+    remark-lint-no-auto-link-without-protocol "^1.0.0"
+    remark-lint-no-blockquote-without-marker "^2.0.0"
+    remark-lint-no-duplicate-definitions "^1.0.0"
+    remark-lint-no-heading-content-indent "^1.0.0"
+    remark-lint-no-inline-padding "^1.0.0"
+    remark-lint-no-literal-urls "^1.0.0"
+    remark-lint-no-shortcut-reference-image "^1.0.0"
+    remark-lint-no-shortcut-reference-link "^1.0.0"
+    remark-lint-no-undefined-references "^1.0.0"
+    remark-lint-no-unused-definitions "^1.0.0"
+    remark-lint-ordered-list-marker-style "^1.0.0"
+
+remark-preset-wooorm@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-preset-wooorm/-/remark-preset-wooorm-4.0.0.tgz#4cb129396d52777184db76557b9c0b5b2f3705f7"
+  integrity sha512-niidcnozBlJj6i1mP/vsubilxrh52nG2TkMD5REFoatOmFElTn/+UO2D0SCLE+o8J/3MTUHD94igwl5Agi38Rg==
+  dependencies:
+    remark-comment-config "^5.0.0"
+    remark-github "^7.0.0"
+    remark-lint-blockquote-indentation "^1.0.0"
+    remark-lint-checkbox-character-style "^1.0.0"
+    remark-lint-checkbox-content-indent "^1.0.0"
+    remark-lint-code-block-style "^1.0.0"
+    remark-lint-definition-case "^1.0.0"
+    remark-lint-definition-spacing "^1.0.0"
+    remark-lint-emphasis-marker "^1.0.0"
+    remark-lint-fenced-code-flag "^1.0.0"
+    remark-lint-fenced-code-marker "^1.0.0"
+    remark-lint-file-extension "^1.0.0"
+    remark-lint-final-definition "^1.0.0"
+    remark-lint-first-heading-level "^1.0.0"
+    remark-lint-heading-style "^1.0.0"
+    remark-lint-link-title-style "^1.0.0"
+    remark-lint-maximum-heading-length "^1.0.0"
+    remark-lint-maximum-line-length "^1.0.0"
+    remark-lint-no-consecutive-blank-lines "^1.0.0"
+    remark-lint-no-duplicate-definitions "^1.0.0"
+    remark-lint-no-emphasis-as-heading "^1.0.0"
+    remark-lint-no-file-name-articles "^1.0.0"
+    remark-lint-no-file-name-consecutive-dashes "^1.0.0"
+    remark-lint-no-file-name-irregular-characters "^1.0.0"
+    remark-lint-no-file-name-mixed-case "^1.0.0"
+    remark-lint-no-file-name-outer-dashes "^1.0.0"
+    remark-lint-no-heading-content-indent "^1.0.0"
+    remark-lint-no-heading-indent "^1.0.0"
+    remark-lint-no-heading-punctuation "^1.0.0"
+    remark-lint-no-html "^1.0.0"
+    remark-lint-no-missing-blank-lines "^1.0.0"
+    remark-lint-no-multiple-toplevel-headings "^1.0.0"
+    remark-lint-no-shell-dollars "^1.0.0"
+    remark-lint-no-table-indentation "^1.0.0"
+    remark-lint-no-tabs "^1.0.0"
+    remark-lint-ordered-list-marker-value "^1.0.0"
+    remark-lint-rule-style "^1.0.0"
+    remark-lint-strong-marker "^1.0.0"
+    remark-lint-table-cell-padding "^1.0.0"
+    remark-lint-table-pipe-alignment "^1.0.0"
+    remark-lint-table-pipes "^1.0.0"
+    remark-lint-unordered-list-marker-style "^1.0.0"
+    remark-preset-lint-recommended "^3.0.1"
+    remark-retext "^3.0.0"
+    remark-toc "^5.0.0"
+    remark-validate-links "^7.0.0"
+    retext-english "^3.0.0"
+    retext-preset-wooorm "^1.0.0"
+    unified "^6.0.0"
+
 remark-rehype@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-3.0.1.tgz#7c35c08e022ca55bd33719548dd555b1a721a181"
   dependencies:
     mdast-util-to-hast "^3.0.0"
+
+remark-retext@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/remark-retext/-/remark-retext-3.1.1.tgz#38eb1ba8ac7c03846eecd534b414355676815927"
+  integrity sha512-6njJXkOTfQhyDYABvi4iEB81x8E6EL5cnLPtfpYrunSLQM2s1j51hma29dVkMzk9FuHqy65Zb1Tgb34UAzw+TQ==
+  dependencies:
+    mdast-util-to-nlcst "^3.2.0"
 
 remark-slug@^5.0.0, remark-slug@^5.1.0:
   version "5.1.0"
@@ -10124,6 +11023,57 @@ remark-squeeze-paragraphs@^3.0.1:
   dependencies:
     mdast-squeeze-paragraphs "^3.0.0"
 
+remark-stringify@^6.0.0:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-6.0.4.tgz#16ac229d4d1593249018663c7bddf28aafc4e088"
+  integrity sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==
+  dependencies:
+    ccount "^1.0.0"
+    is-alphanumeric "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    longest-streak "^2.0.1"
+    markdown-escapes "^1.0.0"
+    markdown-table "^1.1.0"
+    mdast-util-compact "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    stringify-entities "^1.0.1"
+    unherit "^1.0.4"
+    xtend "^4.0.1"
+
+remark-toc@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/remark-toc/-/remark-toc-5.1.0.tgz#77250ac751c47a3d81686033de2f0ae42bc86fb4"
+  integrity sha512-G2qPor2XVn6SgtdoKyD3FhhFuzIOOHK9RYVv2PFwk5PxIsNtxeiIuIy3yjGZvgFzrTXBtqpR+sVf9BC9TWSaHg==
+  dependencies:
+    mdast-util-toc "^3.0.0"
+    remark-slug "^5.0.0"
+
+remark-validate-links@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/remark-validate-links/-/remark-validate-links-7.1.0.tgz#52c161c1fc9a65ea2716755fd8b8b11b7ed09a80"
+  integrity sha512-wqTMqDSzhEeLBaHMNa9tD56ywvuJ+t9j9mPdut/y8pmi13Z1C4KQ1AnY4rLkNsM4i0k+Pu2X8SVS8M2cbz2dEQ==
+  dependencies:
+    github-slugger "^1.2.0"
+    hosted-git-info "^2.5.0"
+    mdast-util-definitions "^1.0.0"
+    mdast-util-to-string "^1.0.4"
+    propose "0.0.5"
+    unist-util-visit "^1.0.0"
+    urljoin "^0.1.5"
+    xtend "^4.0.1"
+
+remark@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-10.0.1.tgz#3058076dc41781bf505d8978c291485fe47667df"
+  integrity sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==
+  dependencies:
+    remark-parse "^6.0.0"
+    remark-stringify "^6.0.0"
+    unified "^7.0.0"
+
 remove-array-items@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/remove-array-items/-/remove-array-items-1.0.0.tgz#07bf42cb332f4cf6e85ead83b5e4e896d2326b21"
@@ -10136,7 +11086,7 @@ repeat-element@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
 
-repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.5.0, repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -10278,6 +11228,99 @@ restore-cursor@^2.0.0:
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+
+retext-contractions@^2.1.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/retext-contractions/-/retext-contractions-2.1.3.tgz#c1a3f44b22ccf505266ef83aa60c0d07162e377c"
+  integrity sha512-HN5iDZZ0WC0tJPuC+KAz00YuCLYcgM9b8sr0kQuBniqz8YsyqKiGFBQJ40sSwTVpz7GL378/5qIBr8n04eMEiA==
+  dependencies:
+    nlcst-is-literal "^1.0.0"
+    nlcst-to-string "^2.0.0"
+    unist-util-visit "^1.1.0"
+
+retext-diacritics@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/retext-diacritics/-/retext-diacritics-1.2.2.tgz#a328f6c556e59a9d1ac347fa64387352371a062d"
+  integrity sha512-1i8FFyAiFMUwqsRENuPr9tPxcL7Ges6Troiz6NMnQL4hpVKvzdZkPGfKK2PGKJaM16rmbU3zSZKbYDSC9BObug==
+  dependencies:
+    match-casing "^1.0.0"
+    nlcst-search "^1.0.0"
+    nlcst-to-string "^2.0.0"
+    object-keys "^1.0.9"
+    quotation "^1.0.1"
+    unist-util-position "^3.0.0"
+
+retext-english@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/retext-english/-/retext-english-3.0.1.tgz#9696762b277f5766eb1a5bc8710df3ec8269e54b"
+  integrity sha512-1ODZj/fzX1B+SqejSLzMwH8tOhkGSiyp7SSg6snvNVMyQgxSux9qr8kV4H684e6rsXtOOisSxINvRqh16BgUVQ==
+  dependencies:
+    parse-english "^4.0.0"
+    unherit "^1.0.4"
+
+retext-indefinite-article@^1.1.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/retext-indefinite-article/-/retext-indefinite-article-1.1.5.tgz#3a7850b05440d40aa2b586530c53fcf756136dc6"
+  integrity sha512-0COCXRPYEziEiorItemJthRWnhDLtYxiB6BCumYmtSgRvehMvc/Q1u7IP1gRDsFEtWQHY/QaAJpuzvhh0yEgAA==
+  dependencies:
+    format "^0.2.2"
+    nlcst-to-string "^2.0.0"
+    number-to-words "^1.2.3"
+    unist-util-is "^2.0.0"
+    unist-util-visit "^1.1.0"
+
+retext-preset-wooorm@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/retext-preset-wooorm/-/retext-preset-wooorm-1.0.1.tgz#8deefb9d3adfedcfa1b1db827061ab99d88e39f4"
+  integrity sha512-jqngU+czrGR8sdsNOjnPmkTJxLNTN8fWWS74BgIZA9fHdsz5Rd/NG+wPzTXwSVs6NaYEniy2RXLH1XBVTeY2qQ==
+  dependencies:
+    retext-contractions "^2.1.0"
+    retext-diacritics "^1.2.0"
+    retext-indefinite-article "^1.1.0"
+    retext-quotes "^2.0.0"
+    retext-redundant-acronyms "^1.2.0"
+    retext-repeated-words "^1.2.0"
+    retext-sentence-spacing "^2.0.0"
+
+retext-quotes@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/retext-quotes/-/retext-quotes-2.0.3.tgz#7b1aa811e9a26cd5830e8495d7ef7aeb7a2a5ed3"
+  integrity sha512-GngYmhEhnuVX6Dv1flM08XgEBCnciH7elulGcgGH0kIc8KYShuScu3qmLAg7NCETytmmgBMvsHEnEOtocRCERw==
+  dependencies:
+    nlcst-to-string "^2.0.0"
+    unist-util-is "^2.0.0"
+    unist-util-visit "^1.1.0"
+
+retext-redundant-acronyms@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/retext-redundant-acronyms/-/retext-redundant-acronyms-1.2.2.tgz#61eec4d672fd5ce12209aacd1bad4ab8f5b7b37f"
+  integrity sha512-cAqICxNKKMOF299PYEea+sOPJtd4DQzDBhprUMmgZAx7Bm0Y8JRODMJuf3N6M4GvNmOdNXTfmz4/QCx677539Q==
+  dependencies:
+    match-casing "^1.0.0"
+    nlcst-search "^1.0.0"
+    nlcst-to-string "^2.0.0"
+    object-keys "^1.0.9"
+    quotation "^1.0.1"
+    unist-util-position "^3.0.0"
+
+retext-repeated-words@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/retext-repeated-words/-/retext-repeated-words-1.2.2.tgz#2f9562f646c7412aad3a39211e678f6466613333"
+  integrity sha512-dpe/iQfYiFqPGrRubzj/oymdFlqed9W7d4qT7VKqt10Sln2Tf+nbdc0w0A5UpcLRMjgza2KnLWTObuy6iV4ffQ==
+  dependencies:
+    nlcst-to-string "^2.0.0"
+    unist-util-is "^2.0.0"
+    unist-util-visit "^1.1.0"
+
+retext-sentence-spacing@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/retext-sentence-spacing/-/retext-sentence-spacing-2.0.3.tgz#529531b58c260c5804c679fa981f280d75a12c65"
+  integrity sha512-m5KwLKIap5MCNC1qA1QfUq0f8sCX50ThluK5GiqXxGZm5OJRqNS+uktQdUSiKAhmGxlctTYAcINgERmpXBclJQ==
+  dependencies:
+    nlcst-to-string "^2.0.0"
+    plur "^2.1.2"
+    unist-util-is "^2.0.0"
+    unist-util-visit "^1.1.0"
 
 retry@^0.10.0:
   version "0.10.1"
@@ -10545,6 +11588,11 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
+shellsubstitute@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shellsubstitute/-/shellsubstitute-1.2.0.tgz#e4f702a50c518b0f6fe98451890d705af29b6b70"
+  integrity sha1-5PcCpQxRiw9v6YRRiQ1wWvKba3A=
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -10594,6 +11642,11 @@ slice-ansi@1.0.0:
   integrity sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==
   dependencies:
     is-fullwidth-code-point "^2.0.0"
+
+sliced@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sliced/-/sliced-1.0.1.tgz#0b3a662b5d04c3177b1926bea82b03f837a2ef41"
+  integrity sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=
 
 slide@^1.1.6:
   version "1.1.6"
@@ -11317,6 +12370,14 @@ to-style@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/to-style/-/to-style-1.3.3.tgz#63a2b70a6f4a7d4fdc2ed57a0be4e7235cb6699c"
 
+to-vfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-4.0.0.tgz#465ade5fc2b9e97e6c80b854d378a5d0f4b5d04a"
+  integrity sha512-Y7EDM+uoU8TZxF5ej2mUR0dLO4qbuuNRnJKxEht2QJWEq2421pyG1D1x8YxPKmyTc6nHh7Td/jLGFxYo+9vkLA==
+  dependencies:
+    is-buffer "^2.0.0"
+    vfile "^3.0.0"
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -11483,7 +12544,62 @@ unicode-trie@^0.3.1:
     pako "^0.2.5"
     tiny-inflate "^1.0.0"
 
-unified@^6.1.1, unified@^6.1.6:
+unified-args@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/unified-args/-/unified-args-6.0.0.tgz#ffa3be9372ebe311099b30435b17269b0000d04c"
+  integrity sha512-1m2pGiTClgcCtCvgtABkJLze8JJiZpzsqujRhzBjZsRwaIIU1Yj36YHY6t2RvidO8d6fucZdk3KX+8eS4+uv9g==
+  dependencies:
+    camelcase "^5.0.0"
+    chalk "^2.0.0"
+    chokidar "^2.0.0"
+    fault "^1.0.2"
+    json5 "^1.0.0"
+    minimist "^1.2.0"
+    text-table "^0.2.0"
+    unified-engine "^6.0.0"
+
+unified-engine@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/unified-engine/-/unified-engine-6.0.1.tgz#22236f1d253a6d07b6605eca83a2bcce08fc6f05"
+  integrity sha512-iDJYH82TgcezQA4IZzhCNJQx7vBsGk4h9s4Q7Fscrb3qcPsxBqVrVNYez2W3sBVTxuU1bFAhyRpA6ba/R4j93A==
+  dependencies:
+    concat-stream "^1.5.1"
+    debug "^3.1.0"
+    fault "^1.0.0"
+    fn-name "^2.0.1"
+    glob "^7.0.3"
+    ignore "^3.2.0"
+    is-empty "^1.0.0"
+    is-hidden "^1.0.1"
+    is-object "^1.0.1"
+    js-yaml "^3.6.1"
+    load-plugin "^2.0.0"
+    parse-json "^4.0.0"
+    to-vfile "^4.0.0"
+    trough "^1.0.0"
+    unist-util-inspect "^4.1.2"
+    vfile-reporter "^5.0.0"
+    vfile-statistics "^1.1.0"
+    x-is-string "^0.1.0"
+    xtend "^4.0.1"
+
+unified-lint-rule@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/unified-lint-rule/-/unified-lint-rule-1.0.3.tgz#e302b0c4a7ac428c0980e049a500e59528001299"
+  integrity sha512-6z+HH3mtlFdj/w3MaQpObrZAd9KRiro370GxBFh13qkV8LYR21lLozA4iQiZPhe7KuX/lHewoGOEgQ4AWrAR3Q==
+  dependencies:
+    wrapped "^1.0.1"
+
+unified-message-control@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unified-message-control/-/unified-message-control-1.0.4.tgz#a5e02c07112f78c6687b83a10392c2fba86dc09b"
+  integrity sha512-e1dEtN4Z/TvLn/qHm+xeZpzqhJTtfZusFErk336kkZVpqrJYiV9ptxq+SbRPFMlN0OkjDYHmVJ929KYjsMTo3g==
+  dependencies:
+    trim "0.0.1"
+    unist-util-visit "^1.0.0"
+    vfile-location "^2.0.0"
+
+unified@^6.0.0, unified@^6.1.1, unified@^6.1.6:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
   dependencies:
@@ -11492,6 +12608,18 @@ unified@^6.1.1, unified@^6.1.6:
     is-plain-obj "^1.1.0"
     trough "^1.0.0"
     vfile "^2.0.0"
+    x-is-string "^0.1.0"
+
+unified@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-7.0.2.tgz#16aa2748a7c936b80846cc69c580cd5ebd844532"
+  integrity sha512-H7HiczCdNcPrqy4meJPtlJSch9+hm6GXLQ9FFLOUiFI1DIUbjvBhMKJtQ7YCaBhEPVXZwwqNyiot9xBUEtmlbg==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^3.0.0"
     x-is-string "^0.1.0"
 
 union-value@^1.0.0:
@@ -11549,6 +12677,13 @@ unist-util-is@^2.0.0, unist-util-is@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
 
+unist-util-modify-children@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.3.tgz#d764a935f612dfb21b1bb92b0ea24321dc19a5f7"
+  integrity sha512-Aw3Us+NPrJGYWyLhcaqYzgxd/pryIanDNHVVvwdtTEEQ3Yfa/+sjnT2EeAAHbtTMAaYEdPW3XN6jxbzVWAo/BQ==
+  dependencies:
+    array-iterate "^1.0.0"
+
 unist-util-position@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.0.1.tgz#8e220c24658239bf7ddafada5725ed0ea1ebbc26"
@@ -11565,9 +12700,14 @@ unist-util-remove@^1.0.0:
   dependencies:
     unist-util-is "^2.0.0"
 
-unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1, unist-util-stringify-position@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+
+unist-util-visit-children@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-1.1.2.tgz#bd78b53db9644b9c339ac502854f15471f964f5b"
+  integrity sha512-q4t6aprUcSQ2/+xlswuh2wUKwUUuMmDjSkfwkMjeVwCXc8NqX8g0FSmNf68CznCmbkrsOPDUR0wj14bCFXXqbA==
 
 unist-util-visit-parents@^2.0.0:
   version "2.0.1"
@@ -11599,6 +12739,13 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+untildify@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-2.1.0.tgz#17eb2807987f76952e9c0485fc311d06a826a2e0"
+  integrity sha1-F+soB5h/dpUunASF/DEdBqgmouA=
+  dependencies:
+    os-homedir "^1.0.0"
 
 unzip-response@^2.0.1:
   version "2.0.1"
@@ -11670,6 +12817,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+urljoin@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/urljoin/-/urljoin-0.1.5.tgz#b25d2c6112c55ac9d50096a49a0f1fb7f4f53921"
+  integrity sha1-sl0sYRLFWsnVAJakmg8ft/T1OSE=
+  dependencies:
+    extend "~2.0.0"
 
 use@^3.1.0:
   version "3.1.1"
@@ -11753,7 +12907,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vfile-location@^2.0.0:
+vfile-location@^2.0.0, vfile-location@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.3.tgz#083ba80e50968e8d420be49dd1ea9a992131df77"
 
@@ -11763,11 +12917,43 @@ vfile-message@^1.0.0:
   dependencies:
     unist-util-stringify-position "^1.1.1"
 
+vfile-reporter@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-5.1.0.tgz#a11dca4c8a1a063a573e788eaddc4188c1b9da62"
+  integrity sha512-I6h4GrkNCZf7nWCxcN7BSDAez8+4xD9+qfu5I7yroH6Kj+lpAFFIYfY6WgfCHyscAow5BkOpfHS5hHGBN1Qf8g==
+  dependencies:
+    repeat-string "^1.5.0"
+    string-width "^2.0.0"
+    supports-color "^5.4.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-sort "^2.1.2"
+    vfile-statistics "^1.1.0"
+
+vfile-sort@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/vfile-sort/-/vfile-sort-2.1.2.tgz#99aa1b644149f0e0114661af94bd514d2be7d466"
+  integrity sha512-KoX1SaGv5CGoIIPHScklExODrVzCFC5Zo0uBM7iQTmd0PtbCswVIQ2cSESUak/dUICNc2lJyDzl9tXEB+4+P/g==
+
+vfile-statistics@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-statistics/-/vfile-statistics-1.1.1.tgz#a22fd4eb844c9eaddd781ad3b3246db88375e2e3"
+  integrity sha512-dxUM6IYvGChHuwMT3dseyU5BHprNRXzAV0OHx1A769lVGsTiT50kU7BbpRFV+IE6oWmU+PwHdsTKfXhnDIRIgQ==
+
 vfile@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
   dependencies:
     is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
+
+vfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-3.0.1.tgz#47331d2abe3282424f4a4bb6acd20a44c4121803"
+  integrity sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==
+  dependencies:
+    is-buffer "^2.0.0"
     replace-ext "1.0.0"
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
@@ -12100,6 +13286,14 @@ wrap-ansi@^3.0.1:
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
+
+wrapped@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wrapped/-/wrapped-1.0.1.tgz#c783d9d807b273e9b01e851680a938c87c907242"
+  integrity sha1-x4PZ2Aeyc+mwHoUWgKk4yHyQckI=
+  dependencies:
+    co "3.1.0"
+    sliced "^1.0.1"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This PR adds code to enforce markdown and prose code style, and fixes docs. Upon merging, it’ll close GH-311.

## Overview

* Add configuration for markdown (excluding the test files)
* Add `@mdx-js/remark-mdx` to parse imports, exports, and JSX to MDAST,
  and stringify them back to markdown. It’s private, and not tested yet,
  but it makes sure remark can run on mdx files too (note: we need to talk
  about the license file there)
* Add `remark` to the `"format"` script, fixing code where possible
* Add `remark` to the `"test"` script, but not outputting in this case
* Add to lint-staged

## Docs

* Use reference links and definitions everywhere
* Use `*` for lists and strong; add more spaces to lists
* Fix broken links, references, and remove superfluous definitions
* Fix AST spec (add comment type, default field)
* Add missing code languages
* Wrap lines around 80 chars
* Use smart quotes (`“”` and `‘’`)
