### PR TITLE
Fix custom loader example

### DIFF
--- a/docs/advanced/custom-loader.md
+++ b/docs/advanced/custom-loader.md
@@ -13,11 +13,10 @@ module.exports = async function (src) {
   const callback = this.async()
   const { content, data } = matter(src)
 
-  const code = `
-    export const frontMatter = ${stringifyObject(data)}
+  const code = `export const frontMatter = ${stringifyObject(data)}
 
-    ${content}
-  `
+${content}`
+  
   return callback(null, code)
 }
 ```


### PR DESCRIPTION
This makes the code uglier, unfortunately, but the example provided here in the docs is incorrect (I found this out the hard way).

Since all the code here is indented by 4 spaces, it is treated by the markdown parser as a code block, and you end up seeing the exports in the file inside of a formatted code block. Eliminating the extra indentation fixes this.