### PR TITLE
Update @next/mdx repo link

### DIFF
--- a/docs/getting-started/next.mdx
+++ b/docs/getting-started/next.mdx
@@ -29,4 +29,4 @@ module.exports = withMDX({
 })
 ```
 
-[next-plugin]: https://github.com/zeit/next.js/tree/master/packages/next-mdx
+[next-plugin]: https://github.com/vercel/next.js/tree/canary/packages/next-mdx


### PR DESCRIPTION
I updated the link to use the default branch instead of `master` to match Next.js docs (https://raw.githubusercontent.com/vercel/next.js/canary/docs/api-reference/next.config.js/custom-page-extensions.md)