### PR TITLE
raw nodes should be labeled as element after conversion

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -65,7 +65,7 @@ function applyHastPluginsAndCompilers(compiler, options) {
   compiler.use(() => ast => {
     visit(ast, 'raw', node => {
       const {children, tagName, properties} = raw(node)
-      node.type = 'jsx'
+      node.type = 'element'
       node.children = children
       node.tagName = tagName
       node.properties = properties


### PR DESCRIPTION
`raw` returns the root node type as `root`, which ends up causing
double-processing issues. We swapped it to `jsx` to fix that, which ends up
causing the converted HAST to get picked off before it can be processed into
template strings, etc. The type should be `element` so that downstream
processing happens appropriately.