### PR TITLE
Stop forwarding options to remark/rehype plugins

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -38,7 +38,7 @@ function createMdxAstCompiler(options) {
     if (Array.isArray(plugin) && plugin.length > 1) {
       fn.use(plugin[0], plugin[1])
     } else {
-      fn.use(plugin, options)
+      fn.use(plugin)
     }
   })
 
@@ -78,7 +78,7 @@ function applyHastPluginsAndCompilers(compiler, options) {
     if (Array.isArray(plugin) && plugin.length > 1) {
       compiler.use(plugin[0], plugin[1])
     } else {
-      compiler.use(plugin, options)
+      compiler.use(plugin)
     }
   })
 

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -244,6 +244,22 @@ it('Should turn a newline into a space with other adjacent phrasing content', as
   expect(result).toContain('<em>foo</em>\n<code>bar</code>')
 })
 
+test('Should not forward MDX options to plugins', async () => {
+  expect.assertions(2)
+  await mdx(``, {
+    remarkPlugins: [
+      options => _tree => {
+        expect(options).toMatchInlineSnapshot(`undefined`)
+      }
+    ],
+    rehypePlugins: [
+      options => _tree => {
+        expect(options).toMatchInlineSnapshot(`undefined`)
+      }
+    ]
+  })
+})
+
 it('Should convert style strings to camelized objects', async () => {
   const result = await mdx(
     `


### PR DESCRIPTION
This no longer serves its initial purpose, and is definitely unexpected behavior that can break plugins which expect certain properties or, worse, if a MDX option happen to match an option of that plugin.

This change shouldn't introduce problems because it's hard to imagine why someone would rely on this undocumented and buggy behavior of this advanced feature instead of filing an issue in this very actively maintained project. Also, if someone was getting around this bug by always forcing custom options, that workaround will continue to work after this change.

Btw, I'm using `toMatchInlineSnapshot` instead of something like `toBeUndefined` just so it's slightly easier to maintain if defaults change to something else, like an empty object instead of `undefined`.

Fixes #575.
