### PR TITLE
fix(deps): react should be a peer dependency

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -50,6 +50,9 @@
     "remark-slug": "5.1.2",
     "rimraf": "2.6.3"
   },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  },
   "jest": {
     "testEnvironment": "node"
   }


### PR DESCRIPTION
React is used in @mdx-js/runtime, so it should be declared as a
peer dependency.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
