### PR TITLE
chore: configure renovate bot to preserve semantic version ranges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
-  "extends": ["config:base"],
+  "extends": ["config:base", ":preserveSemverRanges"],
   "schedule": "before 3am on Monday"
 }


### PR DESCRIPTION
alternative to #1403 

this keeps semantic version ranges, and opens PRs only when a version is released that is out of range (for example `^1.0.0` to `^2.0.0`)