### PR TITLE
docs(getting-started/gatsby): Update gatsby link

### DIFF
--- a/docs/getting-started/gatsby.mdx
+++ b/docs/getting-started/gatsby.mdx
@@ -34,6 +34,6 @@ some awesome content
 For more documentation on programmatically creating pages with Gatsby, see
 the [Gatsby MDX docs][gatsby-mdx-docs].
 
-[gatsby]: https://gatsbyjs.org
-[gatsby-mdx-docs]: https://gatsbyjs.org/docs/mdx/
-[gatsby-plugin-mdx]: https://gatsbyjs.org/packages/gatsby-plugin-mdx/
+[gatsby]: https://gatsbyjs.com
+[gatsby-mdx-docs]: https://gatsbyjs.com/docs/mdx/
+[gatsby-plugin-mdx]: https://gatsbyjs.com/packages/gatsby-plugin-mdx/


### PR DESCRIPTION
# Changes

Update Gatsby website links in docs/getting-started/gatsby.mdx.

# Context
Recently Gatsby merged their gatsby.org and gatsby.com into a single website gatsby.com. So, I updated the corresponding website links in the documentation. Hope it is alright. And finally, thank you for adding support for typescript in Markdown files.