### PR TITLE
Add annotation to use classic runtime

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -92,7 +92,8 @@ function sync(mdx, options = {}) {
 
   const {contents} = compiler.processSync(fileOpts)
 
-  return `/* @jsx mdx */
+  return `/* @jsxRuntime classic */
+/* @jsx mdx */
 ${contents}`
 }
 
@@ -106,7 +107,8 @@ async function compile(mdx, options = {}) {
 
   const {contents} = await compiler.process(fileOpts)
 
-  return `/* @jsx mdx */
+  return `/* @jsxRuntime classic */
+/* @jsx mdx */
 ${contents}`
 }
 


### PR DESCRIPTION
This is a copy of #1307 but for MDX@2. It's to avoid the error `pragma and pragmaFrag cannot be set when runtime is automatic` which is a result of [React's new JSX Transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).

Related discussion at #1345 .