### PR TITLE
docs: add next-mdx to projects

### DIFF
--- a/docs/projects.mdx
+++ b/docs/projects.mdx
@@ -15,6 +15,7 @@
   Spectacle
 - [Charge][]: An opinionated, zero-config static site generator
 - [MDNEXT][]: An ecosystem of tools to get your NextJS + MDX projects blasting off
+- [next-mdx][]: Plugin for Next.js for fetching and rendering MDX files with support for relational data.
 
 ## Sites
 
@@ -45,3 +46,4 @@
 [charge]: https://charge.js.org
 [mdx-fairy-tale]: https://github.com/DeveloperMode/mdx-fairy-tale
 [mdnext]: https://github.com/domitriusclark/mdnext
+[next-mdx]: https://github.com/arshad/next-mdx


### PR DESCRIPTION
Adds `next-mdx` to projects page:

- https://github.com/arshad/next-mdx
- https://next-mdx.org

Thank you