### PR TITLE
Adds @babel/core to the peer dependencies

### DIFF
--- a/packages/babel-plugin-apply-mdx-type-props/package.json
+++ b/packages/babel-plugin-apply-mdx-type-props/package.json
@@ -27,6 +27,9 @@
     "@babel/helper-plugin-utils": "7.0.0",
     "@mdx-js/util": "^1.4.4"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
`@babel/core` is used here:

https://github.com/mdx-js/mdx/blob/master/packages/babel-plugin-apply-mdx-type-props/index.js#L1

That said, I think the dependency could be removed if you were using something like that instead:

```js
const {types: t} = api;
```

Cf here for an example:

https://github.com/arcanis/babel-plugin-lazy-import/blob/master/index.js#L15