### PR TITLE
Fix playground editor

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -3,6 +3,7 @@ const declare = require('@babel/helper-plugin-utils').declare
 const {types: t} = require('@babel/core')
 const toStyleObject = require('to-style').object
 const {paramCase} = require('change-case')
+const uniq = require('lodash.uniq')
 const {toTemplateLiteral} = require('./util')
 
 const STARTS_WITH_CAPITAL_LETTER = /^[A-Z]/
@@ -167,6 +168,7 @@ MDXContent.isMDXComponent = true`
     const jsxNames = babelPluginExtractJsxNamesInstance.state.names
       .filter(name => STARTS_WITH_CAPITAL_LETTER.test(name))
       .filter(name => name !== 'MDXLayout')
+
     const importExportNames = importNames.concat(exportNames)
     const fakedModulesForGlobalScope =
       `const makeShortcode = name => function MDXDefaultShortcode(props) {
@@ -174,7 +176,7 @@ MDXContent.isMDXComponent = true`
   return <div {...props}/>
 };
 ` +
-      [...new Set(jsxNames)]
+      uniq(jsxNames)
         .filter(name => !importExportNames.includes(name))
         .map(name => {
           return `const ${name} = makeShortcode("${name}");`

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -35,6 +35,7 @@
     "change-case": "^3.0.2",
     "detab": "^2.0.0",
     "hast-util-raw": "^5.0.0",
+    "lodash.uniq": "^4.5.0",
     "mdast-util-to-hast": "^4.0.0",
     "remark-mdx": "^1.0.2",
     "remark-parse": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,9 +2686,9 @@ acorn-dynamic-import@^4.0.0:
   integrity sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==
 
 acorn-globals@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.0.tgz#e3b6f8da3c1552a95ae627571f7dd6923bb54103"
-  integrity sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.1.tgz#deb149c59276657ebd40ba2ba849ddd529763ccf"
+  integrity sha512-gJSiKY8dBIjV/0jagZIFBdVMtfQyA5QHCvAT48H2q8REQoW8Fs5AOjqBql1LgSXgrMWdevcE+8cdZ33NtVbIBA==
   dependencies:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
@@ -7217,9 +7217,9 @@ gatsby-mdx@^0.5.6:
     unist-util-visit "^1.4.0"
 
 gatsby-mdx@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/gatsby-mdx/-/gatsby-mdx-0.6.1.tgz#1e2625d007b05e1210e37c1dcf09fdd9099bf718"
-  integrity sha512-7Q6bcKRA6rFJTsTyKpzzp5GjGns5k8oRl/4cOYhdQlA9OREQdRVR/PCiYdHanHJ7cVY8QqUbDxRBdOwxDBtzvQ==
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/gatsby-mdx/-/gatsby-mdx-0.6.2.tgz#1662408fc1730158ea8d77eedc9992f51f8b00e8"
+  integrity sha512-knTLJCONK4I4ItDfnCBuxEy6imXzyUJ9rbjzoqgy8Z8sDjmwlXcJ4j2RRJnjttZP8NxPt/YR/Dljj0HVotC+YA==
   dependencies:
     "@babel/core" "^7.4.3"
     "@babel/plugin-proposal-object-rest-spread" "^7.4.3"
@@ -16693,9 +16693,9 @@ table@^5.2.3:
     string-width "^3.0.0"
 
 tapable@^1.0.0, tapable@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.1.tgz#4d297923c5a72a42360de2ab52dadfaaec00018e"
-  integrity sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
+  integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
 tar-fs@^1.13.0:
   version "1.16.3"
@@ -17562,9 +17562,9 @@ url-parse-lax@^1.0.0:
     prepend-http "^1.0.1"
 
 url-parse@^1.1.8, url-parse@^1.4.3:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.5.tgz#04cbb6ba2be682a18e4417fa2245aa7e3dfdcc50"
-  integrity sha512-4XDvC5vZRjEpjP0L4znrWeoH8P8F0XGBlfLdABi/6oV4o8xUVbTpyrxWHxkK2bT0pSIpcjdIzSoWUhlUfawCAQ==
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.6.tgz#baf91d6e6783c8a795eb476892ffef2737fc0456"
+  integrity sha512-/B8AD9iQ01seoXmXf9z/MjLZQIdOoYl/+gvsQF6+mpnxaTfG9P7srYaiqaDMyKkR36XMXfhqSHss5MyFAO8lew==
   dependencies:
     querystringify "^2.0.0"
     requires-port "^1.0.0"


### PR DESCRIPTION
For a reason I haven't been able to figure out yet,
the new set syntax fails in buble (used by react-live).
So, for now we'll use lodash.uniq while I debug what's
going on.