### PR TITLE
Fix a typo of the sample Webpack config in doc

### DIFF
--- a/docs/getting-started/webpack.mdx
+++ b/docs/getting-started/webpack.mdx
@@ -28,7 +28,7 @@ module.exports = {
       // ...
 
       {
-        test: /\.mdx$/,
+        test: /\.mdx?$/,
         use: ['babel-loader', '@mdx-js/loader']
       }
     ]
@@ -55,7 +55,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.mdx$/,
+        test: /\.mdx?$/,
         use: [
           {
             loader: 'babel-loader'


### PR DESCRIPTION
The context says:

> ...define the following webpack.config.js extension handler for .md and .mdx files...

> If you only want the loader for `.mdx` files you can _change_ the regex to `/\.mdx$/`.

So I suppose the RegExp in the sample config should have be `test: /\.mdx?$/`.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
