### PR TITLE
Improve inline parsing of JSX

### DIFF
--- a/packages/remark-mdx/index.js
+++ b/packages/remark-mdx/index.js
@@ -1,5 +1,5 @@
 const isAlphabetical = require('is-alphabetical')
-const {tag} = require('remark-parse/lib/util/html')
+const {tag} = require('./tag')
 
 const IMPORT_REGEX = /^import/
 const EXPORT_REGEX = /^export/
@@ -7,6 +7,7 @@ const EXPORT_DEFAULT_REGEX = /^export default/
 const EMPTY_NEWLINE = '\n\n'
 const LESS_THAN = '<'
 const GREATER_THAN = '>'
+const SLASH = '/'
 
 const isImport = text => IMPORT_REGEX.test(text)
 const isExport = text => EXPORT_REGEX.test(text)
@@ -65,7 +66,11 @@ function attachParser(parser) {
     }
 
     const nextChar = value.charAt(1)
-    if (nextChar !== GREATER_THAN && !isAlphabetical(nextChar)) {
+    if (
+      nextChar !== GREATER_THAN &&
+      nextChar !== SLASH &&
+      !isAlphabetical(nextChar)
+    ) {
       return
     }
 

--- a/packages/remark-mdx/index.js
+++ b/packages/remark-mdx/index.js
@@ -1,7 +1,12 @@
+const isAlphabetical = require('is-alphabetical')
+const {tag} = require('remark-parse/lib/util/html')
+
 const IMPORT_REGEX = /^import/
 const EXPORT_REGEX = /^export/
 const EXPORT_DEFAULT_REGEX = /^export default/
 const EMPTY_NEWLINE = '\n\n'
+const LESS_THAN = '<'
+const GREATER_THAN = '>'
 
 const isImport = text => IMPORT_REGEX.test(text)
 const isExport = text => EXPORT_REGEX.test(text)
@@ -33,14 +38,15 @@ function attachParser(parser) {
 
   blocks.esSyntax = tokenizeEsSyntax
   blocks.html = wrap(blocks.html)
-  inlines.html = wrap(inlines.html)
+  inlines.html = wrap(inlines.html, inlineJsx)
 
   methods.splice(methods.indexOf('paragraph'), 0, 'esSyntax')
 
-  function wrap(original) {
-    tokenizeJsx.locator = original.locator
+  function wrap(original, customTokenizer) {
+    const tokenizer = customTokenizer || tokenizeJsx
+    tokenizer.locator = original.locator
 
-    return tokenizeJsx
+    return tokenizer
 
     function tokenizeJsx() {
       const node = original.apply(this, arguments)
@@ -51,6 +57,25 @@ function attachParser(parser) {
 
       return node
     }
+  }
+
+  function inlineJsx(eat, value) {
+    if (value.charAt(0) !== LESS_THAN) {
+      return
+    }
+
+    const nextChar = value.charAt(1)
+    if (nextChar !== GREATER_THAN && !isAlphabetical(nextChar)) {
+      return
+    }
+
+    const subvalueMatches = value.match(tag)
+    if (!subvalueMatches) {
+      return
+    }
+
+    const subvalue = subvalueMatches[0]
+    return eat(subvalue)({type: 'jsx', value: subvalue})
   }
 }
 

--- a/packages/remark-mdx/license
+++ b/packages/remark-mdx/license
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Titus Wormer.
+Copyright (c) 2018 Titus Wormer and John Otander.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/remark-mdx/package.json
+++ b/packages/remark-mdx/package.json
@@ -29,8 +29,14 @@
     "remark-parse": "^6.0.0",
     "unified": "^7.0.0"
   },
-  "scripts": {},
+  "scripts": {
+    "test": "jest"
+  },
   "jest": {
     "testEnvironment": "node"
+  },
+  "devDependencies": {
+    "jest": "^23.6.0",
+    "remark-stringify": "^6.0.4"
   }
 }

--- a/packages/remark-mdx/package.json
+++ b/packages/remark-mdx/package.json
@@ -26,6 +26,7 @@
     "index.js"
   ],
   "dependencies": {
+    "is-alphabetical": "^1.0.2",
     "remark-parse": "^6.0.0",
     "unified": "^7.0.0"
   },

--- a/packages/remark-mdx/readme.md
+++ b/packages/remark-mdx/readme.md
@@ -24,7 +24,7 @@ abide by its terms.
 
 ## License
 
-[MIT][] © [Titus Wormer][author]
+[MIT][] © [Titus Wormer][author] and [John Otander][author2]
 
 <!-- Definitions -->
 
@@ -51,3 +51,5 @@ abide by its terms.
 [mdx]: https://github.com/mdx-js/mdx
 
 [author]: https://wooorm.com
