### PR TITLE
Make type test run in their own action, closes #1172

### DIFF
--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  default:
+    name: Test MDX types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: 14
+
+      - name: Setup yarn
+        run: |
+          curl -o- -L https://yarnpkg.com/install.sh | bash
+          export PATH="$HOME/.yarn/bin:$PATH"
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ubuntu-latest-14-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ubuntu-latest-14-yarn-
+
+      - name: Install Dependencies
+        run: yarn --frozen-lockfile
+        env:
+          CI: 'true'
+
+      - name: Build
+        run: yarn build
+
+      - name: Test types
+        run: yarn test-types

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "publish": "lerna publish --force-publish=\"*\"",
     "publish-ci": "lerna publish -y --canary --preid ci --pre-dist-tag ci",
     "publish-next": "lerna publish --force-publish=\"*\" --pre-dist-tag next --preid next",
-    "test": "yarn test-jest && yarn test-parser && yarn test-types",
+    "test": "yarn test-jest && yarn test-parser",
+    "test-all": "yarn test && yarn test-types",
     "test-jest": "jest --runInBand --detectOpenHandles",
     "test-parser": "nyc --reporter lcov tape packages/remark-mdx/test/index.js",
     "test-types": "lerna run test-types"


### PR DESCRIPTION
This will be a temporary change until we see dtslint running stably, then we can move `test-types` back under the `test` command.

Related to #1172 