### PR TITLE
Add MDX fairy tale talk as an example project

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -25,6 +25,7 @@
 ## Other related links
 
 *   [awesome-mdx][]
+*   [MDX: content for kings and princesses][mdx-fairy-tale]
 
 [demoboard]: https://frontarm.com/demoboard
 
@@ -51,3 +52,5 @@
 [spectacle-boilerplate-mdx]: https://github.com/FormidableLabs/spectacle-boilerplate-mdx
 
 [charge]: https://charge.js.org
+
+[mdx-fairy-tale]: https://github.com/DeveloperMode/mdx-fairy-tale


### PR DESCRIPTION
This PR adds a link to the _Other related links_ section of the _Projects using MDX_ page in the docs. The link is to a talk I gave at JAMstack Conf London 2019 about MDX and built using MDX Deck.

The link goes to here:
https://github.com/DeveloperMode/mdx-fairy-tale