### PR TITLE
Don't run lerna publish from root lifecycle

### DIFF
--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -126,7 +126,7 @@ MDX is a monorepo that uses [lerna][].
 In order to release a new version you can follow these steps:
 
 - Draft a release for the next version (vX.X.X)
-- `yarn && yarn test && yarn run publish`
+- `yarn && yarn test && yarn lerna publish --force-publish`
 - Publish release on GitHub
 
 ## Troubleshooting

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "vercel-build": "yarn build && yarn docs-build",
     "postinstall": "yarn-deduplicate --strategy fewer && patch-package || exit 0",
     "prepublishOnly": "yarn build",
-    "publish": "lerna publish --force-publish=\"*\"",
     "publish-ci": "lerna publish -y --canary --preid ci --pre-dist-tag ci",
     "publish-next": "lerna publish --force-publish=\"*\" --pre-dist-tag next --preid next",
     "test-api": "lerna run test-api",


### PR DESCRIPTION
- [The Lerna docs](https://github.com/lerna/lerna/tree/main/commands/publish#:~:text=root-,To%20avoid%20recursive%20calls,Run,-postpublish) warn against running `lerna publish` from the `publish` lifecycle in root, because Lerna will run npm lifecycle scripts during `lerna publish`, recursively:
  > To avoid recursive calls, don't use this root lifecycle to run lerna publish
- This is happening now, e.g. `publish-ci` runs [`lerna publish` `--yes`](https://github.com/mdx-js/mdx/runs/3072339382#step:6:8), which [successfully publishes @mdx-js/vue-loader 2.0.0-ci.17+50253492](https://github.com/mdx-js/mdx/runs/3072339382#step:6:106), however it in turn runs the [`publish` lifecycle in root](https://github.com/mdx-js/mdx/runs/3072339382#step:6:129) which errors, making the "Publish CI tagged release for MDX" workflow status :x: -- although in fact it succeeded.
- This PR drops the `publish` lifecycle in root and replaces `yarn publish` with `lerna publish --force-publish`. You could alternatively use [`--ignore-scripts`](https://github.com/lerna/lerna/tree/main/commands/publish#--ignore-scripts) but that seems unusual. Or you could rename the `publish` script; `release` maybe?
- Maybe this issue has already been discussed?