### PR TITLE
Revert babel error catch during import parsing

### DIFF
--- a/packages/mdx/test/fixtures/imports.mdx
+++ b/packages/mdx/test/fixtures/imports.mdx
@@ -1,6 +1,4 @@
 Hello, world!
 
-import is a word
-
 - import is a word
 - export is a word in lists, too!

--- a/packages/mdx/test/render.test.js
+++ b/packages/mdx/test/render.test.js
@@ -62,7 +62,6 @@ it('turns a newline into a space with other adjacent phrasing content', async ()
 it('ignores escaped import wording', async () => {
   const result = await renderWithReact(IMPORT_FIXTURE)
 
-  expect(result).toContain('<p>import')
   expect(result).toContain('<li>import')
   expect(result).toContain('<li>export')
 })

--- a/packages/remark-mdx/index.js
+++ b/packages/remark-mdx/index.js
@@ -102,10 +102,8 @@ function tokenizeEsSyntax(eat, value) {
   const subvalue = index !== -1 ? value.slice(0, index) : value
 
   if (isImportOrExport(subvalue)) {
-    try {
-      const nodes = extractImportsAndExports(subvalue, this.file)
-      nodes.map(node => eat(node.value)(node))
-    } catch (e) {}
+    const nodes = extractImportsAndExports(subvalue, this.file)
+    nodes.map(node => eat(node.value)(node))
   }
 }
 


### PR DESCRIPTION
This also catches valid errors like duplicate imports
so for now we shouldn't catch these.

Related #763