### PR TITLE
Add dotAll polyfill to fix Firefox bug

### DIFF
--- a/packages/remark-mdx/tag.js
+++ b/packages/remark-mdx/tag.js
@@ -3,11 +3,15 @@
 //
 // MIT License https://github.com/remarkjs/remark/blob/master/license
 
+// https://github.com/DmitrySoshnikov/babel-plugin-transform-modern-regexp#dotall-s-flag
+// Firefox and other browsers don't support the dotAll ("s") flag, but it can be polyfilled via this:
+const dotAllPolyfill = '[\0-\uFFFF]'
+
 const attributeName = '[a-zA-Z_:][a-zA-Z0-9:._-]*'
 const unquoted = '[^"\'=<>`\\u0000-\\u0020]+'
 const singleQuoted = "'[^']*'"
 const doubleQuoted = '"[^"]*"'
-const jsProps = '{.*}'
+const jsProps = '{.*}'.replace('.', dotAllPolyfill)
 const attributeValue =
   '(?:' +
   unquoted +
@@ -23,7 +27,7 @@ const attribute =
 const openTag = '<[A-Za-z]*[A-Za-z0-9\\.\\-]*' + attribute + '*\\s*\\/?>'
 const closeTag = '<\\/[A-Za-z][A-Za-z0-9\\.\\-]*\\s*>'
 const comment = '<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->'
-const processing = '<[?].*?[?]>'
+const processing = '<[?].*?[?]>'.replace('.', dotAllPolyfill)
 const declaration = '<![A-Za-z]+\\s+[^>]*>'
 const cdata = '<!\\[CDATA\\[[\\s\\S]*?\\]\\]>'
 
@@ -42,6 +46,5 @@ exports.tag = new RegExp(
     declaration +
     '|' +
     cdata +
-    ')',
-  's'
+    ')'
 )


### PR DESCRIPTION
Firefox doesn't support the [dotAll](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll) flag (`s`) in Regexp, which is used for the JSX tag . This means using `remark-mdx` in the browser breaks on Firefox right now when parsing MDX.

![image](https://user-images.githubusercontent.com/709451/56238249-dccc5f00-6042-11e9-8aaf-8c8f325f4e51.png)

I manually verified this fixes the bug in Firefox
