### PR TITLE
Make testing matrix simpler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     name: Build and Test on ${{ matrix.os }} with Node.js ${{ matrix.node }}
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
-        node: [10, 12, 14]
+        os: [ubuntu-latest, windows-latest]
+        node: [10, 14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
I'm not sure we need to run such a complex test matrix
because it unfortunately makes CI pretty slow. Here I propose
removing node v12 and MacOS.

Related to #1015 