### PR TITLE
add temporary hack for getting .mjs builds for node v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": "12.x"
   },
   "scripts": {
-    "build": "r -f cjs,esm -o dist --exclude 'babel-plugin-*,create-mdx,*loader,mdx,parcel-plugin-mdx,remark-*,*util'",
+    "build": "r -f cjs,esm -o dist --exclude 'babel-plugin-*,create-mdx,*loader,mdx,parcel-plugin-mdx,remark-*,*util' && cp packages/preact/dist/esm.js packages/preact/dist/esm.mjs",
     "clean": "lerna exec \"rimraf dist node_modules\"",
     "docs": "gatsby develop",
     "docs-build": "gatsby build",

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -20,6 +20,10 @@
   "license": "MIT",
   "main": "dist/cjs.js",
   "module": "dist/esm.js",
+  "exports": {
+    "import": "./dist/esm.mjs",
+    "require": "./dist/cjs.js"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
The Rust version of Toast works with node v14 esm, and the preact package specifically (but also the others) doesn't have valid esm builds for node.

The custom undocumented build system we're using isn't something I want to touch before we make sure this release and such works as a general approach. So this PR includes a small change to the build script to copy the module-appropriate js file from it's location in the preact package to the needed location, and adds additional metadata to the package.json in the form of the exports keyword. This will ensure that existing callers receive the same code as usual while import callers receive the .mjs code.

This is the smallest change I could make to execute this, but we'll probably want to move away from `r` to something like microbundle, which already supports this use case (as well as our existing ones) and is also well maintained and documented, if we want to pursue modern builds for more packages. (I'm happy to do this work in another PR).