### PR TITLE
Fix my name on the blog post

### DIFF
--- a/docs/blog/v1.md
+++ b/docs/blog/v1.md
@@ -183,7 +183,7 @@ We’d like to say thanks to all our contributors and our happy users.  Special 
 [@xyc](https://github.com/xyc),
 [@filoxo](https://github.com/filoxo),
 [@millette](https://github.com/millette),
-[@hugmannrique](https://github.com/hugmannrique),
+[@hugmanrique](https://github.com/hugmanrique),
 [@johnsherrard](https://github.com/johnsherrard),
 [@sw-yx](https://github.com/sw-yx),
 and anyone we may have forgotten.


### PR DESCRIPTION
Just noticed this minor typo on the v1 release blog post.

<!--

Read the [contributing guidelines](https://github.com/mdx-js/mdx/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->
