### PR TITLE
Ignore cache dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   },
   "jest": {
     "testPathIgnorePatterns": [
+      "/.cache/",
       "<rootDir>/examples/create-react-app",
       "<rootDir>/packages/vue",
       "<rootDir>/packages/vue-loader"


### PR DESCRIPTION
It's possible for some tests to end up in
the example cache directory which is then
picked up by jest. This explicitly ignores
those directories while a fix is made
upstream.