### PR TITLE
Encode alt text appropriately

### DIFF
--- a/packages/gatsby-theme-mdx/src/components/layout.js
+++ b/packages/gatsby-theme-mdx/src/components/layout.js
@@ -1,5 +1,4 @@
 import React, {useState, useEffect} from 'react'
-import {Link} from 'gatsby'
 import {Global} from '@emotion/core'
 import {ThemeProvider, css} from 'theme-ui'
 

--- a/packages/mdx/test/index.test.js
+++ b/packages/mdx/test/index.test.js
@@ -54,6 +54,22 @@ describe('@mdx-js/mdx', () => {
     )
   })
 
+  it('should generate JSX-compliant strings', async () => {
+    const Content = await run('!["so" cute](cats.com/cat.jpeg)')
+
+    // Note: Escaped quotes (\") isn't valid for JSX string syntax. So we're
+    // making sure that quotes aren't escaped here (prettier doesn't like us
+    // using the character reference (&quot;) in the expect below)
+    expect(renderToStaticMarkup(<Content />)).toEqual(
+      renderToStaticMarkup(
+        <p>
+          {/* prettier-ignore */}
+          <img src="cats.com/cat.jpeg" alt="&quot;so&quot; cute" />
+        </p>
+      )
+    )
+  })
+
   it('should support `remarkPlugins` (math)', async () => {
     const Content = await run('$x$', {remarkPlugins: [math]})
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

Closes GH-1578

This literally copies @wooorm's edits from XDM into this project, as discussed in [the comments](https://github.com/mdx-js/mdx/issues/1578#issuecomment-862820323) of the issue for this. I tried adding a test but given prettier doesn't like unnecessary character codes & the test data wouldn't have the escaped quotes in it (because prettier wants "\"" to be '"'), it was hard to figure out how to write a good test (well, less prettier's issue and more so prettier showing me why I can't write a good test because all of those things would still be equal). I checked XDM and either I didn't look in the right place or there wasn't a test for that either. So here's some code!
