### PR TITLE
Include react and react-dom in Gatsby example dependencies

### DIFF
--- a/examples/gatsby/package.json
+++ b/examples/gatsby/package.json
@@ -11,6 +11,8 @@
     "@mdx-js/react": "^1.0.6",
     "gatsby": "^2.3.21",
     "gatsby-mdx": "^0.6.1",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "unified-ui": "^0.0.3"
   }
 }


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/mdx-js/mdx/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->

I noticed an issue when running `npm init mdx gatsby` locally:

Steps to reproduce:

* run `npm init mdx gatsby`
* cd into created directory
* run `npm install`
* run `npm start`

Expected: Gatsby successfully starts a dev server at localhost:8000 with `pages/index.mdx` displaying at `/`

Actual:

```
❯ npm start

> gatsby-mdx@1.0.0 start /private/tmp/gatsby-mdx
> gatsby develop

success open and validate gatsby-configs — 0.005 s
success load plugins — 0.405 s
success onPreInit — 0.004 s
success initialize cache — 0.037 s
success copy gatsby files — 0.106 s
success onPreBootstrap — 0.011 s
success source and transform nodes — 0.015 s
success building schema — 0.107 s
success createPages — 0.000 s
success createPagesStatefully — 0.159 s
success onPreExtractQueries — 0.000 s
success update schema — 0.017 s
success extract queries from components — 0.015 s
success run graphql queries — 0.010 s — 2/2 232.33 queries/second
success write out page data — 0.004 s
success write out redirect data — 0.001 s
success onPostBootstrap — 0.000 s

info bootstrap finished - 3.353 s

error There was an error compiling the html.js component for the development server.

See our docs page on debugging HTML builds for help https://gatsby.dev/debug-html

  2 |   if (key in obj) {
  3 |     Object.defineProperty(obj, key, {
> 4 |       value: value,
    | ^
  5 |       enumerable: true,
  6 |       configurable: true,
  7 |       writable: true


  WebpackError: Cannot find module 'react'

  - defineProperty.js:4 Function.Module._resolveFilename
    [lib]/[@babel]/runtime/helpers/defineProperty.js:4:1


  - index.es.js:1 Module.require
    [lib]/[@mdx-js]/react/dist/index.es.js:1:1

  - bootstrap:11 require
    lib/webpack/bootstrap:11:1

  - universalModuleDefinition:3 webpackUniversalModuleDefinition
    lib/webpack/universalModuleDefinition:3:1

  - universalModuleDefinition:10 Object.<anonymous>
    lib/webpack/universalModuleDefinition:10:2

  - gatsby-ssr.js:1 Module._compile
    [lib]/[gatsby-mdx]/gatsby-ssr.js:1:1



  - develop-static-entry.js:86 tryModuleLoad
    lib/.cache/develop-static-entry.js:86:5

  - develop-static-entry.js:76 Function.Module._load
    lib/.cache/develop-static-entry.js:76:3

  - index.es.js:1 Module.require
    [lib]/[@mdx-js]/react/dist/index.es.js:1:1

  - bootstrap:11 require
    lib/webpack/bootstrap:11:1

  - bootstrap:21 Promise
    lib/webpack/bootstrap:21:1

  - api-ssr-docs.js:142 Promise._execute
    lib/.cache/api-ssr-docs.js:142:1


```

I've tested the solution (in this PR), and by adding `react` and `react-dom` as dependencies, I have been able to quickly bootstrap a new Gatsby MDX site to play around with MDX locally.