### PR TITLE
Stringify another array property

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -232,13 +232,19 @@ export default ${fnPostMdxTypeProp}`
 
   if (node.type === 'element') {
     let props = ''
+    
+    const shouldBeStrings = ['className', 'sandbox']
 
-    if (node.properties && Array.isArray(node.properties.className)) {
-      node.properties.className = node.properties.className.join(' ')
-    }
+    if (node.properties) {
+      shouldBeStrings.forEach(prop => {
+        if (Array.isArray(node.properties[prop])) {
+          node.properties[prop] = node.properties[prop].join(' ')
+        }
+      })
 
-    if (node.properties && Object.keys(node.properties).length > 0) {
-      props = JSON.stringify(node.properties)
+      if (Object.keys(node.properties).length > 0) {
+        props = JSON.stringify(node.properties)
+      }
     }
 
     return `<${node.tagName}${

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -232,7 +232,7 @@ export default ${fnPostMdxTypeProp}`
 
   if (node.type === 'element') {
     let props = ''
-    
+
     const shouldBeStrings = ['className', 'sandbox']
 
     if (node.properties) {


### PR DESCRIPTION
Building on @devongovett's #158, this adds the `sandbox` property to the list of properties that should allow spaces.

Without this fix, using `gatsby-remark-embedded-codesandbox` along with `gatsby-plugin-mdx` results in an `iframe` with a `sandbox` attribute of `allow-modals,allow-forms,allow-popups,allow-scripts,allow-same-origin`, even though `gatsby-remark-embedded-codesandbox` is correctly returning space-separated strings.

If this is truly the correct solution, then probably we should include other HTML properties that accept spaces.

If there's a better / more correct way of doing this, I'm all ears! The remark plugin `gatsby-remark-embedded-codesandbox` does appear to be doing everything right however, returning a `node.value` with a `sandbox` attribute separated by spaces. It seems like MDX itself is changing the spaces to commas...

Fixes https://github.com/elboman/gatsby-remark-embedded-codesandbox/issues/7

cc @timneutkens @elboman