### PR TITLE
Update webpack.md

### DIFF
--- a/docs/getting-started/webpack.md
+++ b/docs/getting-started/webpack.md
@@ -13,7 +13,7 @@ for webpack projects.
 ## Installation
 
 ```sh
-npm install --save-dev @mdx-js/loader@next
+npm install --save-dev @mdx-js/loader
 ```
 
 ## Configuration


### PR DESCRIPTION
The @next tag currently points to [1.0.0-rc.4 on npm](https://www.npmjs.com/package/@mdx-js/loader/v/next). I suggest also updating the @next tag on NPM :v:

![image](https://user-images.githubusercontent.com/2470775/60438036-02afdb80-9c10-11e9-9138-b832529c8f11.png)
