### PR TITLE
Fix template string escaping

### DIFF
--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -70,7 +70,10 @@ it('Should output parseable JSX', async () => {
 })
 
 it('Should be able to render JSX with React', async () => {
-  const result = await renderWithReact('# Hello, world!')
+  const result = await renderWithReact(`# Hello, world!
+  
+    const code = () => \`template string\`
+  `)
 
   expect(result).toContain('<h1 style="color:tomato">Hello, world!</h1>')
 })

--- a/packages/mdx/util.js
+++ b/packages/mdx/util.js
@@ -6,8 +6,8 @@ const EMPTY_NEWLINE = '\n\n'
 
 const toTemplateLiteral = text => {
   const escaped = text
-    .replace(/`/g, '\\`') // Escape "`"" since
     .replace(/\\/g, '\\\\') // Escape all "\" to avoid unwanted escaping in text nodes
+    .replace(/`/g, '\\`') // Escape "`"" since
 
   return '{`' + escaped + '`}'
 }


### PR DESCRIPTION
We need to escape template strings after back slash
escaping so that unescaping template strings doesn't
happen by accident.

---

Fixes #430