### PR TITLE
Stop remark-mdx from picking up external babel config

### DIFF
--- a/packages/remark-mdx/extract-imports-and-exports.js
+++ b/packages/remark-mdx/extract-imports-and-exports.js
@@ -50,7 +50,9 @@ module.exports = (value, vfile) => {
 
   transformSync(value, {
     plugins: [syntaxJsxPlugin, proposalObjectRestSpreadPlugin, instance.plugin],
-    filename: vfile.path
+    filename: vfile.path,
+    configFile: false,
+    babelrc: false
   })
 
   const sortedNodes = instance.state.nodes.sort((a, b) => a.start - b.start)


### PR DESCRIPTION
Like #526, but for `@mdx-js/remark-mdx` instead of `@mdx-js/loader`.
This also addresses #569. Without this PR, Babel macro (if used) is accidentally picked up by `@mdx-js/remark-mdx` and the import statement is swallowed, failing the validation of the `eat()` call in remark tokenizer.