### PR TITLE
Fix API documentation example

### DIFF
--- a/docs/advanced/api.mdx
+++ b/docs/advanced/api.mdx
@@ -48,8 +48,8 @@ With more complex input, we can see more interesting output:
 ```js
 import TomatoBox from 'tomato-box'
 
-export author = "Fred Flintstone"
-export default = props => <main {...props} />
+export const author = "Fred Flintstone"
+export default props => <main {...props} />
 
 # Hello, world!
 
@@ -63,21 +63,22 @@ Here is a paragraph
 ```js
 import TomatoBox from 'tomato-box'
 
-const MDXLayout = props => <main {...props} />
+export const author = "Fred Flintstone"
 
 const layoutProps = {
-  author: 'Fred Flintstone'
-}
+  author
+};
 
-export default function MDXContent(props) {
+export default function MDXContent({
+  components,
+  ...props
+}) {
   return (
-    <div name="wrapper" components={components}>
-      <MDXLayout {...layoutProps} {...props}>
-        <h1>{`Hello, world!`}</h1>
-        <p>{`Here is a paragraph`}</p>
-        <TomatoBox />
-      </MDXLayout>
-    </div>
+    <MDXLayout {...layoutProps} {...props} components={components} mdxType="MDXLayout">
+      <h1>{`Hello, world!`}</h1>
+      <p>{`Here is a paragraph`}</p>
+      <TomatoBox mdxType="TomatoBox" />
+    </MDXLayout>
   )
 }
 


### PR DESCRIPTION
The input example was causing mdx API to fail with the current version. Additionally, I updated the output to resemble better the current output, with the user defined export in there.
