### PR TITLE
Pass file name to Babel transform for better errors

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -121,6 +121,7 @@ MDXContent.isMDXComponent = true`
     // Check JSX nodes against imports
     const babelPluginExtractImportNamesInstance = new BabelPluginExtractImportNames()
     transformSync(importStatements, {
+      filename: options.file.path,
       configFile: false,
       babelrc: false,
       plugins: [
@@ -135,6 +136,7 @@ MDXContent.isMDXComponent = true`
     const babelPluginApplyMdxPropToExportsInstance = new BabelPluginApplyMdxProp()
 
     const fnPostMdxTypeProp = transformSync(fn, {
+      filename: options.file.path,
       configFile: false,
       babelrc: false,
       plugins: [
@@ -145,6 +147,7 @@ MDXContent.isMDXComponent = true`
     }).code
 
     const exportStatementsPostMdxTypeProps = transformSync(exportStatements, {
+      filename: options.file.path,
       configFile: false,
       babelrc: false,
       plugins: [
@@ -250,8 +253,8 @@ export default ${fnPostMdxTypeProp}`
 }
 
 function compile(options = {}) {
-  this.Compiler = function (tree) {
-    return toJSX(tree, {}, options)
+  this.Compiler = function (tree, file) {
+    return toJSX(tree, {}, { file, ...options })
   }
 }
 

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -419,3 +419,19 @@ test('Should handle layout props', () => {
     MDXContent.isMDXComponent = true;"
   `)
 })
+
+it('Should include file name in Babel error', async () => {
+  expect(async () => {
+    await mdx(`<br>`, {filepath: '/path/to/file.mdx'})
+  }).rejects.toThrowErrorMatchingInlineSnapshot(`
+    "/path/to/file.mdx: Unterminated JSX contents (8:16)
+
+    [0m [90m  6 | [39m      components[33m=[39m{components}[33m>[39m[0m
+    [0m [90m  7 | [39m[33m<[39m[33mbr[39m[33m>[39m[0m
+    [0m[31m[1m>[22m[39m[90m  8 | [39m    [33m<[39m[33m/[39m[33mMDXLayout[39m[33m>[39m[0m
+    [0m [90m    | [39m                [31m[1m^[22m[39m[0m
+    [0m [90m  9 | [39m  )[0m
+    [0m [90m 10 | [39m}[33m;[39m[0m
+    [0m [90m 11 | [39m[33mMDXContent[39m[33m.[39misMDXComponent [33m=[39m [36mtrue[39m[0m"
+  `)
+})


### PR DESCRIPTION
Before:

```
SyntaxError: unknown: Expected corresponding JSX closing tag for <br> (12:164)
```

After:

```
SyntaxError: /Users/me/my-project/docs/index.mdx: Expected corresponding JSX closing tag for <br> (12:164)
```

https://babeljs.io/docs/en/options#filename