### PR TITLE
Use @next/mdx to use mdx in Next.js

### DIFF
--- a/docs/getting-started/next.md
+++ b/docs/getting-started/next.md
@@ -4,13 +4,13 @@ Next.js provides an [official plugin][next-plugin] to simplify MDX importing
 into your project.
 
 ```shell
-npm install --save-dev @zeit/next-mdx
+npm install --save-dev @next/mdx @mdx-js/loader 
 ```
 
 To configure MDX, add the following to your `next.config.js`:
 
 ```js
-const withMDX = require('@zeit/next-mdx')()
+const withMDX = require('@next/mdx')()
 
 module.exports = withMDX()
 ```
@@ -20,7 +20,7 @@ module.exports = withMDX()
 The Next.js MDX plugin allows for you to also use MDX parsing for `.md` files:
 
 ```js
-const withMDX = require('@zeit/next-mdx')({
+const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/
 })
 
@@ -29,4 +29,4 @@ module.exports = withMDX({
 })
 ```
 
-[next-plugin]: https://github.com/zeit/next-plugins/tree/master/packages/next-mdx
+[next-plugin]: https://github.com/zeit/next.js/tree/canary/packages/next-mdx

--- a/docs/getting-started/next.md
+++ b/docs/getting-started/next.md
@@ -29,4 +29,4 @@ module.exports = withMDX({
 })
 ```
 
-[next-plugin]: https://github.com/zeit/next.js/tree/canary/packages/next-mdx
+[next-plugin]: https://github.com/zeit/next.js/tree/master/packages/next-mdx

--- a/examples/next/next.config.js
+++ b/examples/next/next.config.js
@@ -1,7 +1,7 @@
 const images = require('remark-images')
 const emoji = require('remark-emoji')
 
-const withMDX = require('@zeit/next-mdx')({
+const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
   options: {
     mdPlugins: [images, emoji]

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@mdx-js/loader": "^1.0.16",
     "@mdx-js/mdx": "^1.0.16",
-    "@zeit/next-mdx": "^1.2.0",
-    "next": "^8.0.4",
+    "@next/mdx": "^8.1.0",
+    "next": "^8.1.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "remark-emoji": "^2.0.2",


### PR DESCRIPTION
[@zeit/next-mdx](https://github.com/zeit/next-plugins/tree/master/packages/next-mdx) is now deprecated.
We should use @next/mdx so I fixed documentation.