### PR TITLE
Trim code

### DIFF
--- a/examples/syntax-highlighting/src/components/CodeBlock.js
+++ b/examples/syntax-highlighting/src/components/CodeBlock.js
@@ -30,7 +30,7 @@ export default ({children, className, live, render}) => {
   }
 
   return (
-    <Highlight {...defaultProps} code={children} language={language}>
+    <Highlight {...defaultProps} code={children.trim()} language={language}>
       {({className, style, tokens, getLineProps, getTokenProps}) => (
         <pre className={className} style={{...style, padding: '20px'}}>
           {tokens.map((line, i) => (


### PR DESCRIPTION
Thanks for this project and example! Really helpful for creating documents with interactive parts.

Looks like the following image without this change, there is an extra empty line at the bottom of the code fence when used like this:

<pre>
```html
&lt;div id="1">&lt;/div>
```
</pre>

<img width="255" alt="Screen Shot 2019-07-15 at 16 27 34" src="https://user-images.githubusercontent.com/1935696/61223740-8e039380-a71d-11e9-8e21-84a34471fd3c.png">

## When inspected:

<img width="503" alt="Screen Shot 2019-07-15 at 16 21 26" src="https://user-images.githubusercontent.com/1935696/61223704-7d531d80-a71d-11e9-81b6-a947a7a239fc.png">

