### PR TITLE
 Add wrapExport option for wrapping exported function

### DIFF
--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -296,6 +296,14 @@ it('Should render elements without wrapping blank new lines', async () => {
   expect(result).not.toContain('{`\n`}')
 })
 
+it('Should wrap export function when wrapExport is provided', async () => {
+  const result = await mdx(`# Test`, {
+    wrapExport: 'React.memo'
+  })
+
+  expect(result).toContain(`export default React.memo(MDXContent)`)
+})
+
 test('Should await and render async plugins', async () => {
   const result = await mdx(fixtureBlogPost, {
     rehypePlugins: [
@@ -379,7 +387,7 @@ export default function MDXContent({ components, ...props }) {
       {...layoutProps}
       {...props}
       components={components}>
-      
+
 
 <h1>{\`Hello, world!\`}</h1>
 <p>{\`I'm an awesome paragraph.\`}</p>
@@ -427,7 +435,7 @@ export default function MDXContent({ components, ...props }) {
 \\\\\`
 \`}</code></pre>
     </MDXLayout>
-    )
+  )
 }
 MDXContent.isMDXComponent = true"
 `)

--- a/packages/remark-mdx/test/__snapshots__/test.js.snap
+++ b/packages/remark-mdx/test/__snapshots__/test.js.snap
@@ -15,7 +15,7 @@ export default function MDXContent({ components, ...props }) {
       {...layoutProps}
       {...props}
       components={components}>
-      
+
 
 
 <h1>{\`Hello, world! \`}<Foo bar={{ baz: 'qux' }} /></h1>
@@ -23,7 +23,7 @@ export default function MDXContent({ components, ...props }) {
   Hi!
 </Baz>
     </MDXLayout>
-    )
+  )
 }
 MDXContent.isMDXComponent = true"
 `;


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/mdx-js/mdx/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
Add a `memo` compiler option to wrap the generated component in a `React.memo` call. This could help prevent unnecessary renders if any of the components define objects/arrays/functions inline.

```js
mdx(content, {
  memo: true
})
```

```jsx
function MDXContent({ components, ...props }) {
  // ...
}
export default React.memo(MDXContent);
```

I had to re-organize that code strings a little bit in order to do this. Hopefully that is okay because doing it with template expressions was a bit messy.