### PR TITLE
Add `test-types` script back

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test-api": "lerna run test-api",
     "test-coverage": "lerna run test-coverage",
     "test-types": "lerna run test-types",
-    "test": "yarn build && yarn lint && yarn test-coverage"
+    "test": "yarn build && yarn lint && yarn test-coverage && yarn test-types"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "publish-next": "lerna publish --force-publish=\"*\" --pre-dist-tag next --preid next",
     "test-api": "lerna run test-api",
     "test-coverage": "lerna run test-coverage",
-    "test-types": "lerna run test-types",
+    "test-types": "lerna --concurrency 1 run test-types",
     "test": "yarn build && yarn lint && yarn test-coverage && yarn test-types"
   },
   "dependencies": {},

--- a/packages/loader/types/tsconfig.json
+++ b/packages/loader/types/tsconfig.json
@@ -8,6 +8,7 @@
     "jsx": "react",
     "paths": {
       "@mdx-js/react": ["index.d.ts"]
-    }
+    },
+    "types": []
   }
 }

--- a/packages/mdx/types/tsconfig.json
+++ b/packages/mdx/types/tsconfig.json
@@ -8,6 +8,7 @@
     "jsx": "react",
     "paths": {
       "@mdx-js/mdx": ["index.d.ts"]
-    }
+    },
+    "types": []
   }
 }

--- a/packages/preact/types/tsconfig.json
+++ b/packages/preact/types/tsconfig.json
@@ -9,6 +9,7 @@
     "jsxFactory": "h",
     "paths": {
       "@mdx-js/preact": ["index.d.ts"]
-    }
+    },
+    "types": []
   }
 }

--- a/packages/react/types/tsconfig.json
+++ b/packages/react/types/tsconfig.json
@@ -8,6 +8,7 @@
     "jsx": "react",
     "paths": {
       "@mdx-js/react": ["index.d.ts"]
-    }
+    },
+    "types": []
   }
 }

--- a/packages/remark-mdx/types/tsconfig.json
+++ b/packages/remark-mdx/types/tsconfig.json
@@ -8,6 +8,7 @@
     "jsx": "react",
     "paths": {
       "remark-mdx": ["index.d.ts"]
-    }
+    },
+    "types": []
   }
 }

--- a/packages/runtime/types/tsconfig.json
+++ b/packages/runtime/types/tsconfig.json
@@ -8,6 +8,7 @@
     "jsx": "react",
     "paths": {
       "@mdx-js/runtime": ["index.d.ts"]
-    }
+    },
+    "types": []
   }
 }

--- a/packages/vue-loader/types/tsconfig.json
+++ b/packages/vue-loader/types/tsconfig.json
@@ -8,6 +8,7 @@
     "jsx": "react",
     "paths": {
       "@mdx-js/vue-loader": ["index.d.ts"]
-    }
+    },
+    "types": []
   }
 }

--- a/packages/vue/types/tsconfig.json
+++ b/packages/vue/types/tsconfig.json
@@ -8,6 +8,7 @@
     "jsx": "react",
     "paths": {
       "@mdx-js/vue": ["index.d.ts"]
-    }
+    },
+    "types": []
   }
 }


### PR DESCRIPTION
I ran into *an* issue with `test-types` which this PR solves by adding [`"types": []`](https://www.typescriptlang.org/tsconfig#types) -> `**/tsconfig.json`. If it was *the* issue with `test-types`, perhaps it can be restored -> the CI?

#1179 temporarily moved `test-types` -> its own `types.yml` workflow, suggesting it be moved back -> `test` once it's running stably:
> This will be a temporary change until we see dtslint running stably, then we can move `test-types` back under the `test` command.

`types.yml` was subsequently eliminated in #1338.

The issue I encountered was dtslint implicitly including and checking every `node_modules/@types` declaration:
```
Error: Errors in typescript@3.5 for external dependencies:
../../../node_modules/@types/prettier/index.d.ts(537,14): error TS2456: Type alias 'Doc' circularly references itself.

    at /home/nottheoilrig/mdx/node_modules/dtslint/bin/index.js:206:19
    at Generator.next (<anonymous>)
    at fulfilled (/home/nottheoilrig/mdx/node_modules/dtslint/bin/index.js:6:58)
```

This PR solves that by adding `"types": []` -> `**/tsconfig.json`:
```Shell
$ for tsconfig in $(git ls-files '**/tsconfig.json'); do
  git show ":$tsconfig" | jq '.compilerOptions.types = []' > "$tsconfig"
done
```

This will still type check our explicit `node_modules/@types` dependencies, however it will [no longer implicitly include every `node_modules/@types` declaration](https://github.com/mdx-js/mdx/pull/1615#discussion_r692615204).