### PR TITLE
ci: simplify ci workflows, change master to main on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,3 @@ jobs:
           CI: 'true'
       - name: Test
         run: yarn test
-      # To do: macos isn’t used anymore
-      - name: Publish CI tag to npm
-        if: matrix.node == 12 && matrix.os == 'macOS-latest' && github.event_name == 'push' && github.ref	== 'refs/heads/master'
-        run: |
-          npm set //registry.npmjs.org/:_authToken $NPM_AUTH_TOKEN
-          yarn publish-ci
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,11 @@ jobs:
       - name: Build
         run: yarn build
 
+      # workaround for types changes after building
       - name: Reset git status
-        run: git reset --hard # workaround for types changes after building
+        run: |
+          git status
+          git reset --hard
 
       - name: Publish CI tag to npm
         if: github.ref	== 'refs/heads/main'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Reset git status
+        run: git reset --hard # workaround for types changes after building
+
       - name: Publish CI tag to npm
         if: github.ref	== 'refs/heads/main'
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   default:
@@ -8,15 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # for lerna
 
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: 14
-
-      - name: Setup yarn
-        run: |
-          curl -o- -L https://yarnpkg.com/install.sh | bash
-          export PATH="$HOME/.yarn/bin:$PATH"
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile
@@ -27,7 +24,7 @@ jobs:
         run: yarn build
 
       - name: Publish CI tag to npm
-        if: github.event_name == 'push' && github.ref	== 'refs/heads/master'
+        if: github.ref	== 'refs/heads/main'
         run: |
           npm set //registry.npmjs.org/:_authToken $NPM_AUTH_TOKEN
           yarn publish-ci


### PR DESCRIPTION
I've reset and reopen this PR.

Blocker: types are incompatible with `lf` setting after building on CI

https://github.com/mdx-js/mdx/pull/1496#issuecomment-806891754

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
