### PR TITLE
Use mdxType as prop name

### DIFF
--- a/packages/mdx/create-element.js
+++ b/packages/mdx/create-element.js
@@ -1,7 +1,7 @@
 const React = require('react')
 const {useMDXComponents} = require('@mdx-js/tag')
 
-const TYPE_PROP_NAME = '__MDX_TYPE_PLEASE_DO_NOT_USE__'
+const TYPE_PROP_NAME = 'mdxType'
 
 const DEFAULTS = {
   inlineCode: 'code',
@@ -10,12 +10,12 @@ const DEFAULTS = {
 
 const MDXCreateElement = ({
   components: propComponents,
-  __MDX_TYPE_PLEASE_DO_NOT_USE__,
+  mdxType,
   parentName,
   ...etc
 }) => {
   const components = useMDXComponents(propComponents)
-  const type = __MDX_TYPE_PLEASE_DO_NOT_USE__
+  const type = mdxType
   const Component =
     components[`${parentName}.${type}`] ||
     components[type] ||


### PR DESCRIPTION
In some cases it might be desired to access
the type prop. This namespaces it with mdx
to become mdxType. This shouldn't clash with
most components (if at all) and allows the wrapper
to more easily inspect its children types like you
would with most React elements.
