### PR TITLE
Exclude export const/let/var/function from default check

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -50,7 +50,8 @@ function toJSX(node, parentNode = {}, options = {}) {
 
         if (
           /\bdefault\b/.test(childNode.value) &&
-          !/default\s+as/.test(childNode.value)
+          !/default\s+as/.test(childNode.value) &&
+          !/^export (const|let|var|function)/.test(childNode.value)
         ) {
           let example
 

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -250,6 +250,12 @@ it('Should support semicolons in default export statement', async () => {
 it('Should throw when exporting default via named export', async () => {
   await expect(mdx(`export { default } from './Layout'`)).rejects.toThrow()
   await expect(mdx(`export { Layout as default }`)).rejects.toThrow()
+
+  // Edge case where user has the text "default" as part of the export node
+  await mdx(`export const meta = {
+    description: 'better default behavior.'
+  }`)
+  
   await expect(
     mdx(`export { default as MyComp } from './MyComp'`)
   ).resolves.toContain(`export { default as MyComp } from './MyComp'`)


### PR DESCRIPTION
We ran into this on a blogpost on zeit.co