### PR TITLE
ci: update setup node action, add cross platform testing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.js   text eol=lf
+*.json text eol=lf
+*.jsx  text eol=lf
+*.md   text eol=lf
+*.mdx  text eol=lf
+*.ts   text eol=lf
+*.tsx  text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,34 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  all:
+  build-and-test:
+    name: 'Build on ${{ matrix.platform }} with node.js ${{ matrix.node-version }}'
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [10, 12]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Set up Node.js
+        uses: actions/setup-node@master
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+        name: Install
+      - run: yarn bootstrap
+        name: Bootstrap
+      - run: yarn test
+        name: Test
+  build-and-deploy:
     name: Build test and deploy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          version: 10.x
+          node-version: 10.x
           registry-url: https://registry.npmjs.org/
       - run: yarn
         name: Install


### PR DESCRIPTION
resolves
```
Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use node-version instead
```

warning

---

adds cross platform CI to github actions workflow.
