### PR TITLE
Add missing space-separated properties

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -191,10 +191,26 @@ export default ${fnPostMdxTypeProp}`
   if (node.type === 'element') {
     let props = ''
 
-    const shouldBeStrings = ['className', 'sandbox']
-
     if (node.properties) {
-      shouldBeStrings.forEach(prop => {
+      // From https://github.com/wooorm/property-information/blob/ca74feb1fcd40753367c75b63c893353cd7d8c70/lib/html.js
+      const spaceSeparated = [
+        'acceptCharset',
+        'accessKey',
+        'autoComplete',
+        'className',
+        'controlsList',
+        'headers',
+        'htmlFor',
+        'httpEquiv',
+        'itemProp',
+        'itemRef',
+        'itemType',
+        'ping',
+        'rel',
+        'sandbox',
+      ]
+
+      spaceSeparated.forEach(prop => {
         if (Array.isArray(node.properties[prop])) {
           node.properties[prop] = node.properties[prop].join(' ')
         }

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -6,6 +6,24 @@ const {paramCase, toTemplateLiteral} = require('@mdx-js/util')
 const BabelPluginApplyMdxProp = require('babel-plugin-apply-mdx-type-prop')
 const BabelPluginExtractImportNames = require('babel-plugin-extract-import-names')
 
+// From https://github.com/wooorm/property-information/blob/ca74feb1fcd40753367c75b63c893353cd7d8c70/lib/html.js
+const spaceSeparated = [
+  'acceptCharset',
+  'accessKey',
+  'autoComplete',
+  'className',
+  'controlsList',
+  'headers',
+  'htmlFor',
+  'httpEquiv',
+  'itemProp',
+  'itemRef',
+  'itemType',
+  'ping',
+  'rel',
+  'sandbox',
+]
+
 // eslint-disable-next-line complexity
 function toJSX(node, parentNode = {}, options = {}) {
   const {
@@ -192,24 +210,6 @@ export default ${fnPostMdxTypeProp}`
     let props = ''
 
     if (node.properties) {
-      // From https://github.com/wooorm/property-information/blob/ca74feb1fcd40753367c75b63c893353cd7d8c70/lib/html.js
-      const spaceSeparated = [
-        'acceptCharset',
-        'accessKey',
-        'autoComplete',
-        'className',
-        'controlsList',
-        'headers',
-        'htmlFor',
-        'httpEquiv',
-        'itemProp',
-        'itemRef',
-        'itemType',
-        'ping',
-        'rel',
-        'sandbox',
-      ]
-
       spaceSeparated.forEach(prop => {
         if (Array.isArray(node.properties[prop])) {
           node.properties[prop] = node.properties[prop].join(' ')

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -7,7 +7,7 @@ const BabelPluginApplyMdxProp = require('babel-plugin-apply-mdx-type-prop')
 const BabelPluginExtractImportNames = require('babel-plugin-extract-import-names')
 
 // From https://github.com/wooorm/property-information/blob/ca74feb1fcd40753367c75b63c893353cd7d8c70/lib/html.js
-const spaceSeparated = [
+const spaceSeparatedProperties = [
   'acceptCharset',
   'accessKey',
   'autoComplete',
@@ -210,7 +210,7 @@ export default ${fnPostMdxTypeProp}`
     let props = ''
 
     if (node.properties) {
-      spaceSeparated.forEach(prop => {
+      spaceSeparatedProperties.forEach(prop => {
         if (Array.isArray(node.properties[prop])) {
           node.properties[prop] = node.properties[prop].join(' ')
         }


### PR DESCRIPTION
`rel` arrays are being separated by commas in MDX, causing issues such as https://github.com/gatsbyjs/gatsby/issues/22719

This PR (a followup to #715 and #158) hard-codes the current full list of space-separated properties from [`property-information`](https://github.com/wooorm/property-information/blob/ca74feb1fcd40753367c75b63c893353cd7d8c70/lib/html.js). This is hard-coded because soon #1039 will land, which fixes the issue more correctly.

Ref: https://github.com/gatsbyjs/gatsby/issues/22719#issuecomment-622328980

cc @johno @wooorm 