### PR TITLE
Preserve metastring language from codeblocks

### DIFF
--- a/packages/mdx/mdx-ast-to-mdx-hast.js
+++ b/packages/mdx/mdx-ast-to-mdx-hast.js
@@ -48,7 +48,12 @@ function mdxAstToMdxHast() {
 
         if (meta) {
           Object.keys(meta).forEach(key => {
-            props[key] = meta[key]
+            const isClassKey = key === 'class' || key === 'className'
+            if (props.className && isClassKey) {
+              props.className.push(meta[key])
+            } else {
+              props[key] = meta[key]
+            }
           })
         }
 

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -127,6 +127,18 @@ COPY start.sh /home/start.sh
   )
 })
 
+it('Should preserve lang className in code blocks', async () => {
+  const result = await mdx(
+    `
+\`\`\`js class=foo
+console.log(1)
+\`\`\`
+    `
+  )
+
+  expect(dropWhitespace(result)).toContain(`"className": "language-js foo"`)
+})
+
 it('Should support comments', async () => {
   const resultWithWhitespace = await mdx(`
 <!-- a Markdown comment -->


### PR DESCRIPTION
If there is a class arg in the metastring:
````
```js class=foo
```
````
`className="language-js"` is being replaced with `className="foo"`.

This PR adds the class to the list instead of replacing it: `className="language-js foo"`