### PR TITLE
Adds `tag.js` to published files for `remark-mdx`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bundle.js
 *-error.log
 *-debug.log
 .vscode
+.DS_Store

--- a/packages/remark-mdx/package.json
+++ b/packages/remark-mdx/package.json
@@ -22,7 +22,8 @@
     "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)"
   ],
   "files": [
-    "index.js"
+    "index.js",
+    "tag.js"
   ],
   "dependencies": {
     "is-alphabetical": "^1.0.2",


### PR DESCRIPTION
The `tag.js` file is missing when you try to use the published package. 😢

```
Error: Cannot find module './tag'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/Users/manovotny/Developer/remark-mdx-metadata/node_modules/remark-mdx/index.js:2:15)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
error Command failed with exit code 1.
```

This PR fixes that.

Tested by running `yarn pack` in the `/packages/remark-mdx` folder.