### PR TITLE
Don't compress mdx-js/react output

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
     "react": "^16.8.0"
   },
   "scripts": {
-    "build": "microbundle --format es,cjs --external react --jsx React.createElement --no-sourcemap",
+    "build": "microbundle --format es,cjs --external react --jsx React.createElement --no-sourcemap --no-compress",
     "clean": "rimraf dist",
     "prepublish": "npm run clean && npm run build",
     "test": "jest"


### PR DESCRIPTION
This _appears_ to be causing issues in other environments.
Going to remove the compression of microbundle and see if
it allows this library to better interact with minifiers
in other bundlers and frameworks.

We've confirmed this issue in Next.js and Gatsby but haven't
had a reproducible build. I may've inadvertently stumbled
across it in johno/digital-garden.

With that branch I'm looking to see if this fixes it.