### PR TITLE
Allow for merging of components passed to context with a function

### DIFF
--- a/packages/tag/src/mdx-provider.js
+++ b/packages/tag/src/mdx-provider.js
@@ -1,20 +1,31 @@
 import React from 'react'
 
-const {Provider, Consumer} = React.createContext({})
+const isFunction = obj => typeof obj === 'function'
+
+export const MDXContext = React.createContext({})
 
 export const withMDXComponents = Component => props => (
-  <Consumer>
-    {contextComponents => (
-      <Component
-        {...props}
-        components={props.components || contextComponents}
-      />
-    )}
-  </Consumer>
+  <MDXContext.Consumer>
+    {contextComponents => {
+      const allComponents = props.components || contextComponents
+
+      return <Component {...props} components={allComponents} />
+    }}
+  </MDXContext.Consumer>
 )
 
 const MDXProvider = props => (
-  <Provider value={props.components}>{props.children}</Provider>
+  <MDXContext.Consumer>
+    {outerContextComponents => {
+      const allComponents = isFunction(props.components)
+        ? props.components(outerContextComponents)
+        : props.components
+
+      return (
+        <MDXContext.Provider value={allComponents} children={props.children} />
+      )
+    }}
+  </MDXContext.Consumer>
 )
 
 export default MDXProvider

--- a/packages/tag/test/mdx-provider.test.js
+++ b/packages/tag/test/mdx-provider.test.js
@@ -4,6 +4,8 @@ import {renderToString} from 'react-dom/server'
 import {MDXTag, MDXProvider} from '../src'
 
 const H1 = props => <h1 style={{color: 'tomato'}} {...props} />
+const H2 = props => <h2 style={{color: 'rebeccapurple'}} {...props} />
+const CustomH2 = props => <h2 style={{color: 'papayawhip'}} {...props} />
 
 it('Should allow components to be passed via context', () => {
   const Layout = ({children}) => <div id="layout">{children}</div>
@@ -33,4 +35,23 @@ it('Should allow context components to be overridden', () => {
 
   // MDXTag is passed overriding components
   expect(result).toMatch(/style="color:tomato"/)
+})
+
+it('Should merge components when there is nested context', () => {
+  const components = {h1: H1, h2: H2}
+
+  const result = renderToString(
+    <MDXProvider components={components}>
+      <MDXProvider components={components => ({...components, h2: CustomH2})}>
+        <MDXTag name="h1" />
+        <MDXTag name="h2" />
+      </MDXProvider>
+    </MDXProvider>
+  )
+
+  // MDXTag picks up original component context
+  expect(result).toMatch(/style="color:tomato"/)
+
+  // MDXTag picks up overridden component context
+  expect(result).toMatch(/style="color:papayawhip"/)
 })


### PR DESCRIPTION
If a function is passed to the theme provider it is invoked
with the out context's components. This allows users to opt
in to merging those components.

Related #410