### PR TITLE
ci: remove .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,0 @@
-*.js   text eol=lf
-*.json text eol=lf
-*.jsx  text eol=lf
-*.md   text eol=lf
-*.mdx  text eol=lf
-*.ts   text eol=lf
-*.tsx  text eol=lf


### PR DESCRIPTION
`lf` is ensured by `.editorconfig` already and it results file difference on build

https://github.com/mdx-js/mdx/runs/2193584817#step:6:15

I don't know if there is a better way to fix this issue. And don't know why types files are effected by building, could be a bug of `microbundle`?


<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
