### PR TITLE
Remove destructuring props to prevent shadowing 'components' variable

### DIFF
--- a/packages/tag/src/mdx-provider.js
+++ b/packages/tag/src/mdx-provider.js
@@ -2,16 +2,16 @@ import React from 'react'
 
 const {Provider, Consumer} = React.createContext({})
 
-export const withMDXComponents = Component => ({components, ...props}) => (
+export const withMDXComponents = Component => (props) => (
   <Consumer>
     {contextComponents => (
-      <Component components={components || contextComponents} {...props} />
+      <Component {...props} components={props.components || contextComponents} />
     )}
   </Consumer>
 )
 
-const MDXProvider = ({components, children}) => (
-  <Provider value={components}>{children}</Provider>
+const MDXProvider = (props) => (
+  <Provider value={props.components}>{props.children}</Provider>
 )
 
 export default MDXProvider

--- a/packages/tag/src/mdx-provider.js
+++ b/packages/tag/src/mdx-provider.js
@@ -2,15 +2,18 @@ import React from 'react'
 
 const {Provider, Consumer} = React.createContext({})
 
-export const withMDXComponents = Component => (props) => (
+export const withMDXComponents = Component => props => (
   <Consumer>
     {contextComponents => (
-      <Component {...props} components={props.components || contextComponents} />
+      <Component
+        {...props}
+        components={props.components || contextComponents}
+      />
     )}
   </Consumer>
 )
 
-const MDXProvider = (props) => (
+const MDXProvider = props => (
   <Provider value={props.components}>{props.children}</Provider>
 )
 


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/mdx-js/mdx/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->

Closes #206 

Removes destructuring of `components` from props which was being shadowed after transpiling. 