### PR TITLE
Ignore external babel config when transforming MDX to JSX

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -149,6 +149,8 @@ MDXContent.isMDXComponent = true`
     // Check JSX nodes against imports
     const babelPluginExptractImportNamesInstance = new BabelPluginExtractImportNames()
     transformSync(importStatements, {
+      configFile: false,
+      babelrc: false,
       plugins: [
         require('@babel/plugin-syntax-jsx'),
         require('@babel/plugin-syntax-object-rest-spread'),
@@ -159,6 +161,8 @@ MDXContent.isMDXComponent = true`
 
     const babelPluginExtractJsxNamesInstance = new BabelPluginExtractJsxNames()
     const fnPostMdxTypeProp = transformSync(fn, {
+      configFile: false,
+      babelrc: false,
       plugins: [
         require('@babel/plugin-syntax-jsx'),
         require('@babel/plugin-syntax-object-rest-spread'),


### PR DESCRIPTION
> The word `Project` below refers to any project that uses this library.
> e.g. blog, webapp, news sites, etc

This library transforms raw MDX file to final Javscript codes in 2 passes.
1st Pass: MDX === via @mdx-js/mdx ===> ES6
2nd Pass: ES6 === via @mdj-js/loader or other tools ===> JS shipped to users

Any babel config in `project` should only affect the 2nd pass. In other words, the output of `@mdx-js/mdx` should not be affected by external babel config.

This PR prevents .babelrc or babel.config.js in `project` directory from affecting the output of this library.

### Before this change:
The babel config of projects that use this library screws up the output of this library. For example, instead of
```js
const layoutProps = { author };
export default MDXContent({ components, ...props }) => (
  <wrapper {...props} {...layoutProps}>
    <h1>Title</h1>
    <p>Lorem ipsum dolor sit amet.</p>
  </wrapper>
);
MDXContent.isMDXComponent = true;
```
the following code may be generated.
```js
export default 'use strict';
// some generated babel helper code here
const layoutProps = { author };
const MDXContent({ components, ...props }) => (
  <wrapper {...props} {...layoutProps}>
    <h1>Title</h1>
    <p>Lorem ipsum dolor sit amet.</p>
  </wrapper>
);
MDXContent.isMDXComponent = true;
```

### After this change:
The expected output is generated.
```js
const layoutProps = { author };
export default MDXContent({ components, ...props }) => (
  <wrapper {...props} {...layoutProps}>
    <h1>Title</h1>
    <p>Lorem ipsum dolor sit amet.</p>
  </wrapper>
);
MDXContent.isMDXComponent = true;
```