### PR TITLE
docs: fix @mdx-js/react import

### DIFF
--- a/packages/react/readme.md
+++ b/packages/react/readme.md
@@ -21,7 +21,7 @@ npm install --save @mdx-js/react
 /* @jsx mdx */
 import React from 'react'
 import {renderToString} from 'react-dom/server'
-import {MDXProvider, mdx} from '@mdx/react'
+import {MDXProvider, mdx} from '@mdx-js/react'
 
 const H1 = props => <h1 style={{color: 'tomato'}} {...props} />
 


### PR DESCRIPTION
import from '@mdx-js/react' instead of '@mdx/react'

<!--

Read the [contributing guidelines](https://github.com/mdx-js/mdx/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
