### PR TITLE
docs: fix typo

### DIFF
--- a/docs/guides/syntax-highlighting.md
+++ b/docs/guides/syntax-highlighting.md
@@ -142,7 +142,7 @@ module.exports = {
           {
             resolve: '@mdx-js/loader',
             options: {
-              hastPlugins[rehypePrism]
+              rehypePlugins: [rehypePrism]
             }
           }
         ]


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/mdx-js/mdx/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->

fix some typo

1. hastPlugins has been deprecated in favor of rehypePlugins
2. missing `:`