### PR TITLE
Fix example

### DIFF
--- a/docs/getting-started/next.mdx
+++ b/docs/getting-started/next.mdx
@@ -35,7 +35,7 @@ The Next.js MDX plugin allows for you to also use MDX parsing for `.md` files:
 
 ```js
 const withMDX = require('@next/mdx')({
-  extension: /\.mdx$/
+  extension: /\.mdx?$/
 })
 
 module.exports = withMDX({


### PR DESCRIPTION
Under "Use MDX for .md files", the regex should match both .md and .mdx