### PR TITLE
Remove linked compositor.io example, site is down

### DIFF
--- a/docs/projects.mdx
+++ b/docs/projects.mdx
@@ -20,7 +20,6 @@
 ## Sites
 
 - [Vercel Docs][vercel-docs]
-- [Compositor][]
 - [Prisma][]
 - [Max Stoiber’s Blog][mxstbr]
 - [SmartRate][smrtrt]
@@ -37,7 +36,6 @@
 [mdx-paper]: https://github.com/hubgit/mdx-paper
 [docz]: https://www.docz.site/
 [vercel-docs]: https://github.com/zeit/docs
-[compositor]: https://compositor.io
 [prisma]: https://www.prisma.io/docs
 [mxstbr]: https://mxstbr.com
 [smrtrt]: https://www.smartrate.se


### PR DESCRIPTION
I suppose you could link it to this GitHub account if you wanted to keep it https://github.com/c8r

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
