### PR TITLE
Improve parsing for JSX blocks (including inline)

### DIFF
--- a/packages/remark-mdx/index.js
+++ b/packages/remark-mdx/index.js
@@ -3,7 +3,7 @@ const {tag} = require('./tag')
 
 const IMPORT_REGEX = /^import/
 const EXPORT_REGEX = /^export/
-const EXPORT_DEFAULT_REGEX = /^export default/
+const EXPORT_DEFAULT_REGEX = /^export\s+default\s+/
 const EMPTY_NEWLINE = '\n\n'
 const LESS_THAN = '<'
 const GREATER_THAN = '>'

--- a/packages/remark-mdx/license
+++ b/packages/remark-mdx/license
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Titus Wormer and John Otander.
+Copyright (c) 2018-2019 Titus Wormer and John Otander
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/remark-mdx/tag.js
+++ b/packages/remark-mdx/tag.js
@@ -7,7 +7,8 @@ const attributeName = '[a-zA-Z_:][a-zA-Z0-9:._-]*'
 const unquoted = '[^"\'=<>`\\u0000-\\u0020]+'
 const singleQuoted = "'[^']*'"
 const doubleQuoted = '"[^"]*"'
-const objectProps = '{{[^}]*}}'
+const objectProps = '{{[^\n]*}}'
+const jsProps = '{[^\n]*}'
 const attributeValue =
   '(?:' +
   unquoted +
@@ -17,6 +18,8 @@ const attributeValue =
   doubleQuoted +
   '|' +
   objectProps +
+  '|' +
+  jsProps +
   ')'
 const attribute =
   '(?:\\s+' + attributeName + '(?:\\s*=\\s*' + attributeValue + ')?)'

--- a/packages/remark-mdx/tag.js
+++ b/packages/remark-mdx/tag.js
@@ -7,7 +7,6 @@ const attributeName = '[a-zA-Z_:][a-zA-Z0-9:._-]*'
 const unquoted = '[^"\'=<>`\\u0000-\\u0020]+'
 const singleQuoted = "'[^']*'"
 const doubleQuoted = '"[^"]*"'
-const objectProps = '{{[^\n]*}}'
 const jsProps = '{[^\n]*}'
 const attributeValue =
   '(?:' +
@@ -16,8 +15,6 @@ const attributeValue =
   singleQuoted +
   '|' +
   doubleQuoted +
-  '|' +
-  objectProps +
   '|' +
   jsProps +
   ')'

--- a/packages/remark-mdx/tag.js
+++ b/packages/remark-mdx/tag.js
@@ -20,8 +20,8 @@ const attributeValue =
   ')'
 const attribute =
   '(?:\\s+' + attributeName + '(?:\\s*=\\s*' + attributeValue + ')?)'
-const openTag = '<[A-Za-z]*[A-Za-z0-9\\-]*' + attribute + '*\\s*\\/?>'
-const closeTag = '<\\/[A-Za-z][A-Za-z0-9\\-]*\\s*>'
+const openTag = '<[A-Za-z]*[A-Za-z0-9\\.\\-]*' + attribute + '*\\s*\\/?>'
+const closeTag = '<\\/[A-Za-z][A-Za-z0-9\\.\\-]*\\s*>'
 const comment = '<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->'
 const processing = '<[?].*?[?]>'
 const declaration = '<![A-Za-z]+\\s+[^>]*>'

--- a/packages/remark-mdx/test/fixtures/inline-parsing.js
+++ b/packages/remark-mdx/test/fixtures/inline-parsing.js
@@ -8,6 +8,10 @@ module.exports = [
     mdx: 'Hello, from <Fragment>{props.from}</Fragment>'
   },
   {
+    description: 'Handles components as properties',
+    mdx: 'Hello, from <Some.Component>{props.world}</Some.Component>'
+  },
+  {
     description: 'Ignores escaped JSX',
     mdx: 'This is <span>escaped</span> JSX'
   },

--- a/packages/remark-mdx/test/fixtures/inline-parsing.js
+++ b/packages/remark-mdx/test/fixtures/inline-parsing.js
@@ -34,5 +34,9 @@ module.exports = [
   {
     description: 'Handles nested tags',
     mdx: 'Hello, <Blue><Code>world <Emoji name="world" /></Code></Blue>'
+  },
+  {
+    description: 'Handles string interpolation',
+    mdx: 'Hello, from <span children={`${props.foo}!!!!`} />'
   }
 ]

