### PR TITLE
Issue 449: Migrate travis to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:7.10
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,37 +1,19 @@
-# Javascript Node CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
 version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
-      - image: circleci/node:7.10
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
+      - image: circleci/node:lts
     working_directory: ~/repo
 
     steps:
       - checkout
-
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-
       - run: yarn install
-
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-
-      # run tests!
       - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
       - restore_cache:
           keys:
           - v2-dependencies-{{ checksum "yarn.lock" }}
+          - v2-dependencies-
       - run:
           name: Install and Link
           command: |
@@ -52,7 +53,7 @@ jobs:
           at: /tmp/src
       - run:
           command: |
-            yarn lerna link --force-local
+            yarn bootstrap
             yarn test
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,12 +34,11 @@ jobs:
           command: |
             yarn install
             yarn lerna exec yarn install
-            yarn lerna link --force-local
       - run: yarn lerna exec yarn install
-      # - save_cache:
-      #     paths:
-      #       - node_modules
-      #     key: v2-dependencies-{{ checksum "yarn.lock" }}
+      - save_cache:
+          paths:
+            - node_modules
+          key: v2-dependencies-{{ checksum "yarn.lock" }}
       - persist_to_workspace:
           root: .
           paths:
@@ -51,7 +50,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: /tmp/src
-      - run: yarn test
+      - run:
+          command: |
+            yarn lerna link --force-local
+            yarn test
 
   deploy:
     <<: *mdx-defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,6 @@ jobs:
           at: /tmp/src
       - run:
           command: |
-            echo "//registry.npmjs.org/:_authToken=\${NPM_AUTH_TOKEN}" >> $HOME/.npmrc 2> /dev/null
+            echo "//registry.npmjs.org/:_authToken=\${NPM_AUTH_TOKEN}" >> $CIRCLE_WORKING_DIRECTORY/.npmrc 2> /dev/null
             git fetch --tags
             yarn publish-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,17 @@ jobs:
       - restore_cache:
           keys:
           - v2-dependencies-{{ checksum "yarn.lock" }}
-      - run: yarn
-      - save_cache:
-          paths:
-            - node_modules
-          key: v2-dependencies-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install and Link
+          command: |
+            yarn install
+            yarn lerna exec yarn install
+            yarn lerna link --force-local
+      - run: yarn lerna exec yarn install
+      # - save_cache:
+      #     paths:
+      #       - node_modules
+      #     key: v2-dependencies-{{ checksum "yarn.lock" }}
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,4 +62,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: /tmp/src
-      - run: yarn publish-ci
+      - run:
+          command: |
+            echo "//registry.npmjs.org/:_authToken=\${NPM_AUTH_TOKEN}" >> $HOME/.npmrc 2> /dev/null
+            git fetch --tags
+            yarn publish-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,56 @@
 version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/node:lts
-    working_directory: ~/repo
 
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - install
+      - test:
+          requires:
+            - install
+      - deploy:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master
+
+job-defaults: &mdx-defaults
+  docker:
+    - image: circleci/node:lts
+  working_directory: /tmp/src
+
+jobs:
+  install:
+    <<: *mdx-defaults
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
-      - run: yarn install
+          - v2-dependencies-{{ checksum "yarn.lock" }}
+      - run: yarn
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v2-dependencies-{{ checksum "yarn.lock" }}
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+
+  test:
+    <<: *mdx-defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/src
       - run: yarn test
+
+  deploy:
+    <<: *mdx-defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/src
+      - run: yarn publish-ci


### PR DESCRIPTION
Migrating CI/CD configuration from TravisCI to CircleCI

Some further steps needed to enable CircleCI: (cc @johno )
- [x] [Enable CircleCI](https://circleci.com/docs/2.0/getting-started/#setting-up-your-build-on-circleci) build for mdx repository 
- [ ] Add `NPM_AUTH_TOKEN` as [environment variable on CircleCI](https://circleci.com/gh/leimonio/mdx/edit#env-vars)

Closes #449 