### PR TITLE
Fix comment prefix and suffix

### DIFF
--- a/packages/mdx/md-ast-to-mdx-ast.js
+++ b/packages/mdx/md-ast-to-mdx-ast.js
@@ -1,9 +1,16 @@
 const visit = require('unist-util-visit')
 
+var commentOpen = '<!--'
+var commentClose = '-->'
+
 module.exports = options => tree => {
   visit(tree, 'html', node => {
-    if (node.value.startsWith('<!--') && node.value.endsWith('-->')) {
+    if (
+      node.value.startsWith(commentOpen) &&
+      node.value.endsWith(commentClose)
+    ) {
       node.type = 'comment'
+      node.value = node.value.slice(commentOpen.length, -commentClose.length)
     } else {
       node.type = node.mdxType || 'jsx'
     }

--- a/packages/mdx/md-ast-to-mdx-ast.js
+++ b/packages/mdx/md-ast-to-mdx-ast.js
@@ -1,7 +1,7 @@
 const visit = require('unist-util-visit')
 
 const commentOpen = '<!--'
-var commentClose = '-->'
+const commentClose = '-->'
 
 module.exports = options => tree => {
   visit(tree, 'html', node => {

--- a/packages/mdx/md-ast-to-mdx-ast.js
+++ b/packages/mdx/md-ast-to-mdx-ast.js
@@ -1,6 +1,6 @@
 const visit = require('unist-util-visit')
 
-var commentOpen = '<!--'
+const commentOpen = '<!--'
 var commentClose = '-->'
 
 module.exports = options => tree => {

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -161,7 +161,7 @@ function toJSX(node, parentNode = {}, options = {}) {
   }
 
   if (node.type === 'comment') {
-    return node.value.replace('<!--', '{/*').replace('-->', '*/}')
+    return '{/*' + node.value + '*/}'
   }
 
   if (node.type === 'import' || node.type === 'export' || node.type === 'jsx') {

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -161,7 +161,7 @@ function toJSX(node, parentNode = {}, options = {}) {
   }
 
   if (node.type === 'comment') {
-    return '{/*' + node.value + '*/}'
+    return `{/*${node.value}*/}`
   }
 
   if (node.type === 'import' || node.type === 'export' || node.type === 'jsx') {

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -107,6 +107,18 @@ it('Should render blockquote correctly', async () => {
   parse(result)
 })
 
+it('Should properly expose comments', async () => {
+  const result = await mdx('<!--foo-->', {
+    hastPlugins: [
+      () => tree => {
+        tree.children[0].value = 'bar'
+      }
+    ]
+  })
+
+  expect(result).toContain('{/*bar*/}')
+})
+
 it('Should render HTML inside inlineCode correctly', async () => {
   const result = await mdx('`<div>`')
 


### PR DESCRIPTION
Previously, `<!--` and `-->` were part of comments nodes.
this deferred from the HAST specification.

This PR removed the prefix when comments are found in markdown, and
thus doesn’t need to replace them when rendering to JSX, but rather
prefixes and suffixes them.

Closes GH-312.
