### PR TITLE
Loader renderer option

### DIFF
--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -1,11 +1,19 @@
 const {getOptions} = require('loader-utils')
 const mdx = require('@mdx-js/mdx')
 
-module.exports = async function(content) {
+const DEFAULT_PREPEND = `
+  import React from 'react'
+  import { mdx } from '@mdx-js/react'
+`
+  .split('\n')
+  .map(l => l.trim())
+
+const loader = async function(content) {
   const callback = this.async()
   const options = Object.assign({}, getOptions(this), {
     filepath: this.resourcePath
   })
+
   let result
 
   try {
@@ -14,11 +22,10 @@ module.exports = async function(content) {
     return callback(err)
   }
 
-  const code = `/* @jsx mdx */
-  import React from 'react'
-  import { mdx } from '@mdx-js/react'
-  ${result}
-  `
+  const {prepend = DEFAULT_PREPEND} = options
 
+  const code = `${prepend}\n${result}`
   return callback(null, code)
 }
+
+module.exports = loader

--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -1,12 +1,10 @@
 const {getOptions} = require('loader-utils')
 const mdx = require('@mdx-js/mdx')
 
-const DEFAULT_PREPEND = `
-  import React from 'react'
-  import { mdx } from '@mdx-js/react'
+const DEFAULT_RENDERER = `
+import React from 'react'
+import { mdx } from '@mdx-js/react'
 `
-  .split('\n')
-  .map(l => l.trim())
 
 const loader = async function(content) {
   const callback = this.async()
@@ -22,9 +20,9 @@ const loader = async function(content) {
     return callback(err)
   }
 
-  const {prepend = DEFAULT_PREPEND} = options
+  const {renderer = DEFAULT_RENDERER} = options
 
-  const code = `${prepend}\n${result}`
+  const code = `${renderer}\n${result}`
   return callback(null, code)
 }
 

--- a/packages/loader/readme.md
+++ b/packages/loader/readme.md
@@ -32,6 +32,53 @@ module: {
 }
 ```
 
+The `prepend` option specifies a string that will be prepended to the generated source allowing for the use of any `createElement` implementation. By default, that string is:
+
+```js
+import React from 'react'
+import { mdx } from '@mdx-js/react'
+```
+
+One could use any other implementation. The example below wraps a generic JSX compatible function named `h`.
+
+```js
+const prepend = `
+import { h } from 'generic-implementation'
+
+const mdx = (function (createElement) {
+  return function (name, props, ...children) {
+    if (typeof name === 'string') {
+      if (name === 'wrapper') return children.map(createElement)
+      if (name === 'inlineCode') return createElement('code', props, ...children)
+    }
+
+    return createElement(name, props, ...children)
+  }
+}(h))
+`
+
+// ...
+module: {
+  rules: [
+    // ...
+    {
+      test: /\.mdx?$/,
+      use: [
+        'babel-loader',
+        {
+          loader: '@mdx-js/loader'
+          options: {
+            prepend,
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+For more information on why this is required, see [this post](https://mdxjs.com/blog/custom-pragma).
+
 ## Contribute
 
 See the [Support][] and [Contributing][] guidelines on the MDX website for ways

--- a/packages/loader/readme.md
+++ b/packages/loader/readme.md
@@ -32,17 +32,17 @@ module: {
 }
 ```
 
-The `prepend` option specifies a string that will be prepended to the generated source allowing for the use of any `createElement` implementation. By default, that string is:
+The `renderer` option specifies a string that will be prepended to the generated source allowing for the use of any `createElement` implementation.  By default, that string is:
 
 ```js
 import React from 'react'
 import { mdx } from '@mdx-js/react'
 ```
 
-One could use any other implementation. The example below wraps a generic JSX compatible function named `h`.
+Using the `renderer` option, one can swap out React for another implementation.  The example below wraps a generic JSX compatible function named `h`.
 
 ```js
-const prepend = `
+const renderer = `
 import { h } from 'generic-implementation'
 
 const mdx = (function (createElement) {
@@ -68,7 +68,7 @@ module: {
         {
           loader: '@mdx-js/loader'
           options: {
-            prepend,
+            renderer,
           }
         }
       ]


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

This fixes #711 

- adds the `prepend` to the Webpack loader's `options`.
- it removes the inline pragma `/* @jsx mdx */` - this is not needed since [mdx itself adds this during compilation](https://github.com/mdx-js/mdx/blob/master/packages/mdx/index.js#L112).
- add to README to reflect changes.

All changes are completely backwards compatible... this would just allow for other frameworks to be used with the loader.