### PR TITLE
Add TypeScript error related to mdx imports for search indexing

### DIFF
--- a/docs/advanced/typescript.mdx
+++ b/docs/advanced/typescript.mdx
@@ -56,8 +56,8 @@ improve the developer experience for TypeScript users.
 ---
 
 If you’re getting errors from TypeScript related to imports with an `*.mdx`
-extension, create an `mdx.d.ts` file in your types directory and include it
-inside your `tsconfig.json`.
+extension (e.g., `Cannot find module 'typescript.mdx' or its corresponding type declarations`),
+create an `mdx.d.ts` file in your types directory and include it inside your `tsconfig.json`.
 
 ```tsx
 // types/mdx.d.ts


### PR DESCRIPTION
This is a small addition to the TypeScript documentation which adds the actual error that a user sees when importing `*.mdx` files as modules. 

The main reason to include it is to make sure that this page is picked up and indexed by search engines; I tried searching by the error description and couldn't find anything relevant for MDX.