### PR TITLE
Don't double escape "$" characters that are already escaped

### DIFF
--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -28,7 +28,7 @@ const paramCase = string =>
 
 const toTemplateLiteral = text => {
   const escaped = text
-    .replace(/\\[^$]/g, '\\\\') // Escape all "\" to avoid unwanted escaping in text nodes
+    .replace(/\\(?!\$)/g, '\\\\') // Escape all "\" to avoid unwanted escaping in text nodes
     // and ignore "\$" since it's already escaped and is common
     // with prettier https://github.com/mdx-js/mdx/issues/606
     .replace(/`/g, '\\`') // Escape "`"" since

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -28,7 +28,9 @@ const paramCase = string =>
 
 const toTemplateLiteral = text => {
   const escaped = text
-    .replace(/\\/g, '\\\\') // Escape all "\" to avoid unwanted escaping in text nodes
+    .replace(/\\[^$]/g, '\\\\') // Escape all "\" to avoid unwanted escaping in text nodes
+    // and ignore "\$" since it's already escaped and is common
+    // with prettier https://github.com/mdx-js/mdx/issues/606
     .replace(/`/g, '\\`') // Escape "`"" since
     .replace(/\$\{/g, '\\${') // Escape ${} in text so that it doesn't eval
 

--- a/packages/util/test/test.js
+++ b/packages/util/test/test.js
@@ -38,8 +38,14 @@ describe('isImportOrExport', () => {
 
 describe('toTemplateLiteral', () => {
   it("doesn't double escape '$'", () => {
-    const result = toTemplateLiteral('All the $')
+    const result = toTemplateLiteral('All the \$')
 
-    expect(result).toEqual('{`All the $`}')
+    expect(result).toEqual('{`All the \$`}')
+  })
+
+  it("escapes string interpolation '${'", () => {
+    const result = toTemplateLiteral('All the ${')
+
+    expect(result).toEqual('{`All the \\${`}')
   })
 })

--- a/packages/util/test/test.js
+++ b/packages/util/test/test.js
@@ -1,4 +1,4 @@
-const {paramCase, isImportOrExport} = require('..')
+const {paramCase, isImportOrExport, toTemplateLiteral} = require('..')
 
 const PARAM_CASE_FIXTURES = [
   ['ariaHidden', 'aria-hidden'],
@@ -33,5 +33,13 @@ describe('isImportOrExport', () => {
 
       expect(result).toBeTruthy()
     })
+  })
+})
+
+describe('toTemplateLiteral', () => {
+  it("doesn't double escape '$'", () => {
+    const result = toTemplateLiteral('All the $')
+
+    expect(result).toEqual('{`All the $`}')
   })
 })

--- a/packages/util/test/test.js
+++ b/packages/util/test/test.js
@@ -38,14 +38,16 @@ describe('isImportOrExport', () => {
 
 describe('toTemplateLiteral', () => {
   it("doesn't double escape '$'", () => {
+    // eslint-disable-next-line
     const result = toTemplateLiteral('All the \$')
 
-    expect(result).toEqual('{`All the \$`}')
+    expect(result).toEqual('{`All the $`}')
   })
 
   it("escapes string interpolation '${'", () => {
     const result = toTemplateLiteral('All the ${')
 
+    // eslint-disable-next-line
     expect(result).toEqual('{`All the \\${`}')
   })
 })


### PR DESCRIPTION
Prettier escapes all "$" characters that aren't used for
inline math. This ensures MDX doesn't double escape the
"\$", otherwise "\$" ends up rendered in the document.

Closes #606
