### PR TITLE
Pass filename to babel transform if present

### DIFF
--- a/packages/remark-mdx/extract-imports-and-exports.js
+++ b/packages/remark-mdx/extract-imports-and-exports.js
@@ -42,7 +42,7 @@ const partitionString = (str, indices) =>
     return str.slice(val, indices[i + 1])
   })
 
-module.exports = value => {
+module.exports = (value, vfile) => {
   const instance = new BabelPluginExtractImportsAndExports()
 
   transformSync(value, {
@@ -50,7 +50,8 @@ module.exports = value => {
       '@babel/plugin-syntax-jsx',
       '@babel/plugin-proposal-object-rest-spread',
       instance.plugin
-    ]
+    ],
+    filename: vfile.path
   })
 
   const sortedNodes = instance.state.nodes.sort((a, b) => a.start - b.start)

--- a/packages/remark-mdx/index.js
+++ b/packages/remark-mdx/index.js
@@ -105,7 +105,7 @@ function tokenizeEsSyntax(eat, value) {
   const subvalue = index !== -1 ? value.slice(0, index) : value
 
   if (isExport(subvalue) || isImport(subvalue)) {
-    const nodes = extractImportsAndExports(subvalue)
+    const nodes = extractImportsAndExports(subvalue, this.file)
     nodes.map(node => eat(node.value)(node))
   }
 }

--- a/packages/remark-mdx/test/import-export.test.js
+++ b/packages/remark-mdx/test/import-export.test.js
@@ -1,9 +1,10 @@
 const extract = require('../extract-imports-and-exports')
 const fixtures = require('./fixtures/import-export')
+const vfile = require('vfile')
 
 fixtures.forEach(fixture => {
   it(fixture.description, () => {
-    const result = extract(fixture.mdx)
+    const result = extract(fixture.mdx, vfile({ path: '/test', content: 'testing' }))
 
     expect(result).toMatchSnapshot(fixture.result)
   })


### PR DESCRIPTION
I have been occasionally getting errors from babel about how it won't transform without a filename. This PR makes it such that if there is a filename present, it is passed to babel. In practice this has resolved my errors. I added some modifications to the tests to account for this change, but there is not a full integration test in place to replicate the scenario. I started down the road of adding one but it ended up being quite involved so I figured I'd start here.