### PR TITLE
Correct descriptions/tags in Table of components

### DIFF
--- a/docs/getting-started/-table-of-components.mdx
+++ b/docs/getting-started/-table-of-components.mdx
@@ -16,12 +16,11 @@
 | `tbody`         | [Table body](https://github.com/syntax-tree/mdast#table)             |                                                     |
 | `tr`            | [Table row](https://github.com/syntax-tree/mdast#tablerow)           |                                                     |
 | `td`/`th`       | [Table cell](https://github.com/syntax-tree/mdast#tablecell)         |                                                     |
-| `pre`           | [Pre](https://github.com/syntax-tree/mdast#code)                     |                                                     |
-| `code`          | [Code](https://github.com/syntax-tree/mdast#code)                    | ` ```code``` `                                      |
+| `code`          | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        | `` `inlineCode` ``                                  |
+| `pre`           | [Code](https://github.com/syntax-tree/mdast#code)                    | ` ```code``` `                                      |
 | `em`            | [Emphasis](https://github.com/syntax-tree/mdast#emphasis)            | `_emphasis_`                                        |
 | `strong`        | [Strong](https://github.com/syntax-tree/mdast#strong)                | `**strong**`                                        |
 | `del`           | [Delete](https://github.com/syntax-tree/mdast#delete)                | `~~strikethrough~~`                                 |
-| `inlineCode`    | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        | `` `inlineCode` ``                                  |
 | `hr`            | [Thematic break](https://github.com/syntax-tree/mdast#thematicbreak) | `---` or `***`                                      |
 | `a`             | [Link](https://github.com/syntax-tree/mdast#link)                    | `<https://mdxjs.com>` or `[MDX](https://mdxjs.com)` |
 | `img`           | [Image](https://github.com/syntax-tree/mdast#image)                  | `![alt](https://mdx-logo.now.sh)`                   |

--- a/docs/getting-started/-table-of-components.mdx
+++ b/docs/getting-started/-table-of-components.mdx
@@ -16,6 +16,7 @@
 | `tbody`         | [Table body](https://github.com/syntax-tree/mdast#table)             |                                                     |
 | `tr`            | [Table row](https://github.com/syntax-tree/mdast#tablerow)           |                                                     |
 | `td`/`th`       | [Table cell](https://github.com/syntax-tree/mdast#tablecell)         |                                                     |
+| `code`          | [Code](https://github.com/syntax-tree/mdast#code)                    | ` ```code``` `                                      |
 | `inlineCode`    | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        | `` `inlineCode` ``                                  |
 | `pre`           | [Code](https://github.com/syntax-tree/mdast#code)                    | ` ```code``` `                                      |
 | `em`            | [Emphasis](https://github.com/syntax-tree/mdast#emphasis)            | `_emphasis_`                                        |

--- a/docs/getting-started/-table-of-components.mdx
+++ b/docs/getting-started/-table-of-components.mdx
@@ -16,7 +16,7 @@
 | `tbody`         | [Table body](https://github.com/syntax-tree/mdast#table)             |                                                     |
 | `tr`            | [Table row](https://github.com/syntax-tree/mdast#tablerow)           |                                                     |
 | `td`/`th`       | [Table cell](https://github.com/syntax-tree/mdast#tablecell)         |                                                     |
-| `code`          | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        | `` `inlineCode` ``                                  |
+| `inlineCode`    | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        | `` `inlineCode` ``                                  |
 | `pre`           | [Code](https://github.com/syntax-tree/mdast#code)                    | ` ```code``` `                                      |
 | `em`            | [Emphasis](https://github.com/syntax-tree/mdast#emphasis)            | `_emphasis_`                                        |
 | `strong`        | [Strong](https://github.com/syntax-tree/mdast#strong)                | `**strong**`                                        |

--- a/docs/getting-started/-table-of-components.mdx
+++ b/docs/getting-started/-table-of-components.mdx
@@ -7,7 +7,6 @@
 | `h4`            | [Heading 4](https://github.com/syntax-tree/mdast#heading)            | `####`                                              |
 | `h5`            | [Heading 5](https://github.com/syntax-tree/mdast#heading)            | `#####`                                             |
 | `h6`            | [Heading 6](https://github.com/syntax-tree/mdast#heading)            | `######`                                            |
-| `thematicBreak` | [Thematic break](https://github.com/syntax-tree/mdast#thematicbreak) | `***`                                               |
 | `blockquote`    | [Blockquote](https://github.com/syntax-tree/mdast#blockquote)        | `>`                                                 |
 | `ul`            | [List](https://github.com/syntax-tree/mdast#list)                    | `-`                                                 |
 | `ol`            | [Ordered list](https://github.com/syntax-tree/mdast#list)            | `1.`                                                |
@@ -23,6 +22,6 @@
 | `strong`        | [Strong](https://github.com/syntax-tree/mdast#strong)                | `**strong**`                                        |
 | `del`           | [Delete](https://github.com/syntax-tree/mdast#delete)                | `~~strikethrough~~`                                 |
 | `inlineCode`    | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        | `` `inlineCode` ``                                  |
-| `hr`            | [Break](https://github.com/syntax-tree/mdast#break)                  | `---`                                               |
+| `hr`            | [Thematic break](https://github.com/syntax-tree/mdast#thematicbreak) | `---` or `***`                                      |
 | `a`             | [Link](https://github.com/syntax-tree/mdast#link)                    | `<https://mdxjs.com>` or `[MDX](https://mdxjs.com)` |
 | `img`           | [Image](https://github.com/syntax-tree/mdast#image)                  | `![alt](https://mdx-logo.now.sh)`                   |


### PR DESCRIPTION
Fixed tags for mdast `code`, `inlineCode` and `thematicBreak` types.

Preview here: https://mdx-git-patch-1.mdx.vercel.app/table-of-components