### PR TITLE
Update docs to refer to gatsby-plugin-mdx

### DIFF
--- a/docs/getting-started/gatsby.md
+++ b/docs/getting-started/gatsby.md
@@ -6,7 +6,7 @@ First, scaffold a new Gatsby 2.0 or greater site and install the `gatsby-plugin-
 plugin.
 
 ```shell
-gatsby new gatsby-site https://github.com/gatsbyjs/gatsby-starter-default#v2
+gatsby new gatsby-site
 cd gatsby-site
 yarn add gatsby-plugin-mdx @mdx-js/mdx@latest @mdx-js/react@latest
 ```

--- a/docs/getting-started/gatsby.md
+++ b/docs/getting-started/gatsby.md
@@ -1,24 +1,24 @@
 # Gatsby
 
-In order to use MDX with [Gatsby][] you can use the [gatsby-mdx][mdx-plugin] package.
+To use MDX with [Gatsby][], use [gatsby-plugin-mdx][gatsby-plugin-mdx].
 
-First, scaffold a new Gatsby 2.0 or greater site and install the `gatsby-mdx`
+First, scaffold a new Gatsby 2.0 or greater site and install the `gatsby-plugin-mdx`
 plugin.
 
 ```shell
 gatsby new gatsby-site https://github.com/gatsbyjs/gatsby-starter-default#v2
 cd gatsby-site
-yarn add gatsby-mdx @mdx-js/mdx@latest @mdx-js/react@latest
+yarn add gatsby-plugin-mdx @mdx-js/mdx@latest @mdx-js/react@latest
 ```
 
-Then add `gatsby-mdx` to your `gatsby-config.js` in the `plugins` section.
+Then add `gatsby-plugin-mdx` to your `gatsby-config.js` in the `plugins` section.
 
 ```javascript
 module.exports = {
   siteMetadata: {
     title: `My Ambitious Project`
   },
-  plugins: [`gatsby-mdx`]
+  plugins: [`gatsby-plugin-mdx`]
 }
 ```
 
@@ -32,10 +32,8 @@ some awesome content
 ```
 
 For more documentation on programmatically creating pages with Gatsby, see
-the [gatsby-mdx docs][gatsby-mdx].
+the [gatsby-plugin-mdx docs][gatsby-and-mdx].
 
 [gatsby]: https://gatsbyjs.org
-
-[gatsby-mdx]: https://gatsbyjs.org/docs/mdx/
-
-[mdx-plugin]: https://gatsbyjs.org/packages/gatsby-mdx/
+[gatsby-and-mdx]: https://gatsbyjs.org/docs/mdx/
+[gatsby-plugin-mdx]: https://gatsbyjs.org/packages/gatsby-plugin-mdx/

--- a/docs/getting-started/gatsby.md
+++ b/docs/getting-started/gatsby.md
@@ -1,6 +1,6 @@
 # Gatsby
 
-To use MDX with [Gatsby][], use [gatsby-plugin-mdx][gatsby-plugin-mdx].
+To use MDX with [Gatsby][], use [gatsby-plugin-mdx][].
 
 First, scaffold a new Gatsby 2.0 or greater site and install the `gatsby-plugin-mdx`
 plugin.
@@ -32,8 +32,8 @@ some awesome content
 ```
 
 For more documentation on programmatically creating pages with Gatsby, see
-the [gatsby-plugin-mdx docs][gatsby-and-mdx].
+the [Gatsby MDX docs][gatsby-mdx-docs].
 
 [gatsby]: https://gatsbyjs.org
-[gatsby-and-mdx]: https://gatsbyjs.org/docs/mdx/
+[gatsby-mdx-docs]: https://gatsbyjs.org/docs/mdx/
 [gatsby-plugin-mdx]: https://gatsbyjs.org/packages/gatsby-plugin-mdx/


### PR DESCRIPTION
- Update the Gatsby docs page to refer to `gatsby-plugin-mdx` instead of `gatsby-mdx` (deprecated).
- Remove #v2 from gatsby-default-starter instructions.