### PR TITLE
Update package.json to include the repository 

### DIFF
--- a/packages/babel-plugin-apply-mdx-type-props/package.json
+++ b/packages/babel-plugin-apply-mdx-type-props/package.json
@@ -1,4 +1,9 @@
 {
   "private": true,
-  "name": "babel-plugin-apply-mdx-type-prop"
+  "name": "babel-plugin-apply-mdx-type-prop",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/babel-plugin-apply-mdx-type-props"
+  }
 }

--- a/packages/babel-plugin-extract-export-names/package.json
+++ b/packages/babel-plugin-extract-export-names/package.json
@@ -1,4 +1,9 @@
 {
   "private": true,
-  "name": "babel-plugin-extract-export-names"
+  "name": "babel-plugin-extract-export-names",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/babel-plugin-extract-export-names"
+  }
 }

--- a/packages/babel-plugin-extract-import-names/package.json
+++ b/packages/babel-plugin-extract-import-names/package.json
@@ -1,4 +1,9 @@
 {
   "private": true,
-  "name": "babel-plugin-extract-import-names"
+  "name": "babel-plugin-extract-import-names",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/babel-plugin-extract-import-names"
+  }
 }

--- a/packages/babel-plugin-html-attributes-to-jsx/package.json
+++ b/packages/babel-plugin-html-attributes-to-jsx/package.json
@@ -1,4 +1,9 @@
 {
   "private": true,
-  "name": "babel-plugin-html-attributes-to-jsx"
+  "name": "babel-plugin-html-attributes-to-jsx",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/babel-plugin-html-attributes-to-jsx"
+  }
 }

--- a/packages/gatsby-theme-mdx/package.json
+++ b/packages/gatsby-theme-mdx/package.json
@@ -5,6 +5,11 @@
     "type": "opencollective",
     "url": "https://opencollective.com/unified"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/gatsby-theme-mdx"
+  },
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "contributors": [
     "JounQin <admin@1stg.me> (https://www.1stg.me)"

--- a/packages/remark-mdx-remove-exports/package.json
+++ b/packages/remark-mdx-remove-exports/package.json
@@ -1,4 +1,9 @@
 {
   "private": true,
-  "name": "remark-mdx-remove-exports"
+  "name": "remark-mdx-remove-exports",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/remark-mdx-remove-exports"
+  }
 }

--- a/packages/remark-mdx-remove-imports/package.json
+++ b/packages/remark-mdx-remove-imports/package.json
@@ -1,4 +1,9 @@
 {
   "private": true,
-  "name": "remark-mdx-remove-imports"
+  "name": "remark-mdx-remove-imports",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/remark-mdx-remove-exports"
+  }
 }

--- a/packages/remark-mdxjs/package.json
+++ b/packages/remark-mdxjs/package.json
@@ -1,4 +1,9 @@
 {
   "private": true,
-  "name": "remark-mdxjs"
+  "name": "remark-mdxjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/remark-mdxjs"
+  }
 }

--- a/packages/test-util/package.json
+++ b/packages/test-util/package.json
@@ -1,4 +1,9 @@
 {
   "private": true,
-  "name": "@mdx-js/test-util"
+  "name": "@mdx-js/test-util",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/test-util"
+  }
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,4 +1,10 @@
 {
   "private": true,
-  "name": "@mdx-js/util"
+  "name": "@mdx-js/util",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/util"
+  }
+  
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -7,6 +7,11 @@
     "Jonathan Bakebwa <jonas@akkadu-team.com> (https://jbakebwa.dev)",
     "Christian Murphy <christian.murphy.42@gmail.com>"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdx-js/mdx.git",
+    "directory": "packages/vue"
+  },
   "license": "MIT",
   "main": "dist/mdx-vue.js",
   "module": "dist/mdx-vue.es.js",


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your repositories, please comment on this PR. We will see replies to this pull request.

Published NPM packages with repository information:
* babel-plugin-apply-mdx-type-props
* babel-plugin-extract-export-names
* babel-plugin-extract-import-names
* babel-plugin-html-attributes-to-jsx
* gatsby-theme-mdx
* remark-mdx-remove-exports
* remark-mdx-remove-imports
* remark-mdxjs
* test-util
* util
* vue

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
