### PR TITLE
docs: add temporary link of reference

### DIFF
--- a/docs/guides/table-of-contents.mdx
+++ b/docs/guides/table-of-contents.mdx
@@ -3,3 +3,5 @@ import Note from 'gatsby-theme-mdx/src/components/note'
 # Table of contents
 
 <Note>This guide is a WIP</Note>
+
+You can refer this [table of contents](https://mdxjs.com/getting-started#table-of-components) as of now.


### PR DESCRIPTION
Added a temporary link to refer table of components on the getting-started page. Since I am always forgetting where the list exists