### PR TITLE
Fix Lerna links

### DIFF
--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -150,5 +150,5 @@ If you’re having issues installing locally you might need to run
 [unit-test]: https://twitter.com/sindresorhus/status/579306280495357953
 [collective]: https://opencollective.com/unified
 [micromark]: https://github.com/micromark/micromark
-[lerna]: https://lernajs.io
+[lerna]: https://lerna.js.org
 [lerna-install]: https://github.com/lerna/lerna/issues/1457

--- a/packages/create-mdx/readme.md
+++ b/packages/create-mdx/readme.md
@@ -40,7 +40,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/loader/readme.md
+++ b/packages/loader/readme.md
@@ -93,7 +93,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -56,7 +56,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/parcel-plugin-mdx/readme.md
+++ b/packages/parcel-plugin-mdx/readme.md
@@ -48,7 +48,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/preact/readme.md
+++ b/packages/preact/readme.md
@@ -65,7 +65,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/react/readme.md
+++ b/packages/react/readme.md
@@ -64,7 +64,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/remark-mdx-remove-exports/readme.md
+++ b/packages/remark-mdx-remove-exports/readme.md
@@ -76,7 +76,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/remark-mdx-remove-imports/readme.md
+++ b/packages/remark-mdx-remove-imports/readme.md
@@ -74,7 +74,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/remark-mdx/readme.md
+++ b/packages/remark-mdx/readme.md
@@ -31,7 +31,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/runtime/readme.md
+++ b/packages/runtime/readme.md
@@ -79,7 +79,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/vue-loader/readme.md
+++ b/packages/vue-loader/readme.md
@@ -70,7 +70,7 @@ abide by its terms.
 
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions

--- a/packages/vue/readme.md
+++ b/packages/vue/readme.md
@@ -75,7 +75,6 @@ abide by its terms.
 [MIT][] © [Compositor][] and [Vercel][]
 
 <!-- Definitions -->
-
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
 [lerna]: https://lerna.js.org/

--- a/packages/vue/readme.md
+++ b/packages/vue/readme.md
@@ -75,9 +75,10 @@ abide by its terms.
 [MIT][] © [Compositor][] and [Vercel][]
 
 <!-- Definitions -->
+
 [build]: https://travis-ci.com/mdx-js/mdx
 [build-badge]: https://travis-ci.com/mdx-js/mdx.svg?branch=master
-[lerna]: https://lernajs.io/
+[lerna]: https://lerna.js.org/
 [lerna-badge]: https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg
 [chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
 [chat]: https://github.com/mdx-js/mdx/discussions


### PR DESCRIPTION
This fixes/changes the Lerna links to https://lerna.js.org/.