### PR TITLE
Update typescript.mdx

### DIFF
--- a/docs/advanced/typescript.mdx
+++ b/docs/advanced/typescript.mdx
@@ -39,8 +39,8 @@ declare module '@mdx-js/react' {
     | 'ul'
 
   export type ComponentProps = React.HTMLProps<Element> & {
-    metastring?: string;
-  };
+    metastring?: string
+  }
 
   export type Components = {
     [key in ComponentType]?: React.ComponentType<ComponentProps>

--- a/docs/advanced/typescript.mdx
+++ b/docs/advanced/typescript.mdx
@@ -38,8 +38,12 @@ declare module '@mdx-js/react' {
     | 'tr'
     | 'ul'
 
+  export type ComponentProps = React.HTMLProps<Element> & {
+    metastring?: string;
+  };
+
   export type Components = {
-    [key in ComponentType]?: React.ComponentType<{children: React.ReactNode}>
+    [key in ComponentType]?: React.ComponentType<ComponentProps>
   }
 
   export interface MDXProviderProps {

--- a/docs/advanced/typescript.mdx
+++ b/docs/advanced/typescript.mdx
@@ -38,12 +38,8 @@ declare module '@mdx-js/react' {
     | 'tr'
     | 'ul'
 
-  export type ComponentProps = React.HTMLProps<Element> & {
-    metastring?: string
-  }
-
   export type Components = {
-    [key in ComponentType]?: React.ComponentType<ComponentProps>
+    [key in ComponentType]?: React.ComponentType<any>
   }
 
   export interface MDXProviderProps {


### PR DESCRIPTION
This is a documentation improvement, on the Typescript page.

This change adds default HTML properties and the `metastring` prop to the list of declared props of MDX components.

The existing declaration only allows the `children` prop for MDX components. It will not work, for example, if you'll try to expand the [syntax-highlighting example](https://mdxjs.com/guides/syntax-highlighting) to use `className` or `metastring` props.

I've ran `yarn test` and `yarn docs` to verify this change.