### PR TITLE
process content before and after mdx compile 

### DIFF
--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -12,7 +12,12 @@ const loader = async function(content) {
     filepath: this.resourcePath
   })
 
-  const {renderer = DEFAULT_RENDERER, header, footer} = options
+  const {
+    renderer = DEFAULT_RENDERER,
+    header,
+    footer,
+    defaultExport = true
+  } = options
 
   let headerCode = ''
   if (header) {
@@ -40,6 +45,12 @@ const loader = async function(content) {
 
   try {
     result = await mdx(`${headerCode}${content}`, options)
+    if (!defaultExport) {
+      result = result.replace(
+        'export default function MDXContent',
+        'export function MDXContent'
+      )
+    }
   } catch (err) {
     return callback(err)
   }

--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -21,8 +21,12 @@ const loader = async function(content) {
   }
 
   const {renderer = DEFAULT_RENDERER} = options
+  const {header = ''} = options
+  const {footer = ''} = options
 
-  const code = `${renderer}\n${result}`
+  const code = `${header ? header + '\n' : ''}${renderer}\n${result}${
+    footer ? '\n' + footer : ''
+  }`
   return callback(null, code)
 }
 

--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -12,17 +12,7 @@ const loader = async function(content) {
     filepath: this.resourcePath
   })
 
-  let result
-
-  try {
-    result = await mdx(content, options)
-  } catch (err) {
-    return callback(err)
-  }
-
-  const {renderer = DEFAULT_RENDERER} = options
-  const {header} = options
-  const {footer} = options
+  const {renderer = DEFAULT_RENDERER, header, footer} = options
 
   let headerCode = ''
   if (header) {
@@ -46,7 +36,15 @@ const loader = async function(content) {
     }
   }
 
-  const code = `${renderer}\n${headerCode}${result}${footerCode}`
+  let result
+
+  try {
+    result = await mdx(`${headerCode}${content}`, options)
+  } catch (err) {
+    return callback(err)
+  }
+
+  const code = `${renderer}\n${result}${footerCode}`
   return callback(null, code)
 }
 

--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -21,12 +21,32 @@ const loader = async function(content) {
   }
 
   const {renderer = DEFAULT_RENDERER} = options
-  const {header = ''} = options
-  const {footer = ''} = options
+  const {header} = options
+  const {footer} = options
 
-  const code = `${header ? header + '\n' : ''}${renderer}\n${result}${
-    footer ? '\n' + footer : ''
-  }`
+  let headerCode = ''
+  if (header) {
+    if (typeof header === 'string') {
+      headerCode = `${header}\n`
+    } else if (typeof header === 'function') {
+      headerCode = `${await header(options.filepath)}\n`
+    } else {
+      return callback(new Error('header option must be a string or a function'))
+    }
+  }
+
+  let footerCode = ''
+  if (footer) {
+    if (typeof footer === 'string') {
+      footerCode = `\n${footer}`
+    } else if (typeof footer === 'function') {
+      footerCode = `\n${await footer(options.filepath)}`
+    } else {
+      return callback(new Error('footer option must be a string or a function'))
+    }
+  }
+
+  const code = `${headerCode}${renderer}\n${result}${footerCode}`
   return callback(null, code)
 }
 

--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -46,7 +46,7 @@ const loader = async function(content) {
     }
   }
 
-  const code = `${headerCode}${renderer}\n${result}${footerCode}`
+  const code = `${renderer}\n${headerCode}${result}${footerCode}`
   return callback(null, code)
 }
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

add the `beforeCompile` and `afterCompile` option for injecting code when building.

```js
const injection = require('./lib/next/mdxInjection');
const withMDX = require('@foxmn/next-mdx')({
  extension: /\.mdx?$/,	  extension: /\.mdx?$/,
  options: {	  
      rehypePlugins: [rehypePrism],
      beforeCompile: injection.beforeCompile,
      afterCompile: injection.afterCompile,
});
```
## exampe  
- add common header and footer code
https://github.com/WeFoxTech/website/pull/8

```js
const fs = require('fs');
const path = require('path');

async function readMdxLib(name) {
  const fpath = path.join(__dirname, '..', 'mdx', name);
  const content = await fs.promises.readFile(fpath, { encoding: 'utf8' });
  return content;
}

const beforeCompile = async (path, content) => {
  if (/\/website\/pages\//.test(path)) {
    const header = await readMdxLib('pagesHeader.js');
    return `${header}\n${content}`;
  }
  return content;
};
const afterCompile = async (path, content) => {
  if (/\/website\/pages\//.test(path)) {
    const footer = await readMdxLib('pagesFooter.js');
    content = content.replace(/export default function MDXContent/, 'export function MDXContent');
    return `${content}\n${footer}`;
  }
  return content;
};

module.exports = {
  beforeCompile,
  afterCompile,
};
```

