### PR TITLE
Move sponsorship section location in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,13 +88,6 @@ A nice example of this is [mdx-deck][], a great way to create slides with MDX.
 *   [Next.js plugin](https://mdxjs.com/getting-started/next)
 *   [Gatsby plugin](https://mdxjs.com/getting-started/gatsby)
 
-## Authors
-
-*   [John Otander][john] ([@4lpine][4lpine]) – [Compositor][] + [Clearbit][]
-*   [Tim Neutkens][tim] ([@timneutkens][timneutkens]) – [ZEIT][]
-*   [Guillermo Rauch][guillermo] ([@rauchg][rauchg]) – [ZEIT][]
-*   [Brent Jackson][brent] ([@jxnblk][jxnblk]) – [Compositor][]
-
 ## Sponsors
 
 <!--lint ignore no-html maximum-line-length-->
@@ -128,6 +121,13 @@ A nice example of this is [mdx-deck][], a great way to create slides with MDX.
 </table>
 
 **[Read more about the unified collective on Medium »][announcement]**
+
+## Authors
+
+*   [John Otander][john] ([@4lpine][4lpine]) – [Compositor][] + [Clearbit][]
+*   [Tim Neutkens][tim] ([@timneutkens][timneutkens]) – [ZEIT][]
+*   [Guillermo Rauch][guillermo] ([@rauchg][rauchg]) – [ZEIT][]
+*   [Brent Jackson][brent] ([@jxnblk][jxnblk]) – [Compositor][]
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -11,43 +11,6 @@ You can import components, like interactive charts or notifications, and export
 metadata.
 This makes writing long-form content with components a blast.  🚀
 
-* * *
-
-**Announcing the unified collective!  🎉
-[Read more about it on Medium »][announcement]**
-
-## Sponsors
-
-<!--lint ignore no-html maximum-line-length-->
-
-<table>
-  <tr valign="top">
-    <td width="20%" align="center">
-      <a href="https://zeit.co"><img src="https://avatars1.githubusercontent.com/u/14985020?s=400&v=4"></a>
-      <br><br>🥇
-      <a href="https://zeit.co">ZEIT</a>
-    </td>
-    <td width="20%" align="center">
-      <a href="https://www.gatsbyjs.org"><img src="https://avatars1.githubusercontent.com/u/12551863?s=400&v=4"></a>
-      <br><br>🥇
-      <a href="https://www.gatsbyjs.org">Gatsby</a></td>
-    <td width="20%" align="center">
-      <a href="https://compositor.io"><img src="https://avatars1.githubusercontent.com/u/19245838?s=400&v=4"></a>
-      <br><br>🥉
-      <a href="https://compositor.io">Compositor</a>
-    </td>
-    <td width="20%" align="center">
-      <a href="https://www.holloway.com"><img src="https://avatars1.githubusercontent.com/u/35904294?s=400&v=4"></a>
-      <br><br>
-      <a href="https://www.holloway.com">Holloway</a>
-    </td>
-    <td width="20%" align="center">
-      <br><br><br><br>
-      <a href="https://opencollective.com/unified"><strong>You?</strong>
-    </td>
-  </tr>
-</table>
-
 ## Example
 
 See MDX in action:
@@ -125,16 +88,50 @@ A nice example of this is [mdx-deck][], a great way to create slides with MDX.
 *   [Next.js plugin](https://mdxjs.com/getting-started/next)
 *   [Gatsby plugin](https://mdxjs.com/getting-started/gatsby)
 
-## Related
-
-See related projects in the [MDX specification][spec].
-
 ## Authors
 
 *   [John Otander][john] ([@4lpine][4lpine]) – [Compositor][] + [Clearbit][]
 *   [Tim Neutkens][tim] ([@timneutkens][timneutkens]) – [ZEIT][]
 *   [Guillermo Rauch][guillermo] ([@rauchg][rauchg]) – [ZEIT][]
 *   [Brent Jackson][brent] ([@jxnblk][jxnblk]) – [Compositor][]
+
+## Sponsors
+
+<!--lint ignore no-html maximum-line-length-->
+
+<table>
+  <tr valign="top">
+    <td width="20%" align="center">
+      <a href="https://zeit.co"><img src="https://avatars1.githubusercontent.com/u/14985020?s=400&v=4"></a>
+      <br><br>🥇
+      <a href="https://zeit.co">ZEIT</a>
+    </td>
+    <td width="20%" align="center">
+      <a href="https://www.gatsbyjs.org"><img src="https://avatars1.githubusercontent.com/u/12551863?s=400&v=4"></a>
+      <br><br>🥇
+      <a href="https://www.gatsbyjs.org">Gatsby</a></td>
+    <td width="20%" align="center">
+      <a href="https://compositor.io"><img src="https://avatars1.githubusercontent.com/u/19245838?s=400&v=4"></a>
+      <br><br>🥉
+      <a href="https://compositor.io">Compositor</a>
+    </td>
+    <td width="20%" align="center">
+      <a href="https://www.holloway.com"><img src="https://avatars1.githubusercontent.com/u/35904294?s=400&v=4"></a>
+      <br><br>
+      <a href="https://www.holloway.com">Holloway</a>
+    </td>
+    <td width="20%" align="center">
+      <br><br><br><br>
+      <a href="https://opencollective.com/unified"><strong>You?</strong>
+    </td>
+  </tr>
+</table>
+
+**[Read more about the unified collective on Medium »][announcement]**
+
+## Related
+
+See related projects in the [MDX specification][spec].
 
 ## Contribute
 


### PR DESCRIPTION
We should finish introducing what MDX is before showing the sponsors section.