+
+[author2]: https://johno.com

--- a/packages/remark-mdx/tag.js
+++ b/packages/remark-mdx/tag.js
@@ -1,12 +1,23 @@
-// Source copied from https://github.com/remarkjs/remark/blob/master/packages/remark-parse/lib/util/html.js
+// Source copied and then modified from
+// https://github.com/remarkjs/remark/blob/master/packages/remark-parse/lib/util/html.js
+//
 // MIT License https://github.com/remarkjs/remark/blob/master/license
 
 const attributeName = '[a-zA-Z_:][a-zA-Z0-9:._-]*'
 const unquoted = '[^"\'=<>`\\u0000-\\u0020]+'
 const singleQuoted = "'[^']*'"
 const doubleQuoted = '"[^"]*"'
+const objectProps = '{{[*]}}'
 const attributeValue =
-  '(?:' + unquoted + '|' + singleQuoted + '|' + doubleQuoted + ')'
+  '(?:' +
+  unquoted +
+  '|' +
+  singleQuoted +
+  '|' +
+  doubleQuoted +
+  '|' +
+  objectProps +
+  ')'
 const attribute =
   '(?:\\s+' + attributeName + '(?:\\s*=\\s*' + attributeValue + ')?)'
 const openTag = '<[A-Za-z]*[A-Za-z0-9\\-]*' + attribute + '*\\s*\\/?>'

--- a/packages/remark-mdx/tag.js
+++ b/packages/remark-mdx/tag.js
@@ -7,7 +7,7 @@ const attributeName = '[a-zA-Z_:][a-zA-Z0-9:._-]*'
 const unquoted = '[^"\'=<>`\\u0000-\\u0020]+'
 const singleQuoted = "'[^']*'"
 const doubleQuoted = '"[^"]*"'
-const objectProps = '{{[*]}}'
+const objectProps = '{{[^}]*}}'
 const attributeValue =
   '(?:' +
   unquoted +

--- a/packages/remark-mdx/tag.js
+++ b/packages/remark-mdx/tag.js
@@ -9,7 +9,7 @@ const attributeValue =
   '(?:' + unquoted + '|' + singleQuoted + '|' + doubleQuoted + ')'
 const attribute =
   '(?:\\s+' + attributeName + '(?:\\s*=\\s*' + attributeValue + ')?)'
-const openTag = '<[A-Za-z][A-Za-z0-9\\-]*' + attribute + '*\\s*\\/?>'
+const openTag = '<[A-Za-z]*[A-Za-z0-9\\-]*' + attribute + '*\\s*\\/?>'
 const closeTag = '<\\/[A-Za-z][A-Za-z0-9\\-]*\\s*>'
 const comment = '<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->'
 const processing = '<[?].*?[?]>'

--- a/packages/remark-mdx/tag.js
+++ b/packages/remark-mdx/tag.js
@@ -1,0 +1,35 @@
+// Source copied from https://github.com/remarkjs/remark/blob/master/packages/remark-parse/lib/util/html.js
+// MIT License https://github.com/remarkjs/remark/blob/master/license
+
+const attributeName = '[a-zA-Z_:][a-zA-Z0-9:._-]*'
+const unquoted = '[^"\'=<>`\\u0000-\\u0020]+'
+const singleQuoted = "'[^']*'"
+const doubleQuoted = '"[^"]*"'
+const attributeValue =
+  '(?:' + unquoted + '|' + singleQuoted + '|' + doubleQuoted + ')'
+const attribute =
+  '(?:\\s+' + attributeName + '(?:\\s*=\\s*' + attributeValue + ')?)'
+const openTag = '<[A-Za-z][A-Za-z0-9\\-]*' + attribute + '*\\s*\\/?>'
+const closeTag = '<\\/[A-Za-z][A-Za-z0-9\\-]*\\s*>'
+const comment = '<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->'
+const processing = '<[?].*?[?]>'
+const declaration = '<![A-Za-z]+\\s+[^>]*>'
+const cdata = '<!\\[CDATA\\[[\\s\\S]*?\\]\\]>'
+
+exports.openCloseTag = new RegExp('^(?:' + openTag + '|' + closeTag + ')')
+
+exports.tag = new RegExp(
+  '^(?:' +
+    openTag +
+    '|' +
+    closeTag +
+    '|' +
+    comment +
+    '|' +
+    processing +
+    '|' +
+    declaration +
+    '|' +
+    cdata +
+    ')'
+)

--- a/packages/remark-mdx/test/fixtures.js
+++ b/packages/remark-mdx/test/fixtures.js
@@ -17,6 +17,10 @@ module.exports = [
   },
   {
     description: 'Handles self closing JSX tags',
+    mdx: 'Hello, <span children="world" />'
+  },
+  {
+    description: 'Handles self closing JSX tags with object props',
     mdx: 'Hello <span style={{ color: "tomato" }} />'
   },
   {

--- a/packages/remark-mdx/test/fixtures.js
+++ b/packages/remark-mdx/test/fixtures.js
@@ -16,6 +16,10 @@ module.exports = [
     mdx: 'Hello, <>{props.world}</>'
   },
   {
+    description: 'Handles declarations as props',
+    mdx: 'Hello, <span children={props.world} />'
+  },
+  {
     description: 'Handles self closing JSX tags',
     mdx: 'Hello, <span children="world" />'
   },

--- a/packages/remark-mdx/test/fixtures.js
+++ b/packages/remark-mdx/test/fixtures.js
@@ -1,0 +1,26 @@
+module.exports = [
+  {
+    description: 'Handles object props',
+    mdx: 'Hello <span style={{ color: "tomato" }}>world!</span>!'
+  },
+  {
+    description: 'Handles fragments',
+    mdx: 'Hello, from <Fragment>{props.from}</Fragment>'
+  },
+  {
+    description: 'Ignores escaped JSX',
+    mdx: 'This is <span>escaped</span> JSX'
+  },
+  {
+    description: 'Handles fragment shortcut',
+    mdx: 'Hello, <>{props.world}</>'
+  },
+  {
+    description: 'Handles self closing JSX tags',
+    mdx: 'Hello <span style={{ color: "tomato" }} />'
+  },
+  {
+    description: 'Handles nested tags',
+    mdx: 'Hello, <Blue><Code>world <Emoji name="world" /></Code></Blue>'
+  }
+]

--- a/packages/remark-mdx/test/inline-parsing.test.js
+++ b/packages/remark-mdx/test/inline-parsing.test.js
@@ -20,11 +20,10 @@ const parse = mdx => {
   return result.contents
 }
 
-describe('inline JSX parsing', () => {
-  fixtures.forEach(fixture => {
-    it(fixture.description, () => {
-      const result = parse(fixture.mdx)
-      expect(result.trim()).toEqual(fixture.mdx)
-    })
+fixtures.forEach(fixture => {
+  it(fixture.description, () => {
+    const result = parse(fixture.mdx)
+
+    expect(result.trim()).toEqual(fixture.mdx)
   })
 })

--- a/packages/remark-mdx/test/inline-parsing.test.js
+++ b/packages/remark-mdx/test/inline-parsing.test.js
@@ -1,0 +1,30 @@
+const unified = require('unified')
+const remarkParse = require('remark-parse')
+const remarkStringify = require('remark-stringify')
+const remarkMDX = require('..')
+
+const fixtures = require('./fixtures')
+
+function jsxCompiler() {
+  this.Compiler.prototype.visitors.jsx = node => node.value
+}
+
+const parse = mdx => {
+  const result = unified()
+    .use(remarkParse)
+    .use(remarkMDX)
+    .use(remarkStringify)
+    .use(jsxCompiler)
+    .processSync(mdx)
+
+  return result.contents
+}
+
+describe('inline JSX parsing', () => {
+  fixtures.forEach(fixture => {
+    it(fixture.description, () => {
+      const result = parse(fixture.mdx)
+      expect(result.trim()).toEqual(fixture.mdx)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,7 +1707,6 @@ array-ify@^1.0.0:
 array-includes@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
-  integrity sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
@@ -4590,7 +4589,6 @@ eslint-plugin-prettier@^3.0.0:
 eslint-plugin-react@^7.11.1:
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"
-  integrity sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"
@@ -7046,7 +7044,6 @@ jsprim@^1.2.2:
 jsx-ast-utils@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
-  integrity sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=
   dependencies:
     array-includes "^3.0.3"
 
@@ -10833,7 +10830,7 @@ remark-squeeze-paragraphs@^3.0.1:
   dependencies:
     mdast-squeeze-paragraphs "^3.0.0"
 
-remark-stringify@^6.0.0:
+remark-stringify@^6.0.0, remark-stringify@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-6.0.4.tgz#16ac229d4d1593249018663c7bddf28aafc4e088"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6112,7 +6112,7 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
-is-alphabetical@^1.0.0:
+is-alphabetical@^1.0.0, is-alphabetical@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
 


### PR DESCRIPTION
This pulls in the remark inline HTML parser so that we can customize it to
meet JSX-specific syntax needs.

Adds support for:
- `<>{props.foo}</>`
- `<span style={{ color: 'tomato' }} />`
