### PR TITLE
fix(docs): Add info on making Next.js pick up .mdx pages

### DIFF
--- a/docs/getting-started/next.mdx
+++ b/docs/getting-started/next.mdx
@@ -15,6 +15,20 @@ const withMDX = require('@next/mdx')()
 module.exports = withMDX()
 ```
 
+### Treat `.mdx` files as pages
+
+To have Next.js treat `.mdx` files in the pages directory as pages use the `pageExtensions` property:
+
+```js
+// next.config.js
+const withMDX = require('@next/mdx')({
+  extension: /\.mdx?$/,
+})
+module.exports = withMDX({
+  pageExtensions: ['js', 'jsx', 'mdx'],
+})
+```
+
 ### Use MDX for `.md` files
 
 The Next.js MDX plugin allows for you to also use MDX parsing for `.md` files:


### PR DESCRIPTION
I was creating a new Next.js site, and wanted to use .mdx files as top level pages.
After adding the plugin this didn't just work, it needed extra steps described in the plugin's [README](https://github.com/vercel/next.js/tree/canary/packages/next-mdx).

I've added these steps here for others attempting the same thing.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