--- a/packages/remark-mdx/test/fixtures/inline-parsing.js
+++ b/packages/remark-mdx/test/fixtures/inline-parsing.js
@@ -48,5 +48,13 @@ module.exports = [
     description: 'Handles functions with returns as props',
     mdx:
       'Hello, from <Span children={(some, stuff) => { return some / stuff }} />'
+  },
+  {
+    description: 'Handles nested object props',
+    mdx: 'Hello, from <span some={{ nested: { object: "props" } }} />'
+  },
+  {
+    description: 'Handles multiple inline components with complex JSX',
+    mdx: 'Hello, from <Span children={(some, stuff) => { return some / stuff }} /> <span children={`${props.foo}!!!!`} /> <>{props.world}</>'
   }
 ]

--- a/packages/remark-mdx/test/fixtures/inline-parsing.js
+++ b/packages/remark-mdx/test/fixtures/inline-parsing.js
@@ -38,5 +38,9 @@ module.exports = [
   {
     description: 'Handles string interpolation',
     mdx: 'Hello, from <span children={`${props.foo}!!!!`} />'
+  },
+  {
+    description: 'Handles JS in props',
+    mdx: 'Hello, from <Span children={(some, stuff) => some / stuff} />'
   }
 ]

--- a/packages/remark-mdx/test/fixtures/inline-parsing.js
+++ b/packages/remark-mdx/test/fixtures/inline-parsing.js
@@ -60,5 +60,9 @@ module.exports = [
   {
     description: 'Does not break } outside of JSX',
     mdx: 'Hello, <Component>{props.world}</Component> and a moustache! }:'
+  },
+  {
+    description: 'Handles mailto links',
+    mdx: 'Hello, <Component>{props.world}</Component> and a moustache! }: <https://johno.com>'
   }
 ]

--- a/packages/remark-mdx/test/fixtures/inline-parsing.js
+++ b/packages/remark-mdx/test/fixtures/inline-parsing.js
@@ -62,7 +62,7 @@ module.exports = [
     mdx: 'Hello, <Component>{props.world}</Component> and a moustache! }:'
   },
   {
-    description: 'Handles mailto links',
+    description: 'Handles links',
     mdx: 'Hello, <Component>{props.world}</Component> and a moustache! }: <https://johno.com>'
   }
 ]

--- a/packages/remark-mdx/test/fixtures/inline-parsing.js
+++ b/packages/remark-mdx/test/fixtures/inline-parsing.js
@@ -40,7 +40,11 @@ module.exports = [
     mdx: 'Hello, from <span children={`${props.foo}!!!!`} />'
   },
   {
-    description: 'Handles JS in props',
+    description: 'Handles functions as props',
     mdx: 'Hello, from <Span children={(some, stuff) => some / stuff} />'
+  },
+  {
+    description: 'Handles functions with returns as props',
+    mdx: 'Hello, from <Span children={(some, stuff) => { return some / stuff }} />'
   }
 ]

--- a/packages/remark-mdx/test/fixtures/inline-parsing.js
+++ b/packages/remark-mdx/test/fixtures/inline-parsing.js
@@ -56,5 +56,9 @@ module.exports = [
   {
     description: 'Handles multiple inline components with complex JSX',
     mdx: 'Hello, from <Span children={(some, stuff) => { return some / stuff }} /> <span children={`${props.foo}!!!!`} /> <>{props.world}</>'
+  },
+  {
+    description: 'Does not break } outside of JSX',
+    mdx: 'Hello, <Component>{props.world}</Component> and a moustache! }:'
   }
 ]

--- a/packages/remark-mdx/test/fixtures/inline-parsing.js
+++ b/packages/remark-mdx/test/fixtures/inline-parsing.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 module.exports = [
   {
     description: 'Handles object props',
@@ -45,6 +46,7 @@ module.exports = [
   },
   {
     description: 'Handles functions with returns as props',
-    mdx: 'Hello, from <Span children={(some, stuff) => { return some / stuff }} />'
+    mdx:
+      'Hello, from <Span children={(some, stuff) => { return some / stuff }} />'
   }
 ]

--- a/packages/remark-mdx/test/inline-parsing.test.js
+++ b/packages/remark-mdx/test/inline-parsing.test.js
@@ -3,7 +3,7 @@ const remarkParse = require('remark-parse')
 const remarkStringify = require('remark-stringify')
 const remarkMDX = require('..')
 
-const fixtures = require('./fixtures')
+const fixtures = require('./fixtures/inline-parsing')
 
 function jsxCompiler() {
   this.Compiler.prototype.visitors.jsx = node => node.value


### PR DESCRIPTION
JSX tag parsing was too strict for props, so it caused multiple types of JSX blocks to be missed and then escapes. Ultimately, essentially any syntax and characters can existing in a JSX prop so we just keep waiting for the matching closing curly brace.

This also adds many more complex usages of inline JSX fixtures that are being tested against.