### PR TITLE
Transpile gatsby-plugin-mdx with Babel for theme

### DIFF
--- a/packages/gatsby-theme-mdx/gatsby-config.js
+++ b/packages/gatsby-theme-mdx/gatsby-config.js
@@ -35,7 +35,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-compile-es6-packages',
       options: {
-        modules: ['gatsby-theme-mdx']
+        modules: ['gatsby-theme-mdx', 'gatsby-plugin-mdx']
       }
     },
     {


### PR DESCRIPTION
Unclear whether this is a steadfast solution or a patch for the issue of
having ES6+ code in a npm dependency, but for now it allows the docs
site to be run locally.

Ref: https://github.com/gatsbyjs/gatsby/issues/3780
Ref: https://github.com/mdx-js/mdx/issues/542

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
