### PR TITLE
doc(readme) fix react package example

### DIFF
--- a/packages/react/readme.md
+++ b/packages/react/readme.md
@@ -16,19 +16,24 @@ npm install --save @mdx-js/react
 ```
 
 ## Usage
+```md
+// helloworld.md
+# Hello, World!
+```
 
 ```jsx
-/* @jsx mdx */
 import React from 'react'
-import {renderToString} from 'react-dom/server'
-import {MDXProvider, mdx} from '@mdx-js/react'
+import { MDXProvider } from '@mdx-js/react'
+import { renderToString } from 'react-dom/server'
+
+import HelloWorld from './helloworld.md'
 
 const H1 = props => <h1 style={{color: 'tomato'}} {...props} />
 
 console.log(
   renderToString(
     <MDXProvider components={{ h1: H1 }}>
-      <h1>Hello, world!</h1>
+      <HelloWorld />
     </MDXProvider>
   )
 )


### PR DESCRIPTION
MDXProvider is waiting for Markdown inside. Not HTML.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
