### PR TITLE
fix: resolve dependencies to avoid relying on hoisting

### DIFF
--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -1,10 +1,23 @@
 const {getOptions} = require('loader-utils')
 const mdx = require('@mdx-js/mdx')
+const path = require('path')
 
-const DEFAULT_RENDERER = `
-import React from 'react'
-import { mdx } from '@mdx-js/react'
+let defaultRenderer = null
+
+function getDefaultRenderer() {
+  if (!defaultRenderer) {
+    defaultRenderer = `
+import React from '${path.dirname(
+      require.resolve('react/package.json').replace(/\\/g, '/')
+    )}'
+import { mdx } from '${path
+      .dirname(require.resolve('@mdx-js/react/package.json'))
+      .replace(/\\/g, '/')}'
 `
+  }
+
+  return defaultRenderer
+}
 
 const loader = async function (content) {
   const callback = this.async()
@@ -20,7 +33,7 @@ const loader = async function (content) {
     return callback(err)
   }
 
-  const {renderer = DEFAULT_RENDERER} = options
+  const {renderer = getDefaultRenderer()} = options
 
   const code = `${renderer}\n${result}`
   return callback(null, code)

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -35,5 +35,8 @@
     "@mdx-js/mdx": "1.6.19",
     "@mdx-js/react": "1.6.19",
     "loader-utils": "2.0.0"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1"
   }
 }

--- a/packages/parcel-plugin-mdx/src/MDXAsset.js
+++ b/packages/parcel-plugin-mdx/src/MDXAsset.js
@@ -1,6 +1,7 @@
 const {Asset} = require('parcel-bundler')
 
 const mdx = require('@mdx-js/mdx')
+const path = require('path')
 
 class MDXAsset extends Asset {
   constructor(name, pkg, options) {
@@ -15,8 +16,12 @@ class MDXAsset extends Asset {
     )
     const compiled = await mdx(this.contents, config)
     const fullCode = `/* @jsx mdx */
-import React from 'react';
-import { mdx } from '@mdx-js/react'
+import React from '${path
+      .dirname(require.resolve('react/package.json'))
+      .replace(/\\/g, '/')}';
+import { mdx } from '${path
+      .dirname(require.resolve('@mdx-js/react/package.json'))
+      .replace(/\\/g, '/')}'
 ${compiled}
 `
     return [

--- a/packages/vue-loader/index.js
+++ b/packages/vue-loader/index.js
@@ -1,5 +1,6 @@
 const {getOptions} = require('loader-utils')
 const mdx = require('@mdx-js/mdx')
+const path = require('path')
 
 module.exports = async function (content) {
   const callback = this.async()
@@ -15,7 +16,9 @@ module.exports = async function (content) {
   }
 
   const code = `// vue babel plugin doesn't support pragma replacement
-import { mdx } from '@mdx-js/vue'
+import { mdx } from '${path
+    .dirname(require.resolve('@mdx-js/vue/package.json'))
+    .replace(/\\/g, '/')}'
 let h;
 ${result}
 

--- a/packages/vue-loader/test/test.js
+++ b/packages/vue-loader/test/test.js
@@ -27,5 +27,9 @@ const testFixture = async fixture => {
 
 test('it loads markdown and returns a component', async () => {
   const generatedCode = await testFixture('fixture.md')
-  expect(generatedCode).toContain('require("@mdx-js/vue")')
+  expect(generatedCode).toContain(
+    `require("${path
+      .dirname(require.resolve('@mdx-js/vue/package.json'))
+      .replace(/\\/g, '/')}")`
+  )
 })


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `@mdx-js/*` family of packages relies on hoisting to bring all dependencies to the top level which is not guaranteed to happen and is undefined behaviour.

For a refresher on hoisting, I suggest giving this a read https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies

**How did you fix it?**

- Add missing peer dependency `react` to `@mdx-js/loader` (inherited from `@mdx-js/react`)
- `require.resolve` default renderer dependencies in `@mdx-js/loader`
- `require.resolve` injected imports `react` and `@mdx-js/react` in `@mdx-js/parcel-plugin-mdx`
- `require.resolve` injected imports `@mdx-js/vue` in `@mdx-js/vue-loader`
