### PR TITLE
Improve export name extraction for shortcode generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,5 +134,8 @@
     "bracketSpacing": false,
     "semi": false,
     "trailingComma": "none"
+  },
+  "dependencies": {
+    "gatsby-plugin-mdx": "^1.2.27"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-prettier": "3.1.4",
     "eslint-plugin-react": "7.20.3",
     "gatsby": "2.24.3",
+    "gatsby-plugin-mdx": "^1.2.27",
     "hast-util-select": "4.0.0",
     "husky": "4.2.5",
     "jest": "26.1.0",
@@ -135,7 +136,5 @@
     "semi": false,
     "trailingComma": "none"
   },
-  "dependencies": {
-    "gatsby-plugin-mdx": "^1.2.27"
-  }
+  "dependencies": {}
 }

--- a/packages/babel-plugin-extract-export-names/index.js
+++ b/packages/babel-plugin-extract-export-names/index.js
@@ -38,7 +38,7 @@ class BabelPluginExtractExportNames {
       }
 
       const handleSpecifiers = node => {
-        const {specifiers = []} = node
+        const {specifiers} = node
 
         if (!specifiers) {
           return

--- a/packages/babel-plugin-extract-export-names/index.js
+++ b/packages/babel-plugin-extract-export-names/index.js
@@ -10,8 +10,11 @@ class BabelPluginExtractExportNames {
       const {types: t} = api
 
       const handleDeclarations = node => {
-        const {declarations} = node.declaration || {}
+        if (!node.declaration) {
+          return
+        }
 
+        const {declarations} = node.declaration
         if (!declarations) {
           return
         }

--- a/packages/babel-plugin-extract-export-names/index.js
+++ b/packages/babel-plugin-extract-export-names/index.js
@@ -1,0 +1,65 @@
+const {declare} = require('@babel/helper-plugin-utils')
+
+class BabelPluginExtractExportNames {
+  constructor() {
+    const names = []
+    this.state = {names}
+
+    this.plugin = declare(api => {
+      api.assertVersion(7)
+      const {types: t} = api
+
+      const handleDeclarations = node => {
+        const { declarations } = node.declaration || {}
+
+        if (!declarations) {
+          return
+        }
+
+        declarations.forEach(declaration => {
+          if (t.isIdentifier(declaration.id)) {
+            // export const foo = 'bar'
+            names.push(declaration.id.name)
+          } else if (t.isArrayPattern(declaration.id)) {
+            // export const [ a, b ] = []
+            declaration.id.elements.forEach(decl => {
+              names.push(decl.name)
+            })
+          } else if (t.isObjectPattern(declaration.id)) {
+            // export const { a, b } = {}
+            declaration.id.properties.forEach(decl => {
+              names.push(decl.key.name)
+            })
+          }
+        })
+      }
+
+      const handleSpecifiers = node => {
+        const { specifiers = [] } = node
+
+        if (!specifiers) {
+          return
+        }
+
+        specifiers.forEach(specifier => {
+          if (t.isExportDefaultSpecifier(specifier)) {
+            names.push(specifier.exported.name)
+          } else {
+            names.push(specifier.local.name)
+          }
+        })
+      }
+
+      return {
+        visitor: {
+          ExportNamedDeclaration(path) {
+            handleDeclarations(path.node)
+            handleSpecifiers(path.node)
+          }
+        }
+      }
+    })
+  }
+}
+
+module.exports = BabelPluginExtractExportNames

--- a/packages/babel-plugin-extract-export-names/index.js
+++ b/packages/babel-plugin-extract-export-names/index.js
@@ -10,7 +10,7 @@ class BabelPluginExtractExportNames {
       const {types: t} = api
 
       const handleDeclarations = node => {
-        const { declarations } = node.declaration || {}
+        const {declarations} = node.declaration || {}
 
         if (!declarations) {
           return
@@ -18,15 +18,15 @@ class BabelPluginExtractExportNames {
 
         declarations.forEach(declaration => {
           if (t.isIdentifier(declaration.id)) {
-            // export const foo = 'bar'
+            // Export const foo = 'bar'
             names.push(declaration.id.name)
           } else if (t.isArrayPattern(declaration.id)) {
-            // export const [ a, b ] = []
+            // Export const [ a, b ] = []
             declaration.id.elements.forEach(decl => {
               names.push(decl.name)
             })
           } else if (t.isObjectPattern(declaration.id)) {
-            // export const { a, b } = {}
+            // Export const { a, b } = {}
             declaration.id.properties.forEach(decl => {
               names.push(decl.key.name)
             })
@@ -35,7 +35,7 @@ class BabelPluginExtractExportNames {
       }
 
       const handleSpecifiers = node => {
-        const { specifiers = [] } = node
+        const {specifiers = []} = node
 
         if (!specifiers) {
           return

--- a/packages/babel-plugin-extract-export-names/package.json
+++ b/packages/babel-plugin-extract-export-names/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "babel-plugin-extract-export-names",
+  "version": "2.0.0-next.1",
+  "description": "Extract export names",
+  "repository": "mdx-js/mdx",
+  "homepage": "https://mdxjs.com",
+  "bugs": "https://github.com/mdx-js/mdx/issues",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+  },
+  "author": "John Otander <johnotander@gmail.com> (http://johnotander.com)",
+  "license": "MIT",
+  "files": [
+    "index.js"
+  ],
+  "keywords": [
+    "mdx",
+    "markdown",
+    "react",
+    "jsx",
+    "remark",
+    "babel"
+  ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.10.4"
+  }
+}

--- a/packages/babel-plugin-extract-export-names/readme.md
+++ b/packages/babel-plugin-extract-export-names/readme.md
@@ -1,0 +1,37 @@
+# `babel-plugin-extract-export-names`
+
+Babel plugin that extracts all variable names from
+export statements. Used by the [MDX](https://mdxjs.com)
+pragma.
+
+## Installation
+
+```sh
+yarn add babel-plugin-extract-export-names
+```
+
+## Usage
+
+```js
+const babel = require('@babel/core')
+
+const BabelPluginExtractExportNames = require('babel-plugin-extract-export-names')
+
+const jsx = `
+export const foo = 'bar'
+export const [A] = [1]
+`
+
+const plugin = new BabelPluginExtractExportNames()
+
+const result = babel.transform(jsx, {
+  configFile: false,
+  plugins: [plugin.plugin]
+})
+
+console.log(plugin.state.names)
+```
+
+## License
+
+MIT

--- a/packages/babel-plugin-extract-export-names/readme.md
+++ b/packages/babel-plugin-extract-export-names/readme.md
@@ -1,7 +1,7 @@
 # `babel-plugin-extract-export-names`
 
 Babel plugin that extracts all variable names from
-export statements. Used by the [MDX](https://mdxjs.com)
+export statements.Used by the [MDX](https://mdxjs.com)
 pragma.
 
 ## Installation

--- a/packages/babel-plugin-extract-export-names/test/index.test.js
+++ b/packages/babel-plugin-extract-export-names/test/index.test.js
@@ -38,6 +38,19 @@ describe('babel-plugin-extract-export-names', () => {
   test('adds export names to state', () => {
     const result = transform(FIXTURE)
 
-    expect(result.state.names).toEqual(['foo', 'foo2', 'foo3', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'Super'])
+    expect(result.state.names).toEqual([
+      'foo',
+      'foo2',
+      'foo3',
+      'A',
+      'B',
+      'C',
+      'D',
+      'E',
+      'F',
+      'G',
+      'H',
+      'Super'
+    ])
   })
 })

--- a/packages/babel-plugin-extract-export-names/test/index.test.js
+++ b/packages/babel-plugin-extract-export-names/test/index.test.js
@@ -1,0 +1,43 @@
+const babel = require('@babel/core')
+
+const BabelPluginExtractExportNames = require('..')
+
+const FIXTURE = `
+export const foo = 'bar'
+export const foo2 = {
+  bar: 'baze',
+  hi: \`Hello! \${foo.toJSON() || 'hrm'}\`,
+  abc: {
+    def: 123
+  }
+}
+export const foo3 = [1, 2, 3, { a: 'b' }]
+export const A = 'baz'
+export const [B] = [1]
+export const [C, D, E] = [a, { b: 'c' }]
+export const { F } = { foo: 'bar' }
+export const { G, H } = {}
+export { Super } from './super'
+`
+
+const transform = str => {
+  const plugin = new BabelPluginExtractExportNames()
+
+  const result = babel.transform(str, {
+    configFile: false,
+    plugins: [plugin.plugin]
+  })
+
+  return {
+    ...result,
+    state: plugin.state
+  }
+}
+
+describe('babel-plugin-extract-export-names', () => {
+  test('adds export names to state', () => {
+    const result = transform(FIXTURE)
+
+    expect(result.state.names).toEqual(['foo', 'foo2', 'foo3', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'Super'])
+  })
+})

--- a/packages/babel-plugin-extract-import-names/test/index.test.js
+++ b/packages/babel-plugin-extract-import-names/test/index.test.js
@@ -21,7 +21,7 @@ const transform = str => {
   }
 }
 
-describe('babel-plugin-add-mdx-type-prop', () => {
+describe('babel-plugin-extract-import-names', () => {
   test('adds import names to state', () => {
     const result = transform(FIXTURE)
 

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -45,6 +45,7 @@
     "@mdx-js/util": "^2.0.0-next.1",
     "babel-plugin-apply-mdx-type-prop": "^2.0.0-next.1",
     "babel-plugin-extract-import-names": "^2.0.0-next.1",
+    "babel-plugin-extract-export-names": "^2.0.0-next.1",
     "camelcase-css": "2.0.1",
     "detab": "2.0.3",
     "hast-to-hyperscript": "9.0.0",

--- a/packages/remark-mdxjs/test/__snapshots__/test.js.snap
+++ b/packages/remark-mdxjs/test/__snapshots__/test.js.snap
@@ -8,10 +8,11 @@ const makeShortcode = name => function MDXDefaultShortcode(props) {
   console.warn(\\"Component \\" + name + \\" was not imported, exported, or provided by MDXProvider as global scope\\")
   return <div {...props}/>
 };
-const Baz = makeShortcode(\\"Baz\\");
 const Paragraph = makeShortcode(\\"Paragraph\\");
 const Button = makeShortcode(\\"Button\\");
-const layoutProps = {};
+const layoutProps = {
+  Baz
+};
 const MDXLayout = Foo
 export default function MDXContent({
   components,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12362,7 +12362,7 @@ gatsby-plugin-google-fonts@1.0.1:
   resolved "https://registry.yarnpkg.com/gatsby-plugin-google-fonts/-/gatsby-plugin-google-fonts-1.0.1.tgz#d71054f7bf207b9a8da227380369e18e6f4e0201"
   integrity sha512-p1NVkn27GUnDA5qHM+Z4cCcLCJIardzZXMon3640sT4xuL/AZJbsx3HEt2KY/5oZu0UXIkytkxzV2Da4rQeUIg==
 
-gatsby-plugin-mdx@1.2.26, gatsby-plugin-mdx@^1.2.26:
+gatsby-plugin-mdx@1.2.26:
   version "1.2.26"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.2.26.tgz#3f5f2c929769cf0094eb78e0a052b916e40515d4"
   integrity sha512-1KZEBzRp69H6faiBHeTy0NmWr56Qa5MfLNhi3UqQdZDLRdVxCzgXML7TafBBXuBAsJJBCvQi0Df437fodkdpvQ==
@@ -12395,6 +12395,48 @@ gatsby-plugin-mdx@1.2.26, gatsby-plugin-mdx@^1.2.26:
     remark "^10.0.1"
     remark-retext "^3.1.3"
     retext-english "^3.0.4"
+    static-site-generator-webpack-plugin "^3.4.2"
+    style-to-object "^0.3.0"
+    underscore.string "^3.3.5"
+    unified "^8.4.2"
+    unist-util-map "^1.0.5"
+    unist-util-remove "^1.0.3"
+    unist-util-visit "^1.4.1"
+
+gatsby-plugin-mdx@^1.2.26, gatsby-plugin-mdx@^1.2.27:
+  version "1.2.27"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.2.27.tgz#dadc9ce6e874b1f181c12b5cc019bb7217d4e457"
+  integrity sha512-2j5voALrvJ14JR9UzY9NygatVHRpGcm15jjJRDYtnT9k5ptKkqYLuiPcQ3eBxoqwjvAamLJ8WYRhc/poP/Ezuw==
+  dependencies:
+    "@babel/core" "^7.10.3"
+    "@babel/generator" "^7.10.3"
+    "@babel/helper-plugin-utils" "^7.10.3"
+    "@babel/plugin-proposal-object-rest-spread" "^7.10.3"
+    "@babel/preset-env" "^7.10.3"
+    "@babel/preset-react" "^7.10.1"
+    "@babel/types" "^7.10.3"
+    camelcase-css "^2.0.1"
+    change-case "^3.1.0"
+    core-js "^3.6.5"
+    dataloader "^1.4.0"
+    debug "^4.1.1"
+    escape-string-regexp "^1.0.5"
+    eval "^0.1.4"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^1.3.12"
+    gray-matter "^4.0.2"
+    json5 "^2.1.3"
+    loader-utils "^1.4.0"
+    lodash "^4.17.15"
+    mdast-util-to-string "^1.1.0"
+    mdast-util-toc "^3.1.0"
+    mime "^2.4.6"
+    p-queue "^5.0.0"
+    pretty-bytes "^5.3.0"
+    remark "^10.0.1"
+    remark-retext "^3.1.3"
+    retext-english "^3.0.4"
+    slugify "^1.4.4"
     static-site-generator-webpack-plugin "^3.4.2"
     style-to-object "^0.3.0"
     underscore.string "^3.3.5"


### PR DESCRIPTION
Many different types of export syntax weren't supported,
primarily destructuring for objects and arrays. This adds
export extraction to the import name extraction step so
we can more accurately determine what shortcodes to
generate.

We will eventually want to use something different for
extraction (#1152), but for now let's just make it right before
we make it fast.