### PR TITLE
Fix and improve suggested types

### DIFF
--- a/docs/advanced/typescript.mdx
+++ b/docs/advanced/typescript.mdx
@@ -8,14 +8,44 @@ Where could it go?
 Below are some basic typings to get started with:
 
 ```tsx
-declare module "@mdx-js/react" {
-  import { ComponentType, StyleHTMLAttributes } from "react"
+declare module '@mdx-js/react' {
+  import * as React from 'react'
 
-  type MDXProps = {
-    children: React.ReactNode
-    components: { wrapper: React.ReactNode }
+  type ComponentType =
+    | 'p'
+    | 'h1'
+    | 'h2'
+    | 'h3'
+    | 'h4'
+    | 'h5'
+    | 'h6'
+    | 'thematicBreak'
+    | 'blockquote'
+    | 'ul'
+    | 'ol'
+    | 'li'
+    | 'table'
+    | 'tr'
+    | 'td'
+    | 'pre'
+    | 'code'
+    | 'em'
+    | 'strong'
+    | 'delete'
+    | 'inlineCode'
+    | 'hr'
+    | 'a'
+    | 'img'
+
+  export type Components = {
+    [key in ComponentType]?: React.ComponentType<{ children: React.ReactNode }>
   }
-  export class MDXProvider extends React.Component<MDXProps> {}
+
+  export interface MDXProviderProps {
+    children: React.ReactNode
+    components: Components
+  }
+  export class MDXProvider extends React.Component<MDXProviderProps> {}
 }
 ```
 
@@ -31,7 +61,7 @@ inside your `tsconfig.json`.
 ```tsx
 // types/mdx.d.ts
 declare module '*.mdx' {
-  let MDXComponent: (props) => JSX.Element;
-  export default MDXComponent;
+  let MDXComponent: (props: any) => JSX.Element
+  export default MDXComponent
 }
 ```


### PR DESCRIPTION
The previous type suggestions were broken and did not work, further their was no restriction on elements provided.  Used https://mdxjs.com/getting-started#table-of-components to restrict `components` and exported types for reuse/composition.

This could be the basis for in-repo types, but I suggest not accepting types in-repo unless it is accompanied by tests to exercise usage (and I don't have time to add, sorry).