### PR TITLE
Fix typo within v1 migration docs

### DIFF
--- a/docs/src/pages/migrating/v1.md
+++ b/docs/src/pages/migrating/v1.md
@@ -19,7 +19,7 @@ as its markdown counterpart.
 It also allows MDXProvider to provide global component scope like a `Youtube` or `Twitter`
 component.
 
-The pragma implementation will also cause JSX HTML elements to be rendered with the componen
+The pragma implementation will also cause JSX HTML elements to be rendered with the component
 mapping passed to MDXProvider.
 So, the following will result in two identically rendered `h1`s:
 


### PR DESCRIPTION
This change fixes a minor typo in the v0 -> v1 migration docs

<!--

Read the [contributing guidelines](https://github.com/mdx-js/mdx/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
