### PR TITLE
fix(docs): correct typos in Vue docs

### DIFF
--- a/docs/guides/vue.mdx
+++ b/docs/guides/vue.mdx
@@ -18,7 +18,7 @@ yarn add @mdx-js/vue-loader
 
 ## Configuring webpack
 
-In a [Vue CLI](https://cli.vuejs.org/) you need to add a `webpack.config.js` that
+In a [Vue CLI](https://cli.vuejs.org/) you need to add a `vue.config.js` that
 uses the MDX loader for vue:
 
 ```js

--- a/docs/guides/vue.mdx
+++ b/docs/guides/vue.mdx
@@ -27,7 +27,7 @@ module.exports = {
     module: {
       rules: [
         {
-          test: /.mdx?$/,
+          test: /\.mdx?$/,
           use: ['babel-loader', '@mdx-js/vue-loader']
         }
       ]

--- a/docs/guides/vue.mdx
+++ b/docs/guides/vue.mdx
@@ -27,7 +27,7 @@ module.exports = {
     module: {
       rules: [
         {
-          test: /\.mdx?$/,
+          test: /\.mdx$/,
           use: ['babel-loader', '@mdx-js/vue-loader']
         }
       ]


### PR DESCRIPTION
Fixes two typos in the Vue docs:

- The regexp for matching `.mdx` files is missing a backslash escaping the dot.
- Webpack is configured using `vue.config.js` rather than `webpack.config.js` in Vue CLI (https://cli.vuejs.org/guide/webpack.html)