### PR TITLE
Fix TypeScript error: Cannot find name 'Fragment'.

### DIFF
--- a/packages/loader/types/tsconfig.json
+++ b/packages/loader/types/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "commonjs",
     "lib": ["dom", "es6"],
     "strict": true,
-    "skipLibCheck": true,
     "baseUrl": ".",
     "jsx": "react",
     "paths": {

--- a/packages/mdx/types/tsconfig.json
+++ b/packages/mdx/types/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "commonjs",
     "lib": ["dom", "es6"],
     "strict": true,
-    "skipLibCheck": true,
     "baseUrl": ".",
     "jsx": "react",
     "paths": {

--- a/packages/preact/types/index.d.ts
+++ b/packages/preact/types/index.d.ts
@@ -1,6 +1,13 @@
-// TypeScript Version: 3.4
+// TypeScript Version: 3.5
 
-import {h, Context, AnyComponent, Fragment, FunctionComponent} from 'preact'
+import {
+  h,
+  Context,
+  AnyComponent,
+  Fragment,
+  FunctionComponent,
+  VNode
+} from 'preact'
 
 /**
  * Mapping of names for JSX components to React components
@@ -52,7 +59,7 @@ declare function useMDXComponents(
  */
 declare function withMDXComponents(
   child: AnyComponent<ComponentsProp>
-): ReactElement | null
+): VNode | null
 
 /**
  * Preact hyperscript function wrapped with handler for MDX content

--- a/packages/preact/types/tsconfig.json
+++ b/packages/preact/types/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "commonjs",
     "lib": ["dom", "es6"],
     "strict": true,
-    "skipLibCheck": true,
     "baseUrl": ".",
     "jsx": "react",
     "jsxFactory": "h",

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -2,8 +2,8 @@
 
 import {
   Context,
-  Consumer,
   ComponentType,
+  Fragment,
   FunctionComponent,
   ReactElement,
   createElement

--- a/packages/react/types/tsconfig.json
+++ b/packages/react/types/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "commonjs",
     "lib": ["dom", "es6"],
     "strict": true,
-    "skipLibCheck": true,
     "baseUrl": ".",
     "jsx": "react",
     "paths": {

--- a/packages/remark-mdx/types/tsconfig.json
+++ b/packages/remark-mdx/types/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "commonjs",
     "lib": ["dom", "es6"],
     "strict": true,
-    "skipLibCheck": true,
     "baseUrl": ".",
     "jsx": "react",
     "paths": {

--- a/packages/runtime/types/tsconfig.json
+++ b/packages/runtime/types/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "commonjs",
     "lib": ["dom", "es6"],
     "strict": true,
-    "skipLibCheck": true,
     "baseUrl": ".",
     "jsx": "react",
     "paths": {

--- a/packages/vue-loader/types/tsconfig.json
+++ b/packages/vue-loader/types/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "commonjs",
     "lib": ["dom", "es6"],
     "strict": true,
-    "skipLibCheck": true,
     "baseUrl": ".",
     "jsx": "react",
     "paths": {

--- a/packages/vue/types/tsconfig.json
+++ b/packages/vue/types/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "commonjs",
     "lib": ["dom", "es6"],
     "strict": true,
-    "skipLibCheck": true,
     "baseUrl": ".",
     "jsx": "react",
     "paths": {


### PR DESCRIPTION
Add `import { Fragment } from "react"`, missed in [#1514](https://github.com/mdx-js/mdx/pull/1514/files#diff-c749c3b78a21e2eb84c84458035416c6cc15f688865ea2097c49fe3e5cb68464R68) :heart: