### PR TITLE
Ensure class property is passed as className

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -68,6 +68,13 @@ function applyHastPluginsAndCompilers(compiler, options) {
       node.type = 'element'
       node.children = children
       node.tagName = tagName
+
+      // Transform class property to JSX-friendly className
+      if (properties.class) {
+        properties.className = properties.class
+        delete properties.class
+      }
+
       node.properties = properties
     })
   })


### PR DESCRIPTION
The hast-util-raw package returns a class prop which
needs to be renamed to className.