### PR TITLE
chore: update docs links to unify more gatsby mdx docs on .org

### DIFF
--- a/docs/getting-started/gatsby.md
+++ b/docs/getting-started/gatsby.md
@@ -1,6 +1,6 @@
 # Gatsby
 
-In order to use MDX with [Gatsby][] you can use the [gatsby-mdx][] package.
+In order to use MDX with [Gatsby][] you can use the [gatsby-mdx][mdx-plugin] package.
 
 First, scaffold a new Gatsby 2.0 or greater site and install the `gatsby-mdx`
 plugin.
@@ -35,5 +35,5 @@ For more documentation on programmatically creating pages with Gatsby, see
 the [gatsby-mdx docs][gatsby-mdx].
 
 [gatsby]: https://gatsbyjs.org
-
-[gatsby-mdx]: https://github.com/ChristopherBiscardi/gatsby-mdx
+[gatsby-mdx]: https://gatsbyjs.org/docs/mdx/
+[mdx-plugin]: https://gatsbyjs.org/packages/gatsby-mdx/


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/mdx-js/mdx/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->

As per discussion in https://github.com/gatsbyjs/gatsby/issues/14258, this is a starting point for unifying more of the `gatsby-mdx` docs on Gatsbyjs.org by linking directly to existing docs there rather than the repos.
