### PR TITLE
Fix newline issue in paragraphs

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -168,9 +168,13 @@ MDXContent.isMDXComponent = true`
   if (node.type === 'text') {
     // Don't wrap newlines unless specifically instructed to by the flag,
     // to avoid issues like React warnings caused by text nodes in tables.
-    if (node.value === '\n' && !preserveNewlines) {
+    const shouldPreserveNewlines =
+      preserveNewlines || parentNode.tagName === 'p'
+
+    if (node.value === '\n' && !shouldPreserveNewlines) {
       return node.value
     }
+
     return '{`' + node.value.replace(/`/g, '\\`').replace(/\$/g, '\\$') + '`}'
   }
 

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -204,6 +204,24 @@ Some text <!-- an inline comment -->
   expect(result).toContain('<!-- a template literal -->')
 })
 
+it('Should turn a newline into a space with adjacent anchors', async () => {
+  const result = await renderWithReact(`
+  [foo](/foo)
+  [bar](/bar)
+  `)
+
+  expect(result).toContain('<a href="/foo">foo</a>\n<a href="/bar">bar</a>')
+})
+
+it('Should turn a newline into a space with other adjacent phrasing content', async () => {
+  const result = await renderWithReact(`
+  *foo*
+  \`bar\`
+  `)
+
+  expect(result).toContain('<em>foo</em>\n<code>bar</code>')
+})
+
 it('Should convert style strings to camelized objects', async () => {
   const result = await mdx(
     `


### PR DESCRIPTION
In paragraph nodes newlines were being removed which causes
issues when there are two subsequent nodes like links, spans,
emphasis, bold, etc.

Now, if the parent node is a paragraph tag, we preserve the
newline since it's significant and results in a space that
separates two inline nodes on render.

---

Closes #412