### PR TITLE
fix: not evaluate code block starting with \$

### DIFF
--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -32,6 +32,8 @@ const toTemplateLiteral = text => {
     // and ignore "\$" since it's already escaped and is common
     // with prettier https://github.com/mdx-js/mdx/issues/606
     .replace(/`/g, '\\`') // Escape "`"" since
+    .replace(/(\\\$)/g, '\\$1') // Escape \$ so render it as it is
+    .replace(/(\\\$)(\{)/g, '\\$1\\$2') // Escape \${} so render it as it is
     .replace(/\$\{/g, '\\${') // Escape ${} in text so that it doesn't eval
 
   return '{`' + escaped + '`}'

--- a/packages/util/test/test.js
+++ b/packages/util/test/test.js
@@ -44,4 +44,22 @@ describe('toTemplateLiteral', () => {
     // eslint-disable-next-line no-template-curly-in-string
     expect(result).toEqual('{`All the \\${`}')
   })
+
+  it("escapes string with slash in front of '${' so that it is not evaluated", () => {
+    const originalString = String.raw`Hello \${world}`
+    const result = toTemplateLiteral(originalString)
+
+    expect(result).toEqual('{`Hello \\\\\\$\\{world}`}')
+    // eslint-disable-next-line no-eval
+    expect(originalString).toEqual(eval(result))
+  })
+
+  it("escapes string with slash in front of '$' so that it is not evaluated", () => {
+    const originalString = String.raw`My vars $foo\$bar`
+    const result = toTemplateLiteral(originalString)
+
+    expect(result).toEqual('{`My vars $foo\\\\$bar`}')
+    // eslint-disable-next-line no-eval
+    expect(originalString).toEqual(eval(result))
+  })
 })


### PR DESCRIPTION
_Probably_ fixes #902

For example, this code block

<pre><code>```
python command subdir=\${model.nb_layers}
```
</code></pre>

Produces:

Before:

```
<pre><code parentName="pre" {...{}}>{`python command subdir=\\${model.nb_layers}
      `}</code></pre>
```

-> Uncaught ReferenceError: model is not defined

After:

```
<pre><code parentName="pre" {...{}}>{`python command subdir=\\\$\{model.nb_layers}
      `}</code></pre>
```

-> `python command subdir=\${model.nb_layers}` (same as input)

* * *

Another example:

```
$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.' . "$here\$sut"
```

Produces:

Before:

```
<pre><code parentName="pre" {...{}}>{`$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\\.Tests\\.', '.' . "$here\$sut"
      `}</code></pre>
```

-> `$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.' . "$here$sut` (missed slash -> `$here$sut`, should be `$here\$sut`)

After:

```
<pre><code parentName="pre" {...{}}>{`$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\\.Tests\\.', '.' . "$here\\$sut"
      `}</code></pre>
```

-> `$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.' . "$here\$sut"` (same as input)



