### PR TITLE
Update `mdast-util-to-hast`

### DIFF
--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -52,7 +52,7 @@
     "detab": "2.0.3",
     "hast-to-hyperscript": "9.0.0",
     "lodash.uniq": "4.5.0",
-    "mdast-util-to-hast": "10.0.1",
+    "mdast-util-to-hast": "^10.1.0",
     "recast": "^0.20.4",
     "remark-mdx": "^2.0.0-next.8",
     "remark-parse": "9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19133,6 +19133,20 @@ mdast-util-to-hast@10.0.1:
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
+mdast-util-to-hast@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.1.0.tgz#0ab69ca52f5147486afba50afd4bb0d038e80a05"
+  integrity sha512-oOsIICebvylk3IiZDVUCJG4CesMvAWp3LcbnmVZdoCZI8svvxzXQHm1jgIZeQC3F0K2HnLC6ACgOEYDWY+qHPg==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    mdast-util-definitions "^4.0.0"
+    mdurl "^1.0.0"
+    unist-builder "^2.0.0"
+    unist-util-generated "^1.0.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^2.0.0"
+
 mdast-util-to-hast@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz#132001b266031192348d3366a6b011f28e54dc40"


### PR DESCRIPTION
There’s now a nice `passThrough` option to just pass custom nodes through