### PR TITLE
fix: add useEffect to Web Components example

### DIFF
--- a/examples/react-web-components/src/components/WebComponent.js
+++ b/examples/react-web-components/src/components/WebComponent.js
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react'
+import React, {useRef, useEffect} from 'react'
 
 class ImperativeCounter extends HTMLElement {
   constructor() {
@@ -18,9 +18,11 @@ class ImperativeCounter extends HTMLElement {
   }
 }
 
-window.customElements.define('i-counter', ImperativeCounter)
-
 export const RenderCounter = () => {
+  useEffect(() => {
+    window.customElements.define('i-counter', ImperativeCounter)
+  }, [])
+  
   const counterElement = useRef(null)
   return (
     <div>


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

A user was confused about how to use the Web Components example on Twitter, as the call to `window` was causing issues with SSR. This PR adds useEffect to the example to prevent against it.