### PR TITLE
docs: add spaces after sentences in index

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -19,8 +19,8 @@
 ### Markdown for the component era
 
 MDX is an authorable format that lets you seamlessly write JSX in your Markdown
-documents.You can import components, such as interactive charts or alerts, and
-embed them within your content.This makes writing long-form content with
+documents. You can import components, such as interactive charts or alerts, and
+embed them within your content. This makes writing long-form content with
 components a blast :rocket:.
 
 #### Try it
@@ -59,11 +59,11 @@ during the build stage.
 ## Why?
 
 Before MDX, some of the benefits of writing Markdown were lost when integrating
-with JSX.Implementations were often template string-based which required lots
+with JSX. Implementations were often template string-based which required lots
 of escaping and cumbersome syntax.
 
 MDX seeks to make writing with Markdown _and_ JSX simpler while being more
-expressive.Writing is fun again when you combine components, that can
+expressive. Writing is fun again when you combine components, that can
 even be dynamic or load data, with the simplicity of Markdown for long-form
 content.
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

Simply fix typo in the index page of the docs where spaces were missing after sentences.