### PR TITLE
Add annotation to use classic runtime

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -110,7 +110,8 @@ function sync(mdx, options = {}) {
 
   const {contents} = compiler.processSync(fileOpts)
 
-  return `/* @jsx mdx */
+  return `/* @jsxRuntime classic */
+/* @jsx mdx */
 ${contents}`
 }
 
@@ -124,7 +125,8 @@ async function compile(mdx, options = {}) {
 
   const {contents} = await compiler.process(fileOpts)
 
-  return `/* @jsx mdx */
+  return `/* @jsxRuntime classic */
+/* @jsx mdx */
 ${contents}`
 }
 


### PR DESCRIPTION
React v17 introduces a new syntax, JSX Runtime. MDX uses the traditional `React.createElement`, so if you mix it with the JSX Runtime, it will fail to build. This Pull Request adds an annotation that allows the classic runtime to be used, which is a temporary solution.

ref https://babeljs.io/docs/en/babel-plugin-transform-react-jsx

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
