### PR TITLE
Ensure compiling hast doesn't fail if path contains export

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -72,7 +72,7 @@ function toJSX(node, parentNode = {}, options = {}) {
 
     const exportNames = exportNodes
       .map(node =>
-        node.value.match(/export\s*(var|const|let|class|function)?\s*(\w+)/)
+        node.value.match(/^export\s*(var|const|let|class|function)?\s*(\w+)/)
       )
       .map(match => (Array.isArray(match) ? match[2] : null))
       .filter(Boolean)


### PR DESCRIPTION
Okay, so this one threw me for a hell of a loop. 

I was writing a test for another plugin that wraps mdx loader and it kept inexplicably failing. I went as far as copying a passing test from somewhere else and it was _still_ failing. 

The error was pretty mysterious too:

```
ReferenceError: s is not defined

      292 | 
      293 | const layoutProps = {
    > 294 |   s
          |   ^
      295 | };
      296 | const MDXLayout = docs_page({
      297 |   layout: 'docs-page',
```

Turns out, in `mdx-hast-to-jsx.js`, the calculation of `exportNames` will fail if there is a directory named `export` in the exported file path. Since my test directory was called `layouts-exports-ssg` it caused layoutProps to output garbage because the regex had a miss-match. 

You can check the regex here: https://regexr.com/4sar8