### PR TITLE
Document compatible versions of remark-parse for remark-mdx

### DIFF
--- a/packages/remark-mdx/readme.md
+++ b/packages/remark-mdx/readme.md
@@ -168,4 +168,3 @@ abide by its terms.
 [rehype]: https://github.com/rehypejs/rehype
 [hast]: https://github.com/syntax-tree/hast
 [mdxjs]: https://mdxjs.com
-[remark-parse]: https://github.com/remarkjs/remark/tree/main/packages/remark-parse

--- a/packages/remark-mdx/readme.md
+++ b/packages/remark-mdx/readme.md
@@ -19,17 +19,11 @@ It’s used in [MDXjs][].
 [npm][]:
 
 ```sh
-npm install remark-mdx
-```
+# for latest version
+npm install remark-mdx@next remark-parse
 
-### Installing Other Plugins
-
-You'll probably need other plugins such as [**remark-parse**][remark-parse].
-Make sure you are using compatible versions of such plugins.
-In case of [**remark-parse**][remark-parse] currently version `^8.0.3` is supported (the latest is `9.0.0`).
-
-```sh
-npm install remark-parse@8.0.3
+# for v1
+npm install remark-mdx@1 remark-parse@8
 ```
 
 ## Use

--- a/packages/remark-mdx/readme.md
+++ b/packages/remark-mdx/readme.md
@@ -22,6 +22,16 @@ It’s used in [MDXjs][].
 npm install remark-mdx
 ```
 
+### Installing Other Plugins
+
+You'll probably need other plugins such as [**remark-parse**][remark-parse].
+Make sure you are using compatible versions of such plugins.
+In case of [**remark-parse**][remark-parse] currently version `^8.0.3` is supported (the latest is `9.0.0`).
+
+```sh
+npm install remark-parse@8.0.3
+```
+
 ## Use
 
 Say we have the following file, `example.md`:
@@ -164,3 +174,4 @@ abide by its terms.
 [rehype]: https://github.com/rehypejs/rehype
 [hast]: https://github.com/syntax-tree/hast
 [mdxjs]: https://mdxjs.com
+[remark-parse]: https://github.com/remarkjs/remark/tree/main/packages/remark-parse


### PR DESCRIPTION
Adds a section to [remark-mdx's Readme](https://github.com/mdx-js/mdx/tree/main/packages/remark-mdx) to outline which version of **remark-parse** is to be used with latest version of **remark-mdx**. See [this issue](https://github.com/mdx-js/mdx/issues/1516) for more details.
