### PR TITLE
Insert semicolon to ensure whitespace is not significant

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -150,7 +150,7 @@ function toJSX(node, parentNode = {}, options = {}) {
 ${jsxNodes.map(childNode => toJSX(childNode, node)).join('')}
     </MDXLayout>
   )
-}
+};
 MDXContent.isMDXComponent = true`
 
     // Check JSX nodes against imports

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -100,36 +100,36 @@ it('Should match sample blog post snapshot', async () => {
   const result = await mdx(`# Hello World`)
 
   expect(prettier.format(result, {parser: 'babel'})).toMatchInlineSnapshot(`
-    "/* @jsx mdx */
-    
-    const makeShortcode = name =>
-      function MDXDefaultShortcode(props) {
-        console.warn(
-          \\"Component \\" +
-            name +
-            \\" was not imported, exported, or provided by MDXProvider as global scope\\"
-        );
-        return <div {...props} />;
-      };
-    
-    const layoutProps = {};
-    const MDXLayout = \\"wrapper\\";
-    export default function MDXContent({ components, ...props }) {
-      return (
-        <MDXLayout
-          {...layoutProps}
-          {...props}
-          components={components}
-          mdxType=\\"MDXLayout\\"
-        >
-          <h1>{\`Hello World\`}</h1>
-        </MDXLayout>
-      );
-    }
-    
-    MDXContent.isMDXComponent = true;
-    "
-  `)
+        "/* @jsx mdx */
+        
+        const makeShortcode = name =>
+          function MDXDefaultShortcode(props) {
+            console.warn(
+              \\"Component \\" +
+                name +
+                \\" was not imported, exported, or provided by MDXProvider as global scope\\"
+            );
+            return <div {...props} />;
+          };
+        
+        const layoutProps = {};
+        const MDXLayout = \\"wrapper\\";
+        export default function MDXContent({ components, ...props }) {
+          return (
+            <MDXLayout
+              {...layoutProps}
+              {...props}
+              components={components}
+              mdxType=\\"MDXLayout\\"
+            >
+              <h1>{\`Hello World\`}</h1>
+            </MDXLayout>
+          );
+        }
+        
+        MDXContent.isMDXComponent = true;
+        "
+    `)
 })
 
 it('Should render blockquote correctly', async () => {
@@ -430,8 +430,8 @@ test('Should handle layout props', () => {
       ...props
     }) {
       return <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
-    
-    
+
+
         <h1>{\`Hello, world!\`}</h1>
         <p>{\`I'm an awesome paragraph.\`}</p>
         {
@@ -476,7 +476,7 @@ test('Should handle layout props', () => {
             </tr>
           </tbody>
         </table>
-    
+
         <pre><code parentName=\\"pre\\" {...{
             \\"className\\": \\"language-js\\"
           }}>{\`export const Button = styled.button\\\\\`
@@ -497,7 +497,8 @@ test('Should handle layout props', () => {
     \`}</code></pre>
         </MDXLayout>;
     }
-    
+
+    ;
     MDXContent.isMDXComponent = true;"
   `)
 })

--- a/packages/remark-mdx/test/__snapshots__/test.js.snap
+++ b/packages/remark-mdx/test/__snapshots__/test.js.snap
@@ -31,6 +31,7 @@ export default function MDXContent({
     </MDXLayout>;
 }
 
+;
 MDXContent.isMDXComponent = true;"
 `;
 


### PR DESCRIPTION
For large documents Babel will deopt styling which can
cause whitespace to change. When this happens we can result
in something like:

    /* ... */;}MDXContent.isMDXComponent=true/* ... */

This will result in invalid syntax that causes the document
to break builds. With an explicit semicolon that will no
longer happen.

Closes #618