### PR TITLE
Lazy load dark mode

### DIFF
--- a/packages/gatsby-theme-mdx/src/components/layout.js
+++ b/packages/gatsby-theme-mdx/src/components/layout.js
@@ -164,7 +164,11 @@ const Container = props => (
 export default props => {
   const [menuOpen, setMenuOpen] = useState(false)
   const [dark, setDark] = useState(() => {
-    return window.localStorage.getItem('dark') === 'true'
+    if (typeof window === `undefined`) return false
+
+    const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)')
+      .matches
+    return window.localStorage.getItem('dark') === 'true' || prefersDarkMode
   })
 
   useEffect(() => {

--- a/packages/gatsby-theme-mdx/src/components/layout.js
+++ b/packages/gatsby-theme-mdx/src/components/layout.js
@@ -47,10 +47,11 @@ const MDXConf = () => (
         display: 'flex',
         p: 3
       })}
-      to="/conf">
+      to="/conf"
+    >
       <span aria-label="tada">🎉</span>
-      <span css={css({ ml: 2 })}>MDX Conf &mdash; August 24th, 2020</span>
-      <span css={css({ ml: 'auto' })}>&rarr;</span>
+      <span css={css({ml: 2})}>MDX Conf &mdash; August 24th, 2020</span>
+      <span css={css({ml: 'auto'})}>&rarr;</span>
     </Link>
   </div>
 )
@@ -162,14 +163,9 @@ const Container = props => (
 
 export default props => {
   const [menuOpen, setMenuOpen] = useState(false)
-  const [dark, setDark] = useState(false)
-
-  useEffect(() => {
-    const initialDark = window.localStorage.getItem('dark') === 'true'
-    if (initialDark !== dark) {
-      setDark(initialDark)
-    }
-  }, [])
+  const [dark, setDark] = useState(() => {
+    return window.localStorage.getItem('dark') === 'true'
+  })
 
   useEffect(() => {
     window.localStorage.setItem('dark', dark)


### PR DESCRIPTION
This lazy loads the dark mode preference for the docs from local storage to fix the flash of light mode before useEffect kicks in. I also added a check for ```prefers-color-scheme: dark``` to automatically load the preference.

Closes #1051