### PR TITLE
Fix remark-mdx-remove-exports usage result in readme

### DIFF
--- a/packages/remark-mdx-remove-exports/readme.md
+++ b/packages/remark-mdx-remove-exports/readme.md
@@ -50,7 +50,9 @@ remark()
 Now, running `node example` yields:
 
 ```markdown
-export default props => <div {...props} />
+import { Donut } from 'rebass'
+
+import OtherThing from 'other-place'
 
 # Hello, world!
 


### PR DESCRIPTION
The usage example of the readme in 'remark-mdx-remove-exports' shows the wrong result. It shows the result of the 'remark-mdx-remove-imports' package. This PR adjusts the example result.

