### PR TITLE
Mdx renderer del working tests

### DIFF
--- a/packages/mdx/test/render.test.js
+++ b/packages/mdx/test/render.test.js
@@ -16,7 +16,9 @@ const IMPORT_FIXTURE = fs.readFileSync(
 const components = {
   h1: ({children}) =>
     React.createElement('h1', {style: {color: 'tomato'}}, children),
-  Button: () => React.createElement('button', {}, 'Hello, button!')
+  Button: () => React.createElement('button', {}, 'Hello, button!'),
+  del: ({children}) =>
+    React.createElement('del', {style: {color: 'crimson'}}, children)
 }
 
 it('renders using components from context', async () => {
@@ -64,4 +66,12 @@ it('ignores escaped import wording', async () => {
 
   expect(result).toContain('<li>import')
   expect(result).toContain('<li>export')
+})
+
+it('renders delete component from context', async () => {
+  const result = await renderWithReact(`Hello, ~~world~~ MDX!`, {components})
+
+  expect(result).toContain(
+    '<p>Hello, <del style="color:crimson">world</del> MDX!</p>'
+  )
 })

--- a/packages/react/test/fixture.js
+++ b/packages/react/test/fixture.js
@@ -9,6 +9,7 @@ export default () => (
   <wrapper>
     <h1 />
     <h2 />
+    <del />
     <Component
       components={{
         h3: props => <h3 {...props} />,

--- a/packages/react/test/test.js
+++ b/packages/react/test/test.js
@@ -7,6 +7,7 @@ import Fixture from './fixture'
 const H1 = props => <h1 style={{color: 'tomato'}} {...props} />
 const H2 = props => <h2 style={{color: 'rebeccapurple'}} {...props} />
 const CustomH2 = props => <h2 style={{color: 'papayawhip'}} {...props} />
+const CustomDelete = props => <del style={{color: 'crimson'}} {...props} />
 
 it('Should allow components to be passed via context', () => {
   const Layout = ({children}) => <div id="layout">{children}</div>
@@ -64,4 +65,15 @@ it('Should pass prop components along', () => {
   const result = renderToString(<Fixture />)
 
   expect(result).toMatch(/h3, h4/)
+})
+
+it('Should render custom del', () => {
+  const result = renderToString(
+    <MDXProvider components={{del: CustomDelete}}>
+      <Fixture />
+    </MDXProvider>
+  )
+
+  // CustomDelete is rendered
+  expect(result).toMatch(/style="color:crimson"/)
 })

--- a/packages/react/test/test.js
+++ b/packages/react/test/test.js
@@ -74,6 +74,5 @@ it('Should render custom del', () => {
     </MDXProvider>
   )
 
-  // CustomDelete is rendered
   expect(result).toMatch(/style="color:crimson"/)
 })

--- a/packages/remark-mdx-remove-exports/readme.md
+++ b/packages/remark-mdx-remove-exports/readme.md
@@ -50,9 +50,7 @@ remark()
 Now, running `node example` yields:
 
 ```markdown
-import { Donut } from 'rebass'
-
-import OtherThing from 'other-place'
+export default props => <div {...props} />
 
 # Hello, world!
 

--- a/packages/remark-mdx-remove-exports/readme.md
+++ b/packages/remark-mdx-remove-exports/readme.md
@@ -50,7 +50,9 @@ remark()
 Now, running `node example` yields:
 
 ```markdown
-export default props => <div {...props} />
+import { Donut } from 'rebass'
+
+import OtherThing from 'other-place'
 
 # Hello, world!
 


### PR DESCRIPTION
[This](https://github.com/mdx-js/mdx/issues/801) issue reported that the del is not working correctly. There were some issues in the tests created with the issue. I use this PR to proof that the del substitution is working. I don't think these tests cover any new test case so I don't think we have to merge this PR.