### PR TITLE
fix a reference error

### DIFF
--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import {MDXProvider} from '@mdx-js/vue'
+import {MDXProvider} from '@mdx-js/vue-loader'
 import HelloWorld from './components/HelloWorld'
 import Test from './test.mdx'
 


### PR DESCRIPTION
well,When i use this plugin,i found an error in vue3,I try to use import { MDXProvider } from '@mdx-js/vue-loader' to resolve my question

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
