### PR TITLE
Don't parse ES syntax in open blocks

### DIFF
--- a/packages/mdx/test/fixtures/imports.mdx
+++ b/packages/mdx/test/fixtures/imports.mdx
@@ -1,0 +1,4 @@
+Hello, world!
+
+- import is a word
+- export is a word in lists, too!

--- a/packages/mdx/test/fixtures/imports.mdx
+++ b/packages/mdx/test/fixtures/imports.mdx
@@ -1,4 +1,6 @@
 Hello, world!
 
+import is a word
+
 - import is a word
 - export is a word in lists, too!

--- a/packages/mdx/test/render.test.js
+++ b/packages/mdx/test/render.test.js
@@ -9,6 +9,9 @@ const EXPORT_SHORTCODE_FIXTURE = fs.readFileSync(
 const PONYLANG_FIXTURE = fs.readFileSync(
   path.join(__dirname, './fixtures/ponylang.mdx')
 )
+const IMPORT_FIXTURE = fs.readFileSync(
+  path.join(__dirname, './fixtures/imports.mdx')
+)
 
 const components = {
   h1: ({children}) =>
@@ -54,4 +57,11 @@ it('turns a newline into a space with other adjacent phrasing content', async ()
   `)
 
   expect(result).toContain('<em>foo</em>\n<code>bar</code>')
+})
+
+it('ignores escaped import wording', async () => {
+  const result = await renderWithReact(IMPORT_FIXTURE)
+
+  expect(result).toContain('<li>import')
+  expect(result).toContain('<li>export')
 })

--- a/packages/mdx/test/render.test.js
+++ b/packages/mdx/test/render.test.js
@@ -62,6 +62,7 @@ it('turns a newline into a space with other adjacent phrasing content', async ()
 it('ignores escaped import wording', async () => {
   const result = await renderWithReact(IMPORT_FIXTURE)
 
+  expect(result).toContain('<p>import')
   expect(result).toContain('<li>import')
   expect(result).toContain('<li>export')
 })

--- a/packages/remark-mdx/index.js
+++ b/packages/remark-mdx/index.js
@@ -37,6 +37,8 @@ function attachParser(parser) {
   blocks.html = wrap(block)
   inlines.html = wrap(inlines.html, inlineJsx)
 
+  tokenizeEsSyntax.notInBlock = true
+
   methods.splice(methods.indexOf('paragraph'), 0, 'esSyntax')
 
   function wrap(original, customTokenizer) {

--- a/packages/remark-mdx/index.js
+++ b/packages/remark-mdx/index.js
@@ -102,8 +102,10 @@ function tokenizeEsSyntax(eat, value) {
   const subvalue = index !== -1 ? value.slice(0, index) : value
 
   if (isImportOrExport(subvalue)) {
-    const nodes = extractImportsAndExports(subvalue, this.file)
-    nodes.map(node => eat(node.value)(node))
+    try {
+      const nodes = extractImportsAndExports(subvalue, this.file)
+      nodes.map(node => eat(node.value)(node))
+    } catch (e) {}
   }
 }
 


### PR DESCRIPTION
When a block is open, such as a list or blockquote,
we shouldn't attempt to parse import/export syntax.

Additionally, if a paragraph begins with import/export
and doesn't parse, we now make it a raw paragraph
node.

Related gatsbyjs/gatsby#17315