### PR TITLE
Fix "Edit this page on GitHub" links

### DIFF
--- a/packages/gatsby-theme-mdx/src/components/edit-link.js
+++ b/packages/gatsby-theme-mdx/src/components/edit-link.js
@@ -8,7 +8,7 @@ export default () => (
   <Location>
     {({location}) => (
       <a
-        href={base + location.pathname + '.md'}
+        href={base + location.pathname + '.mdx'}
         css={css({
           display: 'inline-block',
           color: 'inherit',


### PR DESCRIPTION
`Edit this page on GitHub` links at the bottom of all the docs articles point to `.md` files that don't exist. I quick review shows these are all `.mdx` files now.