### PR TITLE
import mdxProvider from @mdx-js/react

### DIFF
--- a/examples/parcel/src/main.js
+++ b/examples/parcel/src/main.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {render} from 'react-dom'
-import {MDXProvider} from '@mdx-js/tag'
+import {MDXProvider} from '@mdx-js/react'
 
 import Content from './content.mdx'
 


### PR DESCRIPTION
fixes parcel example not permitting overriding html elements

fixed as per comment at  https://github.com/mdx-js/mdx/issues/685#issuecomment-515203337

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
