### PR TITLE
Fix npm command to start zero example

### DIFF
--- a/examples/zero/readme.md
+++ b/examples/zero/readme.md
@@ -2,7 +2,7 @@
 
 ```shell
 npm install
-npm run dev
+npm start
 ```
 
 [See documentation](https://mdxjs.com/getting-started/zero)


### PR DESCRIPTION
Because in `package.json` script, looks like we run it with start command

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
