### PR TITLE
Export complete MDX unified processor

### DIFF
--- a/docs/advanced/api.mdx
+++ b/docs/advanced/api.mdx
@@ -13,6 +13,7 @@ the JSX string is created.
 
 - [Async API](#async-api)
 - [Sync API](#sync-api)
+- [Compiler](#compiler)
 
 ## Async API
 
@@ -114,6 +115,46 @@ const jsx = mdx.sync(mdxText)
 <!-- TODO: links should be updated. Can we also inline this example? -->
 
 MDX’s [runtime][] package has [example][] usage.
+
+## Compiler
+
+If you want to extract data from a MDX file, you can access the
+compiler directly:
+
+```js
+const {createCompiler} = require('@mdx-js/mdx')
+const detectFrontmatter = require('remark-frontmatter')
+const vfile = require('vfile')
+const visit = require('unist-util-visit')
+const remove = require('unist-util-remove')
+const yaml = require('yaml')
+
+const file = vfile(`
+---
+title: Hello, MDX
+---
+
+I <3 Markdown and JSX
+`)
+
+function extractFrontmatter() {
+  return function transformer(tree, file) {
+    visit(tree, 'yaml', function visitor(node) {
+      file.data.frontmatter = yaml.parse(node.value)
+    })
+    remove(tree, 'yaml')
+  }
+}
+
+mdxCompiler = createCompiler({
+  remarkPlugins: [detectFrontmatter, extractFrontmatter]
+})
+
+mdxCompiler.process(file, function done(err, file) {
+  console.log(file.data.frontmatter)
+  // { title: "Hello, MDX" }
+})
+```
 
 [ast]: /advanced/ast
 [plugins]: /plugins

--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -91,20 +91,20 @@ function applyHastPluginsAndCompilers(compiler, options) {
   return compiler
 }
 
-function createCompiler(options) {
-  const compiler = createMdxAstCompiler(options)
-  const compilerWithPlugins = applyHastPluginsAndCompilers(compiler, options)
+function createCompiler(options = {}) {
+  const opts = Object.assign({}, DEFAULT_OPTIONS, options)
+  const compiler = createMdxAstCompiler(opts)
+  const compilerWithPlugins = applyHastPluginsAndCompilers(compiler, opts)
 
   return compilerWithPlugins
 }
 
-function sync(mdx, options) {
-  const opts = Object.assign({}, DEFAULT_OPTIONS, options)
-  const compiler = createCompiler(opts)
+function sync(mdx, options = {}) {
+  const compiler = createCompiler(options)
 
   const fileOpts = {contents: mdx}
-  if (opts.filepath) {
-    fileOpts.path = opts.filepath
+  if (options.filepath) {
+    fileOpts.path = options.filepath
   }
 
   const {contents} = compiler.processSync(fileOpts)
@@ -114,12 +114,11 @@ ${contents}`
 }
 
 async function compile(mdx, options = {}) {
-  const opts = Object.assign({}, DEFAULT_OPTIONS, options)
-  const compiler = createCompiler(opts)
+  const compiler = createCompiler(options)
 
   const fileOpts = {contents: mdx}
-  if (opts.filepath) {
-    fileOpts.path = opts.filepath
+  if (options.filepath) {
+    fileOpts.path = options.filepath
   }
 
   const {contents} = await compiler.process(fileOpts)
@@ -134,4 +133,5 @@ module.exports = compile
 exports = compile
 exports.sync = sync
 exports.createMdxAstCompiler = createMdxAstCompiler
+exports.createCompiler = createCompiler
 exports.default = compile


### PR DESCRIPTION
This will allow advanced usage besides just compiling MDX string to JSX, like providing a vfile and attaching various data to it via remark and rehype plugins.