### PR TITLE
Cache MDX compiler in the Webpack loader

### DIFF
--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -1,27 +1,39 @@
 const {getOptions} = require('loader-utils')
-const mdx = require('@mdx-js/mdx')
+const {createCompiler} = require('@mdx-js/mdx')
 
 const DEFAULT_RENDERER = `
 import React from 'react'
 import {mdx} from '@mdx-js/react'
 `
 
+const pragma = `
+/* @jsxRuntime classic */
+/* @jsx mdx */
+/* @jsxFrag mdx.Fragment */
+`
+
+const compilerCache = new Map()
+
 module.exports = async function (content) {
+  if (!compilerCache.has(this.query)) {
+    const {renderer = DEFAULT_RENDERER, ...opts} = getOptions(this)
+    compilerCache.set(this.query, [renderer, createCompiler(opts)])
+  }
+
   const callback = this.async()
-  const options = Object.assign({}, getOptions(this), {
-    filepath: this.resourcePath
-  })
+  const [renderer, compiler] = compilerCache.get(this.query)
 
   let result
 
   try {
-    result = await mdx(content, options)
+    result = await compiler.process({
+      contents: content,
+      path: this.resourcePath
+    })
   } catch (err) {
     return callback(err)
   }
 
-  const {renderer = DEFAULT_RENDERER} = options
-
-  const code = `${renderer}\n${result}`
+  const code = `${renderer}${pragma}${result}`
   return callback(null, code)
 }


### PR DESCRIPTION
A new MDX compiler was created for every file that’s processed. This means that any initialization logic in remark or rehype plugins was always run for every file.

By reusing the MDX compiler, remark and rehype plugins can run heavy setup logic once, just like when they are called by unified directly.

In practice I use this in [remark-mermaidjs](https://github.com/remcohaszing/remark-mermaidjs). This starts a browser once to process a bunch of files, but it requires the same unified processor to run to be able to do so.

The same principle is used in [ts-loader](https://github.com/TypeStrong/ts-loader/blob/953358eb1b090dd9add0824c4746220b0ebe56c1/src/instances.ts#L37-L86) to cache the TypeScript compiler.