### PR TITLE
Forward along components when passed as a prop

### DIFF
--- a/packages/react/src/create-element.js
+++ b/packages/react/src/create-element.js
@@ -24,6 +24,10 @@ const MDXCreateElement = ({
     DEFAULTS[type] ||
     originalType
 
+  if (propComponents) {
+    return React.createElement(Component, {...etc, components: propComponents})
+  }
+
   return React.createElement(Component, etc)
 }
 

--- a/packages/react/test/fixture.js
+++ b/packages/react/test/fixture.js
@@ -3,9 +3,17 @@
 // eslint-disable-next-line no-unused-vars
 import {mdx} from '../src'
 
+const Component = ({components}) => <p>{Object.keys(components).join(', ')}</p>
+
 export default () => (
   <wrapper>
     <h1 />
     <h2 />
+    <Component
+      components={{
+        h3: props => <h3 {...props} />,
+        h4: props => <h4 {...props} />
+      }}
+    />
   </wrapper>
 )

--- a/packages/react/test/test.js
+++ b/packages/react/test/test.js
@@ -59,3 +59,9 @@ it('Should allow removing of context components using the functional form', () =
   // MDXTag picks up overridden component context
   expect(result).toMatch(/style="color:papayawhip"/)
 })
+
+it('Should pass prop components along', () => {
+  const result = renderToString(<Fixture />)
+
+  expect(result).toMatch(/h3, h4/)
+})


### PR DESCRIPTION
MDX element creation dropped the components prop
when it was explicitly passed as a prop. For now
we will continue to forward it along.

For the MDX specific component prop, in the future,
we should consider potentially prefixing as mdxComponents.

Closes #635