### PR TITLE
fix(mdx): add additional typings to mdx api

### DIFF
--- a/packages/mdx/types/index.d.ts
+++ b/packages/mdx/types/index.d.ts
@@ -19,7 +19,7 @@ declare namespace mdx {
     skipExport?: boolean
 
     /**
-     * wrap 'export default' statement with provided string when serialize
+     * wrap 'export default' statement with provided string when serializing
      * to JSX
      */
     wrapExport?: string

--- a/packages/mdx/types/index.d.ts
+++ b/packages/mdx/types/index.d.ts
@@ -12,7 +12,7 @@ declare namespace mdx {
     footnotes?: boolean
 
     /**
-     * skip the addition of 'export default' statement when serialize
+     * skip the addition of 'export default' statement when serializing
      * to JSX
      * @default false
      */

--- a/packages/mdx/types/index.d.ts
+++ b/packages/mdx/types/index.d.ts
@@ -12,6 +12,19 @@ declare namespace mdx {
     footnotes?: boolean
 
     /**
+     * skip the addition of 'export default' statement when serialize
+     * to JSX
+     * @default false
+     */
+    skipExport?: boolean
+
+    /**
+     * wrap 'export default' statement with provided string when serialize
+     * to JSX
+     */
+    wrapExport?: string
+
+    /**
      * remark plugins to transform markdown content
      *
      * @default []

--- a/packages/mdx/types/mdx-test.ts
+++ b/packages/mdx/types/mdx-test.ts
@@ -3,6 +3,8 @@ import * as mdx from '@mdx-js/mdx'
 mdx('# title') // $ExpectType Promise<string>
 mdx('# title', {}) // $ExpectType Promise<string>
 mdx('# title', {footnotes: false}) // $ExpectType Promise<string>
+mdx('# title', {skipExport: false}) // $ExpectType Promise<string>
+mdx('# title', {wrapExport: 'React.memo'}) // $ExpectType Promise<string>
 mdx('# title', {rehypePlugins: [() => () => ({type: 'test'})]}) // $ExpectType Promise<string>
 mdx('# title', {remarkPlugins: [() => () => ({type: 'test'})]}) // $ExpectType Promise<string>
 mdx('# title', {compilers: []}) // $ExpectType Promise<string>
@@ -10,13 +12,16 @@ mdx('# title', {compilers: []}) // $ExpectType Promise<string>
 mdx.sync('# title') // $ExpectType string
 mdx.sync('# title', {}) // $ExpectType string
 mdx.sync('# title', {footnotes: false}) // $ExpectType string
+mdx.sync('# title', {skipExport: false}) // $ExpectType string
+mdx.sync('# title', {wrapExport: 'React.memo'}) // $ExpectType string
 mdx.sync('# title', {rehypePlugins: [() => () => ({type: 'test'})]}) // $ExpectType string
 mdx.sync('# title', {remarkPlugins: [() => () => ({type: 'test'})]}) // $ExpectType string
 mdx.sync('# title', {compilers: []}) // $ExpectType string
 
 mdx.createMdxAstCompiler() // $ExpectType Processor<Settings>
-mdx.createMdxAstCompiler({}) // $ExpectType Processor<Settings>
 mdx.createMdxAstCompiler({footnotes: false}) // $ExpectType Processor<Settings>
+mdx.createMdxAstCompiler({skipExport: false}) // $ExpectType Processor<Settings>
+mdx.createMdxAstCompiler({wrapExport: 'React.memo'}) // $ExpectType Processor<Settings>
 mdx.createMdxAstCompiler({rehypePlugins: [() => () => ({type: 'test'})]}) // $ExpectType Processor<Settings>
 mdx.createMdxAstCompiler({remarkPlugins: [() => () => ({type: 'test'})]}) // $ExpectType Processor<Settings>
 mdx.createMdxAstCompiler({compilers: []}) // $ExpectType Processor<Settings>


### PR DESCRIPTION
Issue: #1210

## What I did
Add `skipExport` and `wrapExport` typings to mdx api

## Context
First of all, thanks for adding some typescript support to mdx. I found that as #1079 was landed, it misses some typings. I personally had a problem with `skipExport` but I found that `wrapExport` looks like it needs typing too. Let me know if something needs to be changed