### PR TITLE
Updated gatsby.md to replace @next tag with @latest

### DIFF
--- a/docs/getting-started/gatsby.md
+++ b/docs/getting-started/gatsby.md
@@ -8,7 +8,7 @@ plugin.
 ```shell
 gatsby new gatsby-site https://github.com/gatsbyjs/gatsby-starter-default#v2
 cd gatsby-site
-yarn add gatsby-mdx @mdx-js/mdx@next @mdx-js/react@next
+yarn add gatsby-mdx @mdx-js/mdx@latest @mdx-js/react@latest
 ```
 
 Then add `gatsby-mdx` to your `gatsby-config.js` in the `plugins` section.


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/mdx-js/mdx/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->

This is a tiny change to update the `@next` tag in the Gatsby docs to `@latest`. If you install the current `@next` which is `1.0.0-rc.4` and if `gatsby-remark-prismjs` is also installed then the project fails to build.
