### PR TITLE
Directly require babel plugins in remark-mdx

### DIFF
--- a/packages/remark-mdx/extract-imports-and-exports.js
+++ b/packages/remark-mdx/extract-imports-and-exports.js
@@ -47,8 +47,8 @@ module.exports = (value, vfile) => {
 
   transformSync(value, {
     plugins: [
-      '@babel/plugin-syntax-jsx',
-      '@babel/plugin-proposal-object-rest-spread',
+      require('@babel/plugin-syntax-jsx'),
+      require('@babel/plugin-proposal-object-rest-spread'),
       instance.plugin
     ],
     filename: vfile.path


### PR DESCRIPTION
- For consistency [with `@mdx-js/mdx`](https://github.com/mdx-js/mdx/blob/master/packages/mdx/mdx-hast-to-jsx.js#L162-L163)
- Prevents resolution issues in monorepo-like scenarios (where `remark-mdx` is in a different parent folder to the CWD, so babel's plugin resolution fails)

<!--

Read the [contributing guidelines](https://github.com/mdx-js/mdx/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
