### PR TITLE
Implement Shortcodes

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -5,7 +5,7 @@ const toStyleObject = require('to-style').object
 const {paramCase} = require('change-case')
 const {toTemplateLiteral} = require('./util')
 
-const startsWithCapitalLetter = /^[A-Z]/
+const STARTS_WITH_CAPITAL_LETTER = /^[A-Z]/
 
 class BabelPluginExtractJsxNames {
   constructor() {
@@ -20,7 +20,7 @@ class BabelPluginExtractJsxNames {
           JSXOpeningElement(path) {
             const jsxName = path.node.name.name
             names.push(jsxName)
-            if (startsWithCapitalLetter.test(jsxName)) {
+            if (STARTS_WITH_CAPITAL_LETTER.test(jsxName)) {
               path.node.attributes.push(
                 t.jSXAttribute(
                   t.jSXIdentifier(`mdxType`),
@@ -165,11 +165,8 @@ MDXContent.isMDXComponent = true`
       ]
     }).code
     const jsxNames = babelPluginExtractJsxNamesInstance.state.names
-      .filter(name => startsWithCapitalLetter.test(name))
-      .filter(name => name != 'MDXLayout')
-    // It doesn't look like exportNames includes the following named export
-    //       export { Baz } from './foo'
-    // should it?
+      .filter(name => STARTS_WITH_CAPITAL_LETTER.test(name))
+      .filter(name => name !== 'MDXLayout')
     const importExportNames = importNames.concat(exportNames)
     const fakedModulesForGlobalScope =
       `const makeShortcode = name => function MDXDefaultShortcode(props) {

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/plugin-syntax-jsx": "^7.2.0",
+    "@babel/helper-plugin-utils": "^7.0.0",
     "change-case": "^3.0.2",
     "detab": "^2.0.0",
     "hast-util-raw": "^5.0.0",

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -97,20 +97,20 @@ it('Should match sample blog post snapshot', async () => {
   const result = await mdx(`# Hello World`)
 
   expect(prettier.format(result, {parser: 'babel'})).toMatchInlineSnapshot(`
-"/* @jsx mdx */
-
-const layoutProps = {};
-const MDXLayout = \\"wrapper\\";
-export default function MDXContent({ components, ...props }) {
-  return (
-    <MDXLayout {...layoutProps} {...props} components={components}>
-      <h1>{\`Hello World\`}</h1>
-    </MDXLayout>
-  );
-}
-MDXContent.isMDXComponent = true;
-"
-`)
+            "/* @jsx mdx */
+            
+            const layoutProps = {};
+            const MDXLayout = \\"wrapper\\";
+            export default function MDXContent({ components, ...props }) {
+              return (
+                <MDXLayout {...layoutProps} {...props} components={components}>
+                  <h1>{\`Hello World\`}</h1>
+                </MDXLayout>
+              );
+            }
+            MDXContent.isMDXComponent = true;
+            "
+      `)
 })
 
 it('Should render blockquote correctly', async () => {
@@ -366,78 +366,84 @@ test('Should handle layout props', () => {
   const result = mdx.sync(fixtureBlogPost)
 
   expect(result).toMatchInlineSnapshot(`
-"/* @jsx mdx */
-import { Baz } from './Fixture'
-import { Buz } from './Fixture'
-export const foo = {
-  hi: \`Fudge \${Baz.displayName || 'Baz'}\`,
-  authors: [
-    'fred',
-    'sally'
-  ]
-}
-const layoutProps = {
-  foo
-};
-const MDXLayout = ({children}) => <div>{children}</div>
-export default function MDXContent({ components, ...props }) {
-  return (
-    <MDXLayout
-      {...layoutProps}
-      {...props}
-      components={components}>
-
-
-<h1>{\`Hello, world!\`}</h1>
-<p>{\`I'm an awesome paragraph.\`}</p>
-{/* I'm a comment */}
-<Foo bg='red'>
-  <Bar>hi</Bar>
-    {hello}
-    {/* another commment */}
-</Foo>
-<pre><code parentName=\\"pre\\" {...{}}>{\`test codeblock
-\`}</code></pre>
-<pre><code parentName=\\"pre\\" {...{\\"className\\":\\"language-js\\"}}>{\`module.exports = 'test'
-\`}</code></pre>
-<pre><code parentName=\\"pre\\" {...{\\"className\\":\\"language-sh\\"}}>{\`npm i -g foo
-\`}</code></pre>
-<table>
-<thead parentName=\\"table\\">
-<tr parentName=\\"thead\\">
-<th parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Test\`}</th>
-<th parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Table\`}</th>
-</tr>
-</thead>
-<tbody parentName=\\"table\\">
-<tr parentName=\\"tbody\\">
-<td parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Col1\`}</td>
-<td parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Col2\`}</td>
-</tr>
-</tbody>
-</table>
-
-<pre><code parentName=\\"pre\\" {...{\\"className\\":\\"language-js\\"}}>{\`export const Button = styled.button\\\\\`
-  font-size: 1rem;
-  border-radius: 5px;
-  padding: 0.25rem 1rem;
-  margin: 0 1rem;
-  background: transparent;
-  color: \\\\\${props => props.theme.primary};
-  border: 2px solid \\\\\${props => props.theme.primary};
-  \\\\\${props =>
-    props.primary &&
-    css\\\\\`
-      background: \\\\\${props => props.theme.primary};
-      color: white;
-    \\\\\`};
-\\\\\`
-\`}</code></pre>
-    </MDXLayout>
-  )
-}
-MDXContent.isMDXComponent = true"
-`)
+    "/* @jsx mdx */
+    import { Baz } from './Fixture'
+    import { Buz } from './Fixture'
+    export const foo = {
+      hi: \`Fudge \${Baz.displayName || 'Baz'}\`,
+      authors: [
+        'fred',
+        'sally'
+      ]
+    }
+    const Foo = props => {
+    console.warn(\\"Component \`Foo\` was not imported, exported, or provided by MDXProvider as global scope\\")
+    }
+    const Bar = props => {
+    console.warn(\\"Component \`Bar\` was not imported, exported, or provided by MDXProvider as global scope\\")
+    }
+    const layoutProps = {
+      foo
+    };
+    const MDXLayout = ({children}) => <div>{children}</div>
+    export default function MDXContent({ components, ...props }) {
+      return (
+        <MDXLayout
+          {...layoutProps}
+          {...props}
+          components={components}>
+    
+    
+    <h1>{\`Hello, world!\`}</h1>
+    <p>{\`I'm an awesome paragraph.\`}</p>
+    {/* I'm a comment */}
+    <Foo bg='red'>
+      <Bar>hi</Bar>
+        {hello}
+        {/* another commment */}
+    </Foo>
+    <pre><code parentName=\\"pre\\" {...{}}>{\`test codeblock
+    \`}</code></pre>
+    <pre><code parentName=\\"pre\\" {...{\\"className\\":\\"language-js\\"}}>{\`module.exports = 'test'
+    \`}</code></pre>
+    <pre><code parentName=\\"pre\\" {...{\\"className\\":\\"language-sh\\"}}>{\`npm i -g foo
+    \`}</code></pre>
+    <table>
+    <thead parentName=\\"table\\">
+    <tr parentName=\\"thead\\">
+    <th parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Test\`}</th>
+    <th parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Table\`}</th>
+    </tr>
+    </thead>
+    <tbody parentName=\\"table\\">
+    <tr parentName=\\"tbody\\">
+    <td parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Col1\`}</td>
+    <td parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Col2\`}</td>
+    </tr>
+    </tbody>
+    </table>
+    
+    <pre><code parentName=\\"pre\\" {...{\\"className\\":\\"language-js\\"}}>{\`export const Button = styled.button\\\\\`
+      font-size: 1rem;
+      border-radius: 5px;
+      padding: 0.25rem 1rem;
+      margin: 0 1rem;
+      background: transparent;
+      color: \\\\\${props => props.theme.primary};
+      border: 2px solid \\\\\${props => props.theme.primary};
+      \\\\\${props =>
+        props.primary &&
+        css\\\\\`
+          background: \\\\\${props => props.theme.primary};
+          color: white;
+        \\\\\`};
+    \\\\\`
+    \`}</code></pre>
+        </MDXLayout>
+      )
+    }
+    MDXContent.isMDXComponent = true"
+  `)
 })
 
 it('Should use fragment as Wrapper', async () => {

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -12,6 +12,9 @@ const {renderToStaticMarkup} = require('react-dom/server')
 
 const mdx = require('../')
 
+const dropWhitespace = str =>
+  str.replace(/\r?\n|\r/g, ' ').replace(/ +(?= )/g, '')
+
 const fixtureBlogPost = fs.readFileSync(
   path.join(__dirname, './fixtures/blog-post.md')
 )
@@ -97,20 +100,68 @@ it('Should match sample blog post snapshot', async () => {
   const result = await mdx(`# Hello World`)
 
   expect(prettier.format(result, {parser: 'babel'})).toMatchInlineSnapshot(`
-            "/* @jsx mdx */
-            
-            const layoutProps = {};
-            const MDXLayout = \\"wrapper\\";
-            export default function MDXContent({ components, ...props }) {
-              return (
-                <MDXLayout {...layoutProps} {...props} components={components}>
-                  <h1>{\`Hello World\`}</h1>
-                </MDXLayout>
-              );
-            }
-            MDXContent.isMDXComponent = true;
-            "
-      `)
+    "/* @jsx mdx */
+    
+    const makeShortcode = name =>
+      function MDXDefaultShortcode(props) {
+        console.warn(
+          \\"Component \\" +
+            name +
+            \\" was not imported, exported, or provided by MDXProvider as global scope\\"
+        );
+        return <div {...props} />;
+      };
+    
+    const layoutProps = {};
+    const MDXLayout = \\"wrapper\\";
+    export default function _objectWithoutProperties(source, excluded) {
+      if (source == null) return {};
+      var target = _objectWithoutPropertiesLoose(source, excluded);
+      var key, i;
+      if (Object.getOwnPropertySymbols) {
+        var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
+        for (i = 0; i < sourceSymbolKeys.length; i++) {
+          key = sourceSymbolKeys[i];
+          if (excluded.indexOf(key) >= 0) continue;
+          if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
+          target[key] = source[key];
+        }
+      }
+      return target;
+    }
+    
+    function _objectWithoutPropertiesLoose(source, excluded) {
+      if (source == null) return {};
+      var target = {};
+      var sourceKeys = Object.keys(source);
+      var key, i;
+      for (i = 0; i < sourceKeys.length; i++) {
+        key = sourceKeys[i];
+        if (excluded.indexOf(key) >= 0) continue;
+        target[key] = source[key];
+      }
+      return target;
+    }
+    
+    function MDXContent(_ref) {
+      let { components } = _ref,
+        props = _objectWithoutProperties(_ref, [\\"components\\"]);
+    
+      return (
+        <MDXLayout
+          {...layoutProps}
+          {...props}
+          components={components}
+          mdxType=\\"MDXLayout\\"
+        >
+          <h1>{\`Hello World\`}</h1>
+        </MDXLayout>
+      );
+    }
+    
+    MDXContent.isMDXComponent = true;
+    "
+  `)
 })
 
 it('Should render blockquote correctly', async () => {
@@ -128,7 +179,7 @@ it('Should properly expose comments', async () => {
     ]
   })
 
-  expect(result).toContain('{/*bar*/}')
+  expect(prettier.format(result)).toContain(`{/*bar*/}`)
 })
 
 it('Should render HTML inside inlineCode correctly', async () => {
@@ -165,13 +216,13 @@ COPY start.sh /home/start.sh
   `
   )
 
-  expect(result).toContain(
-    `{...{"className":"language-dockerfile","metastring":"exec registry=something.com","exec":true,"registry":"something.com"}}`
+  expect(dropWhitespace(result)).toContain(
+    `{...{ "className": "language-dockerfile", "metastring": "exec registry=something.com", "exec": true, "registry": "something.com" }}`
   )
 })
 
 it('Should support comments', async () => {
-  const result = await mdx(`
+  const resultWithWhitespace = await mdx(`
 <!-- a Markdown comment -->
 A paragraph
 
@@ -183,7 +234,6 @@ Some text <!-- an inline comment -->
 
 <div>
   {/* a nested JSX comment */}
-  <!-- div content -->
 </div>
 
 <!-- a comment above -->
@@ -194,15 +244,16 @@ Some text <!-- an inline comment -->
 
 <MyComp content={\`
   <!-- a template literal -->
-\`}
+\`}/>
   `)
-  expect(result).toContain('{/* a Markdown comment */}')
-  expect(result).toContain('{/* an inline comment */}')
+
+  const result = dropWhitespace(resultWithWhitespace)
+  expect(result).toContain('{ /* a Markdown comment */ }')
+  expect(result).toContain('{ /* an inline comment */ }')
   expect(result).toContain('<!-- a code block string -->')
-  expect(result).toContain('{/* a nested JSX comment */}')
-  expect(result).toContain('<!-- div content -->')
-  expect(result).toContain('{/* a comment above */}')
-  expect(result).toContain('{/* a comment below */}')
+  expect(result).toContain('{ /* a nested JSX comment */ }')
+  expect(result).toContain('{ /* a comment above */ }')
+  expect(result).toContain('{ /* a comment below */ }')
   expect(result).toContain('--> should be as-is')
   expect(result).toContain('<!-- a template literal -->')
 })
@@ -238,7 +289,7 @@ $$
     }
   )
   expect(result).not.toContain('"style":"')
-  expect(result).toContain('"style":{')
+  expect(dropWhitespace(result)).toContain('"style": {')
 })
 
 it('Should convert data-* and aria-* properties to param-case', async () => {
@@ -253,7 +304,7 @@ $$
       rehypePlugins: [katex]
     }
   )
-  expect(result).toContain('"aria-hidden":"true"')
+  expect(dropWhitespace(result)).toContain('"aria-hidden": "true"')
 })
 
 it('Should support multiline default export statement', async () => {
@@ -278,7 +329,7 @@ it('Should not include export wrapper if skipExport is true', async () => {
 
 it('Should recognize components as properties', async () => {
   const result = await mdx('# Hello\n\n<MDX.Foo />')
-  expect(result).toContain('<h1>{`Hello`}</h1>\n<MDX.Foo />')
+  expect(dropWhitespace(result)).toContain('<h1>{`Hello`}</h1> <MDX.Foo />')
 })
 
 it('Should contain static isMDXComponent() function', async () => {
@@ -351,9 +402,13 @@ test('Should parse and render footnotes', async () => {
     'This is a paragraph with a [^footnote]\n\n[^footnote]: Here is the footnote'
   )
 
-  expect(result).toContain('<sup parentName="p" {...{"id":"fnref-footnote"}}>')
+  expect(dropWhitespace(result)).toContain(
+    '<sup parentName="p" {...{ "id": "fnref-footnote" }}>'
+  )
 
-  expect(result).toContain('<li parentName="ol" {...{"id":"fn-footnote"}}>')
+  expect(dropWhitespace(result)).toContain(
+    '<li parentName="ol" {...{ "id": "fn-footnote" }}>'
+  )
 }, 10000)
 
 test('Should expose a sync compiler', () => {
@@ -376,54 +431,77 @@ test('Should handle layout props', () => {
         'sally'
       ]
     }
-    const Foo = props => {
-    console.warn(\\"Component \`Foo\` was not imported, exported, or provided by MDXProvider as global scope\\")
-    }
-    const Bar = props => {
-    console.warn(\\"Component \`Bar\` was not imported, exported, or provided by MDXProvider as global scope\\")
-    }
+    const makeShortcode = name => function MDXDefaultShortcode(props) {
+      console.warn(\\"Component \\" + name + \\" was not imported, exported, or provided by MDXProvider as global scope\\")
+      return <div {...props}/>
+    };
+    const Foo = makeShortcode(\\"Foo\\");
+    const Bar = makeShortcode(\\"Bar\\");
     const layoutProps = {
       foo
     };
     const MDXLayout = ({children}) => <div>{children}</div>
-    export default function MDXContent({ components, ...props }) {
-      return (
-        <MDXLayout
-          {...layoutProps}
-          {...props}
-          components={components}>
+    export default function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
+    
+    function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+    
+    function MDXContent(_ref) {
+      let {
+        components
+      } = _ref,
+          props = _objectWithoutProperties(_ref, [\\"components\\"]);
+    
+      return <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
     
     
-    <h1>{\`Hello, world!\`}</h1>
-    <p>{\`I'm an awesome paragraph.\`}</p>
-    {/* I'm a comment */}
-    <Foo bg='red'>
-      <Bar>hi</Bar>
+        <h1>{\`Hello, world!\`}</h1>
+        <p>{\`I'm an awesome paragraph.\`}</p>
+        {
+          /* I'm a comment */
+        }
+        <Foo bg='red' mdxType=\\"Foo\\">
+      <Bar mdxType=\\"Bar\\">hi</Bar>
         {hello}
-        {/* another commment */}
-    </Foo>
-    <pre><code parentName=\\"pre\\" {...{}}>{\`test codeblock
+        {
+            /* another commment */
+          }
+        </Foo>
+        <pre><code parentName=\\"pre\\" {...{}}>{\`test codeblock
     \`}</code></pre>
-    <pre><code parentName=\\"pre\\" {...{\\"className\\":\\"language-js\\"}}>{\`module.exports = 'test'
+        <pre><code parentName=\\"pre\\" {...{
+            \\"className\\": \\"language-js\\"
+          }}>{\`module.exports = 'test'
     \`}</code></pre>
-    <pre><code parentName=\\"pre\\" {...{\\"className\\":\\"language-sh\\"}}>{\`npm i -g foo
+        <pre><code parentName=\\"pre\\" {...{
+            \\"className\\": \\"language-sh\\"
+          }}>{\`npm i -g foo
     \`}</code></pre>
-    <table>
-    <thead parentName=\\"table\\">
-    <tr parentName=\\"thead\\">
-    <th parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Test\`}</th>
-    <th parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Table\`}</th>
-    </tr>
-    </thead>
-    <tbody parentName=\\"table\\">
-    <tr parentName=\\"tbody\\">
-    <td parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Col1\`}</td>
-    <td parentName=\\"tr\\" {...{\\"align\\":\\"left\\"}}>{\`Col2\`}</td>
-    </tr>
-    </tbody>
-    </table>
+        <table>
+          <thead parentName=\\"table\\">
+            <tr parentName=\\"thead\\">
+              <th parentName=\\"tr\\" {...{
+                \\"align\\": \\"left\\"
+              }}>{\`Test\`}</th>
+              <th parentName=\\"tr\\" {...{
+                \\"align\\": \\"left\\"
+              }}>{\`Table\`}</th>
+            </tr>
+          </thead>
+          <tbody parentName=\\"table\\">
+            <tr parentName=\\"tbody\\">
+              <td parentName=\\"tr\\" {...{
+                \\"align\\": \\"left\\"
+              }}>{\`Col1\`}</td>
+              <td parentName=\\"tr\\" {...{
+                \\"align\\": \\"left\\"
+              }}>{\`Col2\`}</td>
+            </tr>
+          </tbody>
+        </table>
     
-    <pre><code parentName=\\"pre\\" {...{\\"className\\":\\"language-js\\"}}>{\`export const Button = styled.button\\\\\`
+        <pre><code parentName=\\"pre\\" {...{
+            \\"className\\": \\"language-js\\"
+          }}>{\`export const Button = styled.button\\\\\`
       font-size: 1rem;
       border-radius: 5px;
       padding: 0.25rem 1rem;
@@ -439,10 +517,10 @@ test('Should handle layout props', () => {
         \\\\\`};
     \\\\\`
     \`}</code></pre>
-        </MDXLayout>
-      )
+        </MDXLayout>;
     }
-    MDXContent.isMDXComponent = true"
+    
+    MDXContent.isMDXComponent = true;"
   `)
 })
 

--- a/packages/parcel-plugin-mdx/test/index.test.js
+++ b/packages/parcel-plugin-mdx/test/index.test.js
@@ -36,6 +36,8 @@ describe('MDXAsset', () => {
   })
 
   it('should render components with MDX.', () => {
-    expect(value).toContain('<Component>component</Component>')
+    expect(value).toContain(
+      '<Component mdxType="Component">component</Component>'
+    )
   })
 })

--- a/packages/react/src/create-element.js
+++ b/packages/react/src/create-element.js
@@ -12,6 +12,7 @@ const DEFAULTS = {
 const MDXCreateElement = ({
   components: propComponents,
   mdxType,
+  originalType,
   parentName,
   ...etc
 }) => {
@@ -21,7 +22,7 @@ const MDXCreateElement = ({
     components[`${parentName}.${type}`] ||
     components[type] ||
     DEFAULTS[type] ||
-    type
+    originalType
 
   return React.createElement(Component, etc)
 }
@@ -30,7 +31,7 @@ MDXCreateElement.displayName = 'MDXCreateElement'
 export default function(type, props) {
   const args = arguments
 
-  if (typeof type === 'string') {
+  if (typeof type === 'string' || props.mdxType) {
     const argsLength = args.length
 
     const createElementArgArray = new Array(argsLength)
@@ -42,8 +43,8 @@ export default function(type, props) {
         newProps[key] = props[key]
       }
     }
-
-    newProps[TYPE_PROP_NAME] = type
+    newProps.originalType = type
+    newProps[TYPE_PROP_NAME] = typeof type === 'string' ? type : props.mdxType
 
     createElementArgArray[1] = newProps
 

--- a/packages/remark-mdx/test/__snapshots__/test.js.snap
+++ b/packages/remark-mdx/test/__snapshots__/test.js.snap
@@ -5,6 +5,9 @@ exports[`correctly transpiles 1`] = `
 
 export { Baz } from './foo'
 
+const Baz = props => {
+console.warn(\\"Component \`Baz\` was not imported, exported, or provided by MDXProvider as global scope\\")
+}
 const layoutProps = {
   
 };

--- a/packages/remark-mdx/test/__snapshots__/test.js.snap
+++ b/packages/remark-mdx/test/__snapshots__/test.js.snap
@@ -5,30 +5,39 @@ exports[`correctly transpiles 1`] = `
 
 export { Baz } from './foo'
 
-const Baz = props => {
-console.warn(\\"Component \`Baz\` was not imported, exported, or provided by MDXProvider as global scope\\")
-}
+const makeShortcode = name => function MDXDefaultShortcode(props) {
+  console.warn(\\"Component \\" + name + \\" was not imported, exported, or provided by MDXProvider as global scope\\")
+  return <div {...props}/>
+};
+const Baz = makeShortcode(\\"Baz\\");
 const layoutProps = {
   
 };
 const MDXLayout = Foo
-export default function MDXContent({ components, ...props }) {
-  return (
-    <MDXLayout
-      {...layoutProps}
-      {...props}
-      components={components}>
+export default function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
+
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+
+function MDXContent(_ref) {
+  let {
+    components
+  } = _ref,
+      props = _objectWithoutProperties(_ref, [\\"components\\"]);
+
+  return <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
 
 
 
-<h1>{\`Hello, world! \`}<Foo bar={{ baz: 'qux' }} /></h1>
-<Baz>
+    <h1>{\`Hello, world! \`}<Foo bar={{
+        baz: 'qux'
+      }} mdxType=\\"Foo\\" /></h1>
+    <Baz mdxType=\\"Baz\\">
   Hi!
-</Baz>
-    </MDXLayout>
-  )
+    </Baz>
+    </MDXLayout>;
 }
-MDXContent.isMDXComponent = true"
+
+MDXContent.isMDXComponent = true;"
 `;
 
 exports[`maintains the proper positional info 1`] = `

--- a/packages/runtime/test/index.test.js
+++ b/packages/runtime/test/index.test.js
@@ -31,7 +31,7 @@ export default ({ children, id }) => <div id={id}>{children}</div>
 describe('renders MDX with the proper components', () => {
   it('default layout', () => {
     const result = render(
-      <MDX components={components} scope={scope} children={mdx} />
+      <MDX components={{...components, ...scope}} children={mdx} />
     )
 
     expect(result).toMatch(/style="color:tomato"/)
@@ -41,8 +41,7 @@ describe('renders MDX with the proper components', () => {
   it('custom layout', () => {
     const result = render(
       <MDX
-        components={components}
-        scope={scope}
+        components={{...components, ...scope}}
         children={mdxLayout}
         id="layout"
       />


### PR DESCRIPTION
Take the import and export names, compare them to the names declared in jsx. If there's a mismatch it means we can a custom component that isn't imported. In that case, we create a component for it that will warn if it doesn't get provider by MDXProvider (or some other hypothetical way if someone wants to get crazy and do webpack replacements or something else non-supported).


This is the processing side of shortcodes, the PR still needs the createElement replacement code written to do the replacements on the other side.