### PR TITLE
feat: added tw icon to menu and sidebar; optimised search's css

### DIFF
--- a/packages/gatsby-theme-mdx/src/components/buttons.js
+++ b/packages/gatsby-theme-mdx/src/components/buttons.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import {css} from 'theme-ui'
+
+export const GithubButton = ({dark, customCss}) => (
+  <a
+    href="https://github.com/mdx-js/mdx"
+    css={css({
+      display: 'flex',
+      alignItems: 'center',
+      p: 2,
+      color: 'inherit',
+      ...customCss
+    })}
+  >
+    <img
+      src={`https://icon.now.sh/github/24/${dark ? 'fff' : '000'}`}
+      alt="GitHub logo"
+    />
+  </a>
+)
+
+export const TwitterButton = ({dark, customCss}) => (
+  <a
+    href="https://twitter.com/mdx_js"
+    css={css({
+      display: 'flex',
+      alignItems: 'center',
+      p: 2,
+      color: 'inherit',
+      ...customCss
+    })}
+  >
+    <img
+      src={`https://icon.now.sh/twitter/24/${dark ? 'fff' : '000'}`}
+      alt="Twitter logo"
+    />
+  </a>
+)

--- a/packages/gatsby-theme-mdx/src/components/dark-toggle.js
+++ b/packages/gatsby-theme-mdx/src/components/dark-toggle.js
@@ -14,7 +14,7 @@ export default ({dark, setDark, ...props}) => (
       border: 0,
       borderRadius: 99999,
       mr: 2,
-      p: 1,
+      p: 2,
       '&:focus': {
         outline: 'none',
         boxShadow: '0 0 0 2px'

--- a/packages/gatsby-theme-mdx/src/components/header.js
+++ b/packages/gatsby-theme-mdx/src/components/header.js
@@ -6,6 +6,7 @@ import Burger from './burger'
 import theme from './theme'
 import DarkToggle from './dark-toggle'
 import Search from './search'
+import {GithubButton, TwitterButton} from './buttons'
 
 const MenuButton = props => (
   <button
@@ -64,26 +65,23 @@ export default ({toggleMenu, dark, setDark}) => (
       css={{
         display: 'none',
         [theme.mediaQueries.big]: {
-          display: 'inline'
+          display: 'inline',
+          padding: '8px'
         }
       }}
     >
       v{pkg.version}
     </span>
-    <a
-      href="https://github.com/mdx-js/mdx"
-      css={css({
-        display: 'flex',
-        alignItems: 'center',
-        p: 3,
-        color: 'inherit'
-      })}
-    >
-      <img
-        src={`https://icon.now.sh/github/24/${dark ? 'fff' : '000'}`}
-        alt="GitHub logo"
-      />
-    </a>
+    <GithubButton dark={dark} />
+    <TwitterButton
+      dark={dark}
+      customCss={{
+        display: 'none',
+        [theme.mediaQueries.big]: {
+          display: 'flex'
+        }
+      }}
+    />
     <DarkToggle dark={dark} setDark={setDark} />
     <MenuButton
       onClick={toggleMenu}

--- a/packages/gatsby-theme-mdx/src/components/layout.js
+++ b/packages/gatsby-theme-mdx/src/components/layout.js
@@ -8,6 +8,7 @@ import Header from './header'
 import Pagination from './pagination'
 import EditLink from './edit-link'
 import {SkipNavLink, SkipNavContent} from './skip-nav'
+import {GithubButton, TwitterButton} from './buttons'
 import baseTheme from './theme'
 
 const styles = (
@@ -172,6 +173,15 @@ export default props => {
           <Main>
             <Sidebar onClick={closeMenu} open={menuOpen}>
               <SidebarContent />
+              <div
+                css={css({
+                  display: 'flex',
+                  pl: 16
+                })}
+              >
+                <GithubButton dark={dark} />
+                <TwitterButton dark={dark} />
+              </div>
             </Sidebar>
             <Container className="searchable-content">
               <SkipNavContent />

--- a/packages/gatsby-theme-mdx/src/components/search.js
+++ b/packages/gatsby-theme-mdx/src/components/search.js
@@ -24,20 +24,21 @@ const styles = theme =>
       display: 'flex',
       alignItems: 'center',
       // <3 CSS
-      '.algolia-autocomplete': {
-        '@media screen and (min-width:40em)': {
-          width: '500px'
-        },
-        '.ds-dropdown-menu': {
-          '@media screen and (max-width:40em)': {
+      [theme.mediaQueries.big]: {
+        '.algolia-autocomplete': {
+          width: '450px'
+        }
+      },
+      [theme.mediaQueries.maxBig]: {
+        '.algolia-autocomplete.algolia-autocomplete-left': {
+          '.ds-dropdown-menu': {
             position: 'fixed',
-            top: '128px',
-            right: 0,
-            bottom: 0,
-            left: 0,
-            margin: 16,
-            minWidth: 'calc(100vw - 32px)',
-            backgroundColor: 'white'
+            top: '60px',
+            right: '0px',
+            bottom: '0px',
+            margin: '5px',
+            minWidth: 'calc(100vw - 20px)',
+            maxWidth: 'calc(100vw - 20px)'
           }
         }
       }

--- a/packages/gatsby-theme-mdx/src/components/theme.js
+++ b/packages/gatsby-theme-mdx/src/components/theme.js
@@ -32,7 +32,8 @@ export default {
     monospace: '"Roboto Mono", Menlo, monospace'
   },
   mediaQueries: {
-    big: '@media screen and (min-width: 40em)'
+    big: '@media screen and (min-width: 48em)',
+    maxBig: '@media screen and (max-width: 47.9em)'
   },
   styles: {
     h1: {


### PR DESCRIPTION
# Twitter Button & Header improvements

> (...) please try to limit the scope (...)

Hopefully, updating the Header and Search is still in the scope of adding the Twitter Button from your point of view. Let's see. :)

Resolves #945 

## Twitter Button

### Twitter Button in the Header (previous top - new bottom)

![image](https://user-images.githubusercontent.com/1043668/74475415-adc38b80-4ea7-11ea-8413-f6c6eaa49b56.png)

### Twitter and GitHub button in the Sidebar (previous left - new right)

![image](https://user-images.githubusercontent.com/1043668/74475471-c92e9680-4ea7-11ea-9384-1463970639b2.png)

## Search Updates (previous left - now right)

Due to the new Twitter button in the Header, I had to improve (fix) the css of the Search component as well.

### Increased `em` in the existing Media Query

```diff
mediaQueries: {
-	big: '@media screen and (min-width: 40em)'
+   big: '@media screen and (min-width: 48em)',
+   maxBig: '@media screen and (max-width: 47.9em)'
}
```

This resolves issues on smaller devices (eg. iPhone 5 or iPad):

- DarkToggle button was not visible, due to the width of the Search input
- menu is not rendered, but can be opened with a click on the burger button

![image](https://user-images.githubusercontent.com/1043668/74474776-743e5080-4ea6-11ea-8232-95e469ab363f.png)

![image](https://user-images.githubusercontent.com/1043668/74475216-4a395e00-4ea7-11ea-93a0-f4e60a7ba111.png)

![image](https://user-images.githubusercontent.com/1043668/74475269-63420f00-4ea7-11ea-9308-0a53af40651d.png)

## References

- [Tweet about adding Twitter to the header](https://twitter.com/4lpine/status/1227685644954062849)
