### PR TITLE
fix: `options.file` could be `undefined` error in `toJSX`

### DIFF
--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -120,8 +120,9 @@ MDXContent.isMDXComponent = true`
 
     // Check JSX nodes against imports
     const babelPluginExtractImportNamesInstance = new BabelPluginExtractImportNames()
+    let filename = (options && options.file && options.file.path)? options.file.path : ""
     transformSync(importStatements, {
-      filename: options.file.path,
+      filename,
       configFile: false,
       babelrc: false,
       plugins: [
@@ -136,7 +137,7 @@ MDXContent.isMDXComponent = true`
     const babelPluginApplyMdxPropToExportsInstance = new BabelPluginApplyMdxProp()
 
     const fnPostMdxTypeProp = transformSync(fn, {
-      filename: options.file.path,
+      filename,
       configFile: false,
       babelrc: false,
       plugins: [
@@ -147,7 +148,7 @@ MDXContent.isMDXComponent = true`
     }).code
 
     const exportStatementsPostMdxTypeProps = transformSync(exportStatements, {
-      filename: options.file.path,
+      filename,
       configFile: false,
       babelrc: false,
       plugins: [

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -120,7 +120,8 @@ MDXContent.isMDXComponent = true`
 
     // Check JSX nodes against imports
     const babelPluginExtractImportNamesInstance = new BabelPluginExtractImportNames()
-    let filename = options && options.file && options.file.path ? options.file.path : ""
+    const filename =
+      options && options.file && options.file.path ? options.file.path : ''
     transformSync(importStatements, {
       filename,
       configFile: false,

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -120,8 +120,7 @@ MDXContent.isMDXComponent = true`
 
     // Check JSX nodes against imports
     const babelPluginExtractImportNamesInstance = new BabelPluginExtractImportNames()
-    const filename =
-      options && options.file && options.file.path ? options.file.path : ''
+    const filename = options.file && options.file.path
     transformSync(importStatements, {
       filename,
       configFile: false,

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -120,7 +120,7 @@ MDXContent.isMDXComponent = true`
 
     // Check JSX nodes against imports
     const babelPluginExtractImportNamesInstance = new BabelPluginExtractImportNames()
-    let filename = (options && options.file && options.file.path)? options.file.path : ""
+    let filename = options && options.file && options.file.path ? options.file.path : ""
     transformSync(importStatements, {
       filename,
       configFile: false,


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

`toJSX` could be called outside, see [storybook](https://github.com/storybookjs/storybook/blob/next/addons/docs/src/mdx/mdx-compiler-plugin.js#L314), where `options.file` could be unavailable.