### PR TITLE
Use babel standalone in runtime, change exports to variable declarations

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -24,7 +24,7 @@
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "scripts": {
-    "build": "microbundle --format es,cjs --external react,@babel/standalone,@babel/plugin-proposal-object-rest-spread,@babel/plugin-syntax-jsx,babel-plugin-remove-export-keywords,@mdx-js/mdx,@mdx-js/react --jsx React.createElement --no-sourcemap",
+    "build": "microbundle --format es,cjs --external react,@babel/standalone,@babel/types,@babel/plugin-proposal-object-rest-spread,@babel/plugin-transform-react-jsx,babel-plugin-remove-export-keywords,@mdx-js/mdx,@mdx-js/react --jsx React.createElement --no-sourcemap",
     "clean": "rimraf dist",
     "prepublish": "yarn clean && yarn build",
     "test": "jest"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -24,7 +24,7 @@
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "scripts": {
-    "build": "microbundle --format es,cjs --external react,buble,@mdx-js/mdx,@mdx-js/react --jsx React.createElement --no-sourcemap",
+    "build": "microbundle --format es,cjs --external react,@babel/standalone,@babel/plugin-proposal-object-rest-spread,@babel/plugin-syntax-jsx,@mdx-js/mdx,@mdx-js/react --jsx React.createElement --no-sourcemap",
     "clean": "rimraf dist",
     "prepublish": "yarn clean && yarn build",
     "test": "jest"
@@ -33,9 +33,12 @@
     "dist"
   ],
   "dependencies": {
+    "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+    "@babel/plugin-transform-react-jsx": "^7.2.0",
+    "@babel/standalone": "^7.5.5",
     "@mdx-js/mdx": "^1.3.0",
     "@mdx-js/react": "^1.3.0",
-    "buble": "^0.19.8"
+    "babel-plugin-remove-export-keywords": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.5.5",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -24,7 +24,7 @@
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "scripts": {
-    "build": "microbundle --format es,cjs --external react,@babel/standalone,@babel/plugin-proposal-object-rest-spread,@babel/plugin-syntax-jsx,@mdx-js/mdx,@mdx-js/react --jsx React.createElement --no-sourcemap",
+    "build": "microbundle --format es,cjs --external react,@babel/standalone,@babel/plugin-proposal-object-rest-spread,@babel/plugin-syntax-jsx,babel-plugin-remove-export-keywords,@mdx-js/mdx,@mdx-js/react --jsx React.createElement --no-sourcemap",
     "clean": "rimraf dist",
     "prepublish": "yarn clean && yarn build",
     "test": "jest"

--- a/packages/runtime/readme.md
+++ b/packages/runtime/readme.md
@@ -47,6 +47,16 @@ export default () => (
 )
 ```
 
+### Options
+
+| Name            | Default | Description                                         |
+| --------------- | ------- | --------------------------------------------------- |
+| `remarkPlugins` | `[]`    | Remark plugins to transform the MDAST               |
+| `rehypePlugins` | `[]`    | Rehype plugins to transform the HAST                |
+| `babelPlugins`  | `[]`    | Babel plugins to transform the JSX before evaluated |
+
+[Read more about plugins](https://mdxjs.com/advanced/plugins)
+
 ## Contribute
 
 See the [Support][] and [Contributing][] guidelines on the MDX website for ways

--- a/packages/runtime/src/index.js
+++ b/packages/runtime/src/index.js
@@ -1,5 +1,8 @@
 import React from 'react'
-import {transform} from 'buble'
+import {transform} from '@babel/standalone'
+import babelPluginJsx from '@babel/plugin-transform-react-jsx'
+import babelPluginSpread from '@babel/plugin-proposal-object-rest-spread'
+import babelPluginExports from 'babel-plugin-remove-export-keywords'
 import mdx from '@mdx-js/mdx'
 import {MDXProvider, mdx as createElement} from '@mdx-js/react'
 
@@ -8,6 +11,7 @@ export default ({
   components = {},
   remarkPlugins = [],
   rehypePlugins = [],
+  babelPlugins = [],
   children,
   ...props
 }) => {
@@ -28,7 +32,12 @@ export default ({
     .trim()
 
   const {code} = transform(jsx, {
-    objectAssign: 'Object.assign'
+    plugins: [
+      babelPluginJsx,
+      babelPluginSpread,
+      babelPluginExports,
+      ...babelPlugins
+    ]
   })
 
   const keys = Object.keys(fullScope)

--- a/packages/runtime/test/index.test.js
+++ b/packages/runtime/test/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {renderToString as render} from 'react-dom/server'
+import {renderToStaticMarkup as render} from 'react-dom/server'
 import slug from 'remark-slug'
 import autolinkHeadings from 'remark-autolink-headings'
 import addClasses from 'rehype-add-classes'
@@ -16,9 +16,13 @@ const scope = {
 }
 
 const mdx = `
+export const foo = 'bar'
+
 # Hello, world
 
 <Foo />
+
+<h1>Hello, from {foo}</h1>
 `
 
 const mdxLayout = `
@@ -30,7 +34,7 @@ export default ({ children, id }) => <div id={id}>{children}</div>
 `
 
 describe('renders MDX with the proper components', () => {
-  it('default layout', () => {
+  it('defaults layout', () => {
     const result = render(
       <MDX components={{...components, ...scope}} children={mdx} />
     )
@@ -39,7 +43,7 @@ describe('renders MDX with the proper components', () => {
     expect(result).toMatch(/Foobarbaz/)
   })
 
-  it('custom layout', () => {
+  it('allows a custom layout', () => {
     const result = render(
       <MDX
         components={{...components, ...scope}}
@@ -51,6 +55,14 @@ describe('renders MDX with the proper components', () => {
     expect(result).toMatch(/style="color:tomato"/)
     expect(result).toMatch(/Foobarbaz/)
     expect(result).toMatch(/id="layout"/)
+  })
+
+  it('removes export keywords', () => {
+    const result = render(
+      <MDX components={{...components, ...scope}} children={mdx} />
+    )
+
+    expect(result).toMatch(/Hello, from bar/)
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,6 +1033,11 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/standalone@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.5.5.tgz#9d3143f6078ff408db694a4254bd6f03c5c33962"
+  integrity sha512-YIp5taErC4uvp4d5urJtWMui3cpvZt83x57l4oVJNvFtDzumf3pMgRmoTSpGuEzh1yzo7jHhg3mbQmMhmKPbjA==
+
 "@babel/template@^7.0.0 <7.4.0":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"


### PR DESCRIPTION
This allows us to add in additional babel plugins including a default which transforms exports into variable declarations for usage in playgrounds and other browser environments.
