### PR TITLE
Remove layoutProps from compiled output

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -83,15 +83,12 @@ function toJSX(node, parentNode = {}, options = {}) {
     const exportStatements = exportNodes
       .map(childNode => toJSX(childNode, node))
       .join('\n')
-    const layoutProps = `const layoutProps = {
-  ${exportNames.join(',\n')}
-};`
     const mdxLayout = `const MDXLayout = ${layout ? layout : '"wrapper"'}`
 
     const fn = `function MDXContent({ components, ...props }) {
   return (
     <MDXLayout
-      {...layoutProps}
+${exportNames.map(name => `      ${name}={${name}}`).join('\n')}
       {...props}
       components={components}>
 ${jsxNodes.map(childNode => toJSX(childNode, node)).join('')}
@@ -157,7 +154,6 @@ MDXContent.isMDXComponent = true`
     const moduleBase = `${importStatements}
 ${exportStatementsPostMdxTypeProps}
 ${fakedModulesForGlobalScope}
-${layoutProps}
 ${mdxLayout}`
 
     if (skipExport) {

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -54,16 +54,10 @@ it('Should match sample blog post snapshot', async () => {
                 return <div {...props} />;
               };
 
-            const layoutProps = {};
             const MDXLayout = \\"wrapper\\";
             export default function MDXContent({ components, ...props }) {
               return (
-                <MDXLayout
-                  {...layoutProps}
-                  {...props}
-                  components={components}
-                  mdxType=\\"MDXLayout\\"
-                >
+                <MDXLayout {...props} components={components} mdxType=\\"MDXLayout\\">
                   <h1>{\`Hello World\`}</h1>
                 </MDXLayout>
               );
@@ -338,15 +332,12 @@ test('Should handle layout props', () => {
     };
     const Foo = makeShortcode(\\"Foo\\");
     const Bar = makeShortcode(\\"Bar\\");
-    const layoutProps = {
-      foo
-    };
     const MDXLayout = ({children}) => <div>{children}</div>
     export default function MDXContent({
       components,
       ...props
     }) {
-      return <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
+      return <MDXLayout foo={foo} {...props} components={components} mdxType=\\"MDXLayout\\">
 
 
         <h1>{\`Hello, world!\`}</h1>

--- a/packages/remark-mdx/test/__snapshots__/test.js.snap
+++ b/packages/remark-mdx/test/__snapshots__/test.js.snap
@@ -11,15 +11,12 @@ const makeShortcode = name => function MDXDefaultShortcode(props) {
 const Baz = makeShortcode(\\"Baz\\");
 const Paragraph = makeShortcode(\\"Paragraph\\");
 const Button = makeShortcode(\\"Button\\");
-const layoutProps = {
-  
-};
 const MDXLayout = Foo
 export default function MDXContent({
   components,
   ...props
 }) {
-  return <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
+  return <MDXLayout {...props} components={components} mdxType=\\"MDXLayout\\">
 
 
 


### PR DESCRIPTION
There is no need to collect exports into `layoutProps` just to spread it in the layout component, these variables are already in scope so we can just add them directly.

Unfortunately, this doesn't fix the Next.js issue outlined https://github.com/mdx-js/mdx/issues/742#issuecomment-612652071. Maybe MDX should allow providing a blacklist for certain export names, which won't get added to the layout component.

Fixes #742.