### PR TITLE
fix: remove unnecessary cli option npm-client for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .js,.md,.mdx",
     "prepublish": "lerna run prepublish",
     "publish": "lerna publish --force-publish=\"*\"",
-    "publish-ci": "lerna publish -y --canary --preid ci --npm-tag ci --npm-client npm",
+    "publish-ci": "lerna publish -y --canary --preid ci --npm-tag ci",
     "publish-next": "lerna publish --npm-tag next --preid rc --force-publish=\"*\"",
     "test": "lerna run test && yarn lint"
   },


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

`npm-client` option is useless for `lerna publish` and causes [CI error](https://circleci.com/gh/mdx-js/mdx/1491?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).