### PR TITLE
Add `jsxFrag` pragma, use fragment for shortcode warning

### DIFF
--- a/packages/mdx/estree-to-js.js
+++ b/packages/mdx/estree-to-js.js
@@ -5,13 +5,16 @@ module.exports = estreeToJs
 const customGenerator = Object.assign({}, astring.baseGenerator, {
   JSXAttribute: JSXAttribute,
   JSXClosingElement: JSXClosingElement,
+  JSXClosingFragment: JSXClosingFragment,
   JSXElement: JSXElement,
   JSXEmptyExpression: JSXEmptyExpression,
   JSXExpressionContainer: JSXExpressionContainer,
+  JSXFragment: JSXFragment,
   JSXIdentifier: JSXIdentifier,
   JSXMemberExpression: JSXMemberExpression,
   JSXNamespacedName: JSXNamespacedName,
   JSXOpeningElement: JSXOpeningElement,
+  JSXOpeningFragment: JSXOpeningFragment,
   JSXSpreadAttribute: JSXSpreadAttribute,
   JSXText: JSXText
 })
@@ -36,6 +39,11 @@ function JSXClosingElement(node, state) {
   this[node.name.type](node.name, state)
 }
 
+// `</>`
+function JSXClosingFragment(node, state) {
+  state.write('</>')
+}
+
 // `<div></div>`
 function JSXElement(node, state) {
   state.write('<')
@@ -54,6 +62,24 @@ function JSXElement(node, state) {
   } else {
     state.write(' />')
   }
+}
+
+// `<></>`
+function JSXFragment(node, state) {
+  this[node.openingFragment.type](node.openingElement, state)
+
+  let index = -1
+
+  while (++index < node.children.length) {
+    this[node.children[index].type](node.children[index], state)
+  }
+
+  /* istanbul ignore if - incorrect tree. */
+  if (!node.closingFragment) {
+    throw new Error('Cannot handle fragment w/o closing tag')
+  }
+
+  this[node.closingFragment.type](node.closingElement, state)
 }
 
 // `{}`
@@ -75,6 +101,11 @@ function JSXOpeningElement(node, state) {
   while (++index < node.attributes.length) {
     this[node.attributes[index].type](node.attributes[index], state)
   }
+}
+
+// `<>`
+function JSXOpeningFragment(node, state) {
+  state.write('<>')
 }
 
 // `div`

