### PR TITLE
Ensure all class props are transformed to className

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -69,12 +69,6 @@ function applyHastPluginsAndCompilers(compiler, options) {
       node.children = children
       node.tagName = tagName
 
-      // Transform class property to JSX-friendly className
-      if (properties.class) {
-        properties.className = properties.class
-        delete properties.class
-      }
-
       node.properties = properties
     })
   })

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -72,10 +72,17 @@ function toJSX(node, parentNode = {}, options = {}) {
   let children = ''
 
   if (node.properties != null) {
+    // Turn style strings into JSX-friendly style object
     if (typeof node.properties.style === 'string') {
       node.properties.style = toStyleObject(node.properties.style, {
         camelize: true
       })
+    }
+
+    // Transform class property to JSX-friendly className
+    if (node.properties.class) {
+      node.properties.className = node.properties.class
+      delete node.properties.class
     }
 
     // AriaProperty => aria-property


### PR DESCRIPTION
When plugins apply proper HAST nodes the className
transform was missed because it only operated on raw
nodes.

Proper fix for #534