### PR TITLE
docs: Include thead, tbody to Table of components

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -411,6 +411,8 @@ component object you pass to `MDXProvider`.
 | `ol`            | [Ordered list](https://github.com/syntax-tree/mdast#list)            | `1.`                                                |
 | `li`            | [List item](https://github.com/syntax-tree/mdast#listitem)           |                                                     |
 | `table`         | [Table](https://github.com/syntax-tree/mdast#table)                  |                                                     |
+| `thead`         | [Table head](https://github.com/syntax-tree/mdast#table)             |                                                     |
+| `tbody`         | [Table body](https://github.com/syntax-tree/mdast#table)             |                                                     |
 | `tr`            | [Table row](https://github.com/syntax-tree/mdast#tablerow)           |                                                     |
 | `td`/`th`       | [Table cell](https://github.com/syntax-tree/mdast#tablecell)         |                                                     |
 | `pre`           | [Pre](https://github.com/syntax-tree/mdast#code)                     |                                                     |


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

Add Table's `thead` and `tbody` to the "Table of components" section of Getting Started doc page.
