### PR TITLE
JetBrains plugin now available

### DIFF
--- a/docs/editors.mdx
+++ b/docs/editors.mdx
@@ -6,12 +6,12 @@ The community has begun adding MDX syntax highlighting support for some editors!
 - [vscode-mdx-preview][]: MDX Preview for VS Code
 - [vim][]: Vim
 - [sublime][]: Sublime
+- [JetBrains IntelliJ/WebStorm][jetbrains]
 
 ### Editors needing support
 
 - Atom
 - Emacs
-- [JetBrains IntelliJ/WebStorm][jetbrains]
 
 ---
 
@@ -21,4 +21,4 @@ Original GitHub issue: [#119](https://github.com/mdx-js/mdx/issues/119)
 [vscode-mdx-preview]: https://github.com/xyc/vscode-mdx-preview
 [vim]: https://github.com/jxnblk/vim-mdx-js
 [sublime]: https://github.com/jonsuh/mdx-sublime
-[jetbrains]: https://youtrack.jetbrains.com/issue/WEB-32599
+[jetbrains]: https://plugins.jetbrains.com/plugin/14944-mdx


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/WEB-32599 has been closed with the release of https://plugins.jetbrains.com/plugin/14944-mdx, so I think it's fair to say IntelliJ can be listed as supporting now.
