### PR TITLE
fix code in guide syntax highlighting guide

### DIFF
--- a/docs/guides/syntax-highlighting.md
+++ b/docs/guides/syntax-highlighting.md
@@ -27,7 +27,7 @@ import {MDXProvider} from '@mdx-js/tag'
 
 const components = {
   pre: props => <div {...props} />,
-  code: props => <pre style={{ color: 'tomato' }} />
+  code: props => <pre style={{ color: 'tomato' }} {...props} />
 }
 
 export default props => (


### PR DESCRIPTION
Without `{...props}` all the tags are invisible, because they have no content

