### PR TITLE
Add missing react peer dep to the webpack loader

### DIFF
--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -40,6 +40,9 @@
     "test-types": "dtslint types",
     "test": "yarn test-coverage && yarn test-types"
   },
+  "peerDependencies": {
+    "react": ">=16"
+  },
   "dependencies": {
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",


### PR DESCRIPTION
`@mdx-js/loader` was missing a peer dependency on react causing a warning when installing with Yarn 2.

```sh
➤ YN0002: │ @mdx-js/loader@npm:1.6.22 doesn't provide react (p12550), requested by @mdx-js/react
```

This PR fixes the issue by adding the peer dependency to `@mdx-js/loader` which follows [Yarn's recommendations](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0).