### PR TITLE
Fix remark-mdx readme title

### DIFF
--- a/packages/remark-mdx/readme.md
+++ b/packages/remark-mdx/readme.md
@@ -1,4 +1,4 @@
-# `@mdx-js/remark-mdx`
+# [remark][]-[mdx][]
 
 [![Build Status][build-badge]][build]
 [![lerna][lerna-badge]][lerna]


### PR DESCRIPTION
**regarding `remark-mdx/readme.md`:**

The title currently reads `@mdx-js/remark-mdx`, but that's not the package name.
It was confusing for me, this fixes that.