### PR TITLE
Add publish script and configuration for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,8 @@ cache:
   yarn: true
   directories:
     - node_modules
+deploy:
+  provider: script
+  script: yarn publish-ci
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "docs:deploy": "npm run docs:build && now dist --public && now alias",
     "test": "remark . -qf && eslint . && lerna run test",
     "format": "remark . -qfo && eslint . --fix",
-    "publish": "lerna publish"
+    "publish": "lerna publish",
+    "publish-ci": "lerna publish -y --canary --preid ci --npm-tag=ci"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
As discussed in https://github.com/mdx-js/mdx/issues/344 this PR addresses:
- [x] adding the script for publishing through ci
- [x] adding configuration for running above script on successful build only for `master` branch

