### PR TITLE
Fix runtime build script

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -23,6 +23,9 @@
   ],
   "main": "dist",
   "scripts": {
+    "build": "babel src -d dist",
+    "clean": "rimraf dist",
+    "prepublish": "yarn clean && yarn build",
     "test": "jest"
   },
   "files": [
@@ -44,7 +47,8 @@
     "react-dom": "^16.6.3",
     "rehype-add-classes": "^1.0.0",
     "remark-autolink-headings": "^5.0.0",
-    "remark-slug": "^5.1.0"
+    "remark-slug": "^5.1.0",
+    "rimraf": "^2.6.3"
   },
   "jest": {
     "testEnvironment": "node"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11124,6 +11124,13 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.
   dependencies:
     glob "^7.0.5"
 
+rimraf@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
Looks like in 0.16.1 the prepare script was dropped,
most likely inadvertently. This adds it back (as a
more proper prepublish script as well).

Related #386