### PR TITLE
Improve default export detection

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -49,7 +49,8 @@ function toJSX(node, parentNode = {}, options = {}) {
         }
 
         if (
-          /\bdefault\b/.test(childNode.value) &&
+          (/export\s{\s?default\s?}\sfrom/.test(childNode.value) ||
+            /export\s{.*?as\sdefault\s?}/.test(childNode.value)) &&
           !/default\s+as/.test(childNode.value) &&
           !/^export (const|let|var|function)/.test(childNode.value)
         ) {

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -49,10 +49,8 @@ function toJSX(node, parentNode = {}, options = {}) {
         }
 
         if (
-          (/export\s{\s?default\s?}\sfrom/.test(childNode.value) ||
-            /export\s{.*?as\sdefault\s?}/.test(childNode.value)) &&
-          !/default\s+as/.test(childNode.value) &&
-          !/^export (const|let|var|function)/.test(childNode.value)
+          /^export\s{\s?default\s?}\sfrom/.test(childNode.value) ||
+          /^export\s{.*?as\sdefault\s?}/.test(childNode.value)
         ) {
           let example
 

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -250,12 +250,27 @@ it('Should support semicolons in default export statement', async () => {
 it('Should throw when exporting default via named export', async () => {
   await expect(mdx(`export { default } from './Layout'`)).rejects.toThrow()
   await expect(mdx(`export { Layout as default }`)).rejects.toThrow()
+  await expect(
+    mdx(`export { foo as bar, Layout as default }`)
+  ).rejects.toThrow()
 
-  // Edge case where user has the text "default" as part of the export node
-  await mdx(`export const meta = {
-    description: 'better default behavior.'
-  }`)
+  // Ensure that word "default" appearing in export node does not throw
+  const fixture1 = `export const meta = {
+  description: 'better default as behavior.'
+}`
+  await expect(mdx(fixture1)).resolves.toContain(fixture1)
 
+  // Ensure that a full export pattern within metadata does not throw
+  const fixture2 = `export const meta = {
+decription: 'How to use es6 exports',
+examples: [
+  'export { default } from "./example"',
+  'export { foo as default }'
+]
+}`
+  await expect(mdx(fixture2)).resolves.toContain(fixture2)
+
+  // Ensure that `export { default as x }` pattern does not throw
   await expect(
     mdx(`export { default as MyComp } from './MyComp'`)
   ).resolves.toContain(`export { default as MyComp } from './MyComp'`)


### PR DESCRIPTION
Closes https://github.com/mdx-js/mdx/issues/341

Definitely preferable to get a true parser in here as is being discussed, but this at least resolves the major bug of disallowing the word "default" anywhere within front matter in the meantime! 😁 