### PR TITLE
Add support for export * statements in remark-mdx

### DIFF
--- a/packages/remark-mdx/extract-imports-and-exports.js
+++ b/packages/remark-mdx/extract-imports-and-exports.js
@@ -22,6 +22,10 @@ class BabelPluginExtractImportsAndExports {
             const {start} = path.node
             nodes.push({type: 'export', start})
           },
+          ExportAllDeclaration(path) {
+            const {start} = path.node
+            nodes.push({type: 'export', start})
+          },
           ImportDeclaration(path) {
             const {start} = path.node
 

--- a/packages/remark-mdx/test/__snapshots__/import-export.test.js.snap
+++ b/packages/remark-mdx/test/__snapshots__/import-export.test.js.snap
@@ -35,6 +35,17 @@ Array [
 ]
 `;
 
+exports[`Handles export all 1`] = `
+Array [
+  Object {
+    "type": "export",
+    "value": Array [
+      "export * from './foo'",
+    ],
+  },
+]
+`;
+
 exports[`Handles multiline default exports 1`] = `
 Array [
   Object {

--- a/packages/remark-mdx/test/fixtures/import-export.js
+++ b/packages/remark-mdx/test/fixtures/import-export.js
@@ -25,5 +25,9 @@ module.exports = [
   {
     description: 'Handles multiline default exports',
     mdx: ['export default props => (', '  <main {...props} />', ')'].join('\n')
+  },
+  {
+    description: 'Handles export all',
+    mdx: ["export * from './foo'"]
   }
 ]


### PR DESCRIPTION
## Scope

Adds the ability to use an `export *` statement inside an mdx file. 

## Context

While working https://github.com/hashicorp/next-mdx-enhanced/pull/37 I kept getting these remark eat errors. 

```
Incorrectly eaten value: please report this warning on https://git.io/vg5Ft
```

Thanks to the playground I traced it down to the export statement I added to the above PR:

```
export * from 'blah'
```

Check out the above PR link for details about why I was trying to add this.