### PR TITLE
Make contributing guide top level, add redirect

### DIFF
--- a/docs/_app.js
+++ b/docs/_app.js
@@ -44,6 +44,8 @@ const navOrder = [
 ]
 /* eslint-enable prettier/prettier */
 
+const ignoredPaths = ['/advanced/contributing']
+
 const pageNames = {
   index: 'Introduction',
   next: 'Next.js',
@@ -73,7 +75,9 @@ const sortRoutes = routes =>
 export default class App extends React.Component {
   render() {
     const {routes} = this.props
-    const nav = sortRoutes(routes)
+    const nav = sortRoutes(routes).filter(
+      route => !ignoredPaths.includes(route.path)
+    )
 
     return (
       <RebassMDX>

--- a/docs/_ui.js
+++ b/docs/_ui.js
@@ -1,6 +1,18 @@
-import React from 'react'
+/* global window */
+import React, {Component} from 'react'
 import {Pre} from 'rebass'
 import {LiveEditor as Editor, LivePreview} from '@compositor/x0/components'
+
+export class Redirect extends Component {
+  componentDidMount() {
+    const {to} = this.props
+    window.location = to
+  }
+
+  render() {
+    return <h1>Redirecting...</h1>
+  }
+}
 
 export const Logo = () => (
   <div>

--- a/docs/advanced/contributing.md
+++ b/docs/advanced/contributing.md
@@ -1,3 +1,3 @@
-import Contributing from '../../contributing.md'
+import { Redirect } from '../_ui'
 
-<Contributing />
+<Redirect to='/contributing' />

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,3 @@
+import Contributing from '../contributing.md'
+
+<Contributing />


### PR DESCRIPTION
It was pointed out to me that it's silly for the contributing page to live in the advanced section. This removes it and adds a temporary redirect for the old url (in a hacky way) to serve as a bandaid until we begin implementing the new docs site.