--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -7,7 +7,8 @@ const mdxAstToMdxHast = require('./mdx-ast-to-mdx-hast')
 const mdxHastToJsx = require('./mdx-hast-to-jsx')
 
 const pragma = `/* @jsxRuntime classic */
-/* @jsx mdx */`
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */`
 
 function createMdxAstCompiler(options = {}) {
   return unified()

--- a/packages/mdx/mdx-hast-to-jsx.js
+++ b/packages/mdx/mdx-hast-to-jsx.js
@@ -151,7 +151,10 @@ function serializeEstree(estree, options) {
   }
 
   estree.body = [
-    ...createMakeShortcodeHelper(magicShortcodes),
+    ...createMakeShortcodeHelper(
+      magicShortcodes,
+      options.mdxFragment === false
+    ),
     ...estree.body,
     ...exports
   ]
@@ -282,7 +285,7 @@ function createMdxLayout(declaration, mdxLayoutDefault) {
   ]
 }
 
-function createMakeShortcodeHelper(names) {
+function createMakeShortcodeHelper(names, useElement) {
   const func = {
     type: 'VariableDeclaration',
     declarations: [
@@ -329,22 +332,39 @@ function createMakeShortcodeHelper(names) {
                 },
                 {
                   type: 'ReturnStatement',
-                  argument: {
-                    type: 'JSXElement',
-                    openingElement: {
-                      type: 'JSXOpeningElement',
-                      attributes: [
-                        {
-                          type: 'JSXSpreadAttribute',
-                          argument: {type: 'Identifier', name: 'props'}
-                        }
-                      ],
-                      name: {type: 'JSXIdentifier', name: 'div'},
-                      selfClosing: true
-                    },
-                    closingElement: null,
-                    children: []
-                  }
+                  argument: useElement
+                    ? {
+                        type: 'JSXElement',
+                        openingElement: {
+                          type: 'JSXOpeningElement',
+                          attributes: [
+                            {
+                              type: 'JSXSpreadAttribute',
+                              argument: {type: 'Identifier', name: 'props'}
+                            }
+                          ],
+                          name: {type: 'JSXIdentifier', name: 'div'},
+                          selfClosing: true
+                        },
+                        closingElement: null,
+                        children: []
+                      }
+                    : {
+                        type: 'JSXFragment',
+                        openingFragment: {type: 'JSXOpeningFragment'},
+                        closingFragment: {type: 'JSXClosingFragment'},
+                        children: [
+                          {
+                            type: 'JSXExpressionContainer',
+                            expression: {
+                              type: 'MemberExpression',
+                              object: {type: 'Identifier', name: 'props'},
+                              property: {type: 'Identifier', name: 'children'},
+                              computed: false
+                            }
+                          }
+                        ]
+                      }
                 }
               ]
             }

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -564,23 +564,17 @@ describe('@mdx-js/mdx', () => {
   })
 
   it('should not crash but issue a warning when an undefined component is used', async () => {
-    const Content = await run('x <Y /> z')
+    const Content = await run('w <X>y</X> z')
     const warn = console.warn
     console.warn = jest.fn()
 
-    // To do: a fragment would probably be better?
-    // Maybe the components children?
     expect(renderToStaticMarkup(<Content />)).toEqual(
-      renderToStaticMarkup(
-        <p>
-          x <div /> z
-        </p>
-      )
+      renderToStaticMarkup(<p>w y z</p>)
     )
 
     expect(console.warn).toHaveBeenCalledWith(
       'Component `%s` was not imported, exported, or provided by MDXProvider as global scope',
-      'Y'
+      'X'
     )
 
     console.warn = warn

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -44,8 +44,10 @@
   ],
   "scripts": {
     "build": "microbundle -f modern,es,cjs src/index.js",
-    "test": "jest test --coverage",
-    "test-types": "dtslint types"
+    "test-api": "jest test",
+    "test-coverage": "jest test --coverage",
+    "test-types": "dtslint types",
+    "test": "yarn test-coverage && yarn test-types"
   },
   "peerDependencies": {
     "preact": "^10.4.6"

--- a/packages/preact/src/create-element.js
+++ b/packages/preact/src/create-element.js
@@ -41,7 +41,7 @@ const MDXCreateElement = forwardRef((props, ref) => {
 
 MDXCreateElement.displayName = 'MDXCreateElement'
 
-export default function (type, props) {
+function mdx(type, props) {
   const args = arguments
   const mdxType = props && props.mdxType
 
@@ -73,3 +73,7 @@ export default function (type, props) {
 
   return h.apply(null, args)
 }
+
+mdx.Fragment = Fragment
+
+export default mdx

--- a/packages/preact/test/test.js
+++ b/packages/preact/test/test.js
@@ -55,7 +55,7 @@ describe('@mdx-js/preact', () => {
     const warn = console.warn
     console.warn = jest.fn()
 
-    expect(render(<Content />)).toEqual('<div></div>')
+    expect(render(<Content />)).toEqual('')
 
     expect(console.warn).toHaveBeenCalledWith(
       'Component `%s` was not imported, exported, or provided by MDXProvider as global scope',

--- a/packages/react/src/create-element.js
+++ b/packages/react/src/create-element.js
@@ -40,7 +40,7 @@ const MDXCreateElement = React.forwardRef((props, ref) => {
 
 MDXCreateElement.displayName = 'MDXCreateElement'
 
-export default function (type, props) {
+function mdx(type, props) {
   const args = arguments
   const mdxType = props && props.mdxType
 
@@ -72,3 +72,7 @@ export default function (type, props) {
 
   return React.createElement.apply(null, args)
 }
+
+mdx.Fragment = React.Fragment
+
+export default mdx

--- a/packages/react/test/test.js
+++ b/packages/react/test/test.js
@@ -51,11 +51,11 @@ describe('@mdx-js/react', () => {
   })
 
   test('should warn on missing components', async () => {
-    const Content = await run('<Component />')
+    const Content = await run('<Component>x</Component>')
     const warn = console.warn
     console.warn = jest.fn()
 
-    expect(renderToString(<Content />)).toEqual('<div></div>')
+    expect(renderToString(<Content />)).toEqual('<p>x</p>')
 
     expect(console.warn).toHaveBeenCalledWith(
       'Component `%s` was not imported, exported, or provided by MDXProvider as global scope',

--- a/packages/vue-loader/index.js
+++ b/packages/vue-loader/index.js
@@ -35,7 +35,11 @@ async function mdxLoader(content) {
   let result
 
   try {
-    result = await mdx(content, {...options, skipExport: true})
+    result = await mdx(content, {
+      ...options,
+      skipExport: true,
+      mdxFragment: false
+    })
   } catch (err) {
     return callback(err)
   }

--- a/packages/vue/test/test.js
+++ b/packages/vue/test/test.js
@@ -7,7 +7,7 @@ import {MDXProvider, mdx} from '../src'
 
 const run = async value => {
   // Turn the serialized MDX code into serialized JSX…
-  const doc = await mdxTransform(value, {skipExport: true})
+  const doc = await mdxTransform(value, {skipExport: true, mdxFragment: false})
 
   // …and that into serialized JS.
   const {code} = await babelTransform(doc, {


### PR DESCRIPTION
This adds a `/* @jsxFrag mdx.Fragment */` next to the existing
`/* @jsx mdx */` pragma.
From MDX runtimes, this exports as `mdx.Fragment` either `React.Fragment`
or `Preact.Fragment`.

Vue 2 does not support fragments, but as JSX and hence MDX is already
specific to React or Vue, well: folks shouldn’t use fragments in MDX
files targeting Vue.

As we have fragments, we can also use that to pass children through
missing components: `<>{props.children}</>`.
This fixes runtimes where HTML is not available, such as React Native.
But, as Vue doesn’t like that, there’s a hidden flag to still use
the original behavior: `<div {...props} />`.
Still, there remains a difference in frameworks: Vue does not put
`children` in `props`, so `{...props}` has never passed children along
in Vue.

Closes GH-972.
Closes GH-990.
Closes GH-1014.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
