### PR TITLE
`exporting` fails

### DIFF
--- a/packages/remark-mdx/index.js
+++ b/packages/remark-mdx/index.js
@@ -4,7 +4,7 @@ const block = require('./block')
 const {tag} = require('./tag')
 
 const IMPORT_REGEX = /^import/
-const EXPORT_REGEX = /^export/
+const EXPORT_REGEX = /^export\s/
 const EMPTY_NEWLINE = '\n\n'
 const LESS_THAN = '<'
 const GREATER_THAN = '>'

--- a/packages/remark-mdx/test/fixtures/import-export.js
+++ b/packages/remark-mdx/test/fixtures/import-export.js
@@ -25,5 +25,9 @@ module.exports = [
   {
     description: 'Handles multiline default exports',
     mdx: ['export default props => (', '  <main {...props} />', ')'].join('\n')
+  },
+  {
+    description: 'does not handle non-export words',
+    mdx: `exporting that from the same file as a React component will make the config`
   }
 ]


### PR DESCRIPTION
<img width="712" alt="Screen Shot 2019-04-21 at 8 52 38 PM" src="https://user-images.githubusercontent.com/551247/56482653-0be73400-647a-11e9-85d5-8a9497635f21.png">

The error points to `[remark-mdx]/extract-imports-and-exports.js:48:3`, which seems like it should never make it there?

<details>

<summary>gatsby develop output</summary>

GATSBY_SCREENSHOT_PLACEHOLDER=true yarn develop
yarn run v1.15.2
$ GATSBY_GRAPHQL_IDE=playground gatsby develop
success open and validate gatsby-configs — 0.015 s
success load plugins — 3.750 s
success onPreInit — 0.017 s
success initialize cache — 0.054 s
success copy gatsby files — 0.093 s
success onPreBootstrap — 0.008 s
error Plugin gatsby-plugin-mdx returned an error


  SyntaxError: unknown: Unexpected token, expected ";" (1:10)
  > 1 | exporting that from the same file as a React component will make the config
      |           ^
    2 | information available to the component as a `data` prop on the component. For
    3 | instance, the title attribute could be referenced as
    4 | `props.data.site.siteMetadata.title`./Users/biscarch/github/gatsbyjs/gatsby/docs/docs/migrating-from-v0-to-v1.md: unknown: Unexpecte  d token, expected ";" (1:10)
  > 1 | exporting that from the same file as a React component will make the config
      |           ^
    2 | information available to the component as a `data` prop on the component. For
    3 | instance, the title attribute could be referenced as
    4 | `props.data.site.siteMetadata.title`.

  - index.js:3851 Object.raise
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:3851:17

  - index.js:5167 Object.unexpected
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:5167:16

  - index.js:5149 Object.semicolon
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:5149:40

  - index.js:7827 Object.parseExpressionStatement
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:7827:10

  - index.js:7425 Object.parseStatementContent
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:7425:19

  - index.js:7291 Object.parseStatement
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:7291:17

  - index.js:7868 Object.parseBlockOrModuleBlockBody
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:7868:25

  - index.js:7855 Object.parseBlockBody
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:7855:10

  - index.js:7220 Object.parseTopLevel
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:7220:10

  - index.js:8863 Object.parse
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:8863:17

  - index.js:11135 parse
    [www]/[remark-mdx]/[@babel]/parser/lib/index.js:11135:38

  - normalize-file.js:170 parser
    [www]/[remark-mdx]/[@babel]/core/lib/transformation/normalize-file.js:170:34

  - normalize-file.js:138 normalizeFile
    [www]/[remark-mdx]/[@babel]/core/lib/transformation/normalize-file.js:138:11

  - index.js:44 runSync
    [www]/[remark-mdx]/[@babel]/core/lib/transformation/index.js:44:43

  - transform.js:43 transformSync
    [www]/[remark-mdx]/[@babel]/core/lib/transform.js:43:38

  - extract-imports-and-exports.js:48 module.exports
    [www]/[remark-mdx]/extract-imports-and-exports.js:48:3


✨  Done in 58.26s.

</details>