### PR TITLE
Add `isMDXComponent` static class prop to generated classes

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -118,8 +118,7 @@ function toJSX(node, parentNode = {}, options = {}) {
                .join('')}
            </MDXTag>
   }
-}
-MDXContent.isMDXComponent = () => true`
+}MDXContent.isMDXComponent = () => true`
     )
   }
   // Recursively walk through children

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -118,7 +118,8 @@ function toJSX(node, parentNode = {}, options = {}) {
                .join('')}
            </MDXTag>
   }
-}MDXContent.isMDXComponent = () => true`
+}
+MDXContent.isMDXComponent = () => true`
     )
   }
   // Recursively walk through children

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -103,7 +103,6 @@ function toJSX(node, parentNode = {}, options = {}) {
       `${
         skipExport ? '' : 'export default'
       } class MDXContent extends React.Component {
-  static isMDXComponent = () => true
   constructor(props) {
     super(props)
     this.layout = ${layout || 'null'}
@@ -119,7 +118,8 @@ function toJSX(node, parentNode = {}, options = {}) {
                .join('')}
            </MDXTag>
   }
-}`
+}
+MDXContent.isMDXComponent = () => true`
     )
   }
   // Recursively walk through children

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -103,6 +103,7 @@ function toJSX(node, parentNode = {}, options = {}) {
       `${
         skipExport ? '' : 'export default'
       } class MDXContent extends React.Component {
+  static isMDXElement = () => true
   constructor(props) {
     super(props)
     this.layout = ${layout || 'null'}

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -119,7 +119,7 @@ function toJSX(node, parentNode = {}, options = {}) {
            </MDXTag>
   }
 }
-MDXContent.isMDXComponent = () => true`
+MDXContent.isMDXComponent = true`
     )
   }
   // Recursively walk through children

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -103,7 +103,7 @@ function toJSX(node, parentNode = {}, options = {}) {
       `${
         skipExport ? '' : 'export default'
       } class MDXContent extends React.Component {
-  static isMDXElement = () => true
+  static isMDXComponent = () => true
   constructor(props) {
     super(props)
     this.layout = ${layout || 'null'}

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -106,6 +106,7 @@ it('Should match sample blog post snapshot', async () => {
     );
   }
 }
+MDXContent.isMDXComponent = () => true
 "
 `)
 })

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -106,7 +106,7 @@ it('Should match sample blog post snapshot', async () => {
     );
   }
 }
-MDXContent.isMDXComponent = () => true;
+MDXContent.isMDXComponent = true;
 "
 `)
 })

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -291,9 +291,7 @@ it('Should recognize components as properties', async () => {
 
 it('Should contain static isMDXComponent() function', async () => {
   const result = await mdx('# Hello World')
-  expect(result).toContain(
-    'MDXContent.isMDXComponent = () => true'
-  )
+  expect(result).toContain('MDXContent.isMDXComponent = () => true')
 })
 
 it('Should render elements without wrapping blank new lines', async () => {

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -289,6 +289,13 @@ it('Should recognize components as properties', async () => {
   )
 })
 
+it('Should contain static isMDXComponent() function', async () => {
+  const result = await mdx('# Hello World')
+  expect(result).toContain(
+    'MDXContent.isMDXComponent = () => true'
+  )
+})
+
 it('Should render elements without wrapping blank new lines', async () => {
   const result = await mdx(`
   | Test | Table |

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -106,7 +106,7 @@ it('Should match sample blog post snapshot', async () => {
     );
   }
 }
-MDXContent.isMDXComponent = () => true
+MDXContent.isMDXComponent = () => true;
 "
 `)
 })

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -292,7 +292,7 @@ it('Should recognize components as properties', async () => {
 
 it('Should contain static isMDXComponent() function', async () => {
   const result = await mdx('# Hello World')
-  expect(result).toContain('MDXContent.isMDXComponent = () => true')
+  expect(result).toContain('MDXContent.isMDXComponent = true')
 })
 
 it('Should render elements without wrapping blank new lines', async () => {


### PR DESCRIPTION
There's currently no way to detect whether a class was generated by `@mdx-js/mdx`, and this PR adds a `isMDXComponent()` static class property to check whether the exported component was generated by mdx.

Closes #368