### PR TITLE
Grouped imports shouldn't have empty newline separation

### DIFF
--- a/packages/remark-mdx/index.js
+++ b/packages/remark-mdx/index.js
@@ -95,7 +95,7 @@ function attachCompiler(compiler) {
 }
 
 function stringifyEsSyntax(node) {
-  return node.value
+  return node.value.trim()
 }
 
 function tokenizeEsSyntax(eat, value) {

--- a/packages/remark-mdx/test/__snapshots__/test.js.snap
+++ b/packages/remark-mdx/test/__snapshots__/test.js.snap
@@ -189,5 +189,11 @@ exports[`removes newlines between imports and exports 1`] = `
 "import Foo1 from \\"./foo\\"
 import Foo2 from \\"./foo\\"
 import Foo3 from \\"./foo\\"
+
+export const foo = \\"bar\\"
+
+export default props => <article {...props} />
+
+import Foo4 from \\"./foo\\"
 "
 `;

--- a/packages/remark-mdx/test/__snapshots__/test.js.snap
+++ b/packages/remark-mdx/test/__snapshots__/test.js.snap
@@ -184,3 +184,10 @@ Object {
   "type": "root",
 }
 `;
+
+exports[`removes newlines between imports and exports 1`] = `
+"import Foo1 from \\"./foo\\"
+import Foo2 from \\"./foo\\"
+import Foo3 from \\"./foo\\"
+"
+`;

--- a/packages/remark-mdx/test/__snapshots__/test.js.snap
+++ b/packages/remark-mdx/test/__snapshots__/test.js.snap
@@ -194,6 +194,6 @@ export const foo = \\"bar\\"
 
 export default props => <article {...props} />
 
-import Foo4 from \\"./foo\\"
+export const fred = \\"flintstone\\"
 "
 `;

--- a/packages/remark-mdx/test/test.js
+++ b/packages/remark-mdx/test/test.js
@@ -66,8 +66,14 @@ it('maintains the proper positional info', () => {
 })
 
 it('removes newlines between imports and exports', () => {
-  const fixture =
-    'import Foo1 from "./foo"\nimport Foo2 from "./foo"\nimport Foo3 from "./foo"'
+  const fixture = [
+    'import Foo1 from "./foo"',
+    'import Foo2 from "./foo"',
+    'import Foo3 from "./foo"',
+    'export const foo = "bar"',
+    'export default props => <article {...props} />',
+    'import Foo4 from "./foo"'
+  ].join('\n')
 
   const result = stringify(fixture)
 

--- a/packages/remark-mdx/test/test.js
+++ b/packages/remark-mdx/test/test.js
@@ -1,5 +1,7 @@
 const unified = require('unified')
 const remarkParse = require('remark-parse')
+const remarkStringify = require('remark-stringify')
+
 const remarkMdx = require('..')
 const mdxAstToMdxHast = require('../../mdx/mdx-ast-to-mdx-hast')
 const mdxHastToJsx = require('../../mdx/mdx-hast-to-jsx')
@@ -41,6 +43,16 @@ const parse = mdx => {
   return result
 }
 
+const stringify = mdx => {
+  const result = unified()
+    .use(remarkParse)
+    .use(remarkStringify)
+    .use(remarkMdx)
+    .processSync(mdx)
+
+  return result.contents
+}
+
 it('correctly transpiles', () => {
   const result = transpile(FIXTURE)
 
@@ -49,6 +61,15 @@ it('correctly transpiles', () => {
 
 it('maintains the proper positional info', () => {
   const result = parse(FIXTURE)
+
+  expect(result).toMatchSnapshot()
+})
+
+it('removes newlines between imports and exports', () => {
+  const fixture =
+    'import Foo1 from "./foo"\nimport Foo2 from "./foo"\nimport Foo3 from "./foo"'
+
+  const result = stringify(fixture)
 
   expect(result).toMatchSnapshot()
 })

--- a/packages/remark-mdx/test/test.js
+++ b/packages/remark-mdx/test/test.js
@@ -72,7 +72,7 @@ it('removes newlines between imports and exports', () => {
     'import Foo3 from "./foo"',
     'export const foo = "bar"',
     'export default props => <article {...props} />',
-    'import Foo4 from "./foo"'
+    'export const fred = "flintstone"'
   ].join('\n')
 
   const result = stringify(fixture)


### PR DESCRIPTION
Before, each import is turned into its own node, even when grouped like so:

```js
import Foo1 from "./foo"
import Foo2 from "./foo"
import Foo3 from "./foo"
```

So, when combining back to a string we ended up with:

```js
import Foo1 from "./foo"

import Foo2 from "./foo"

import Foo3 from "./foo"
```

We now combine adjacent nodes of the same type. Though, if the node is a default export it is treated specially.