### PR TITLE
Add Getting started and Using MDX pages

### DIFF
--- a/docs/_asset/index.css
+++ b/docs/_asset/index.css
@@ -782,7 +782,6 @@ button:focus {
 
   code {
     background-color: var(--gray-6);
-    color: var(--gray-0);
   }
 
   pre code,

--- a/docs/getting-started/index.server.mdx
+++ b/docs/getting-started/index.server.mdx
@@ -1,482 +1,105 @@
-import {NavGroup} from '../_component/nav.server.js'
 import TableOfComponents from '../_component/table-of-components.server.mdx'
-import {Editor} from '../_component/editor.client.js'
 export const navSortSelf = 2
 
 # Getting started
 
-If you have an existing project you want to integrate MDX with, check out
-the installation guides.
-
-{
-  (() => {
-    const category = props.navTree.children.find(
-      item => item.name === '/getting-started/'
-    )
-
-    return (
-      <nav>
-        <NavGroup items={category.children} includeDescription />
-      </nav>
-    )
-  })()
-}
+This article explains how to integrate MDX into your project.
+If you’re new to MDX we recommend that you start with [§ What is MDX][what].
+See [§ Using MDX][use] when you’re ready to use MDX.
 
 ## Contents
 
-*   [Hello World](#hello-world)
-*   [Syntax](#syntax)
-    *   [Markdown](#markdown)
-    *   [JSX](#jsx)
-    *   [MDX](#mdx)
-*   [Working with components](#working-with-components)
-    *   [MDXProvider](#mdxprovider)
-    *   [Table of components](#table-of-components)
-*   [Installation guides](#installation-guides)
-    *   [Scaffold out an app](#scaffold-out-an-app)
-    *   [Do it yourself](#do-it-yourself)
-
-## Hello World
-
-The smallest MDX example looks like this:
-
-```markdown
-# Hello, world!
-```
-
-It displays a heading saying “Hello, world!” on the page.
-You could also write it like so:
-
-```jsx
-<h1>Hello, world!</h1>
-```
-
-This displays the same heading.
-
-## Syntax
-
-MDX syntax can be boiled down to being JSX in Markdown.
-It’s a superset of Markdown syntax that also supports importing, exporting, and
-JSX.
-
-### Markdown
-
-Traditionally, Markdown is used to generate HTML.
-Many developers like writing markup in Markdown as it often looks more like
-what’s intended and it is typically terser.
-Instead of the following HTML:
-
-```html
-<blockquote>
-  <p>A blockquote with <em>some</em> emphasis.</p>
-</blockquote>
-```
-
-You can write the equivalent in Markdown (or MDX) like so:
-
-```markdown
-> A blockquote with _some_ emphasis.
-```
-
-Markdown is good for **content**.
-MDX supports standard [Markdown syntax][md].
-It’s important to understand Markdown in order to learn MDX.
-
-### JSX
-
-Recently, more and more developers have started using [JSX][] to generate HTML
-markup.
-JSX is typically combined with a frontend framework like React or Vue.
-These frameworks add support for components, which let you change repeating
-things like the following markup:
-
-```html
-<h2>Hello, Venus!</h2>
-<h2>Hello, Mars!</h2>
-```
-
-…to JSX (or MDX) like this:
-
-```jsx
-<Welcome name="Venus" />
-<Welcome name="Mars" />
-```
-
-JSX is good for **components**.
-It makes repeating things more clear and allows for separation of concerns.
-MDX fully supports [JSX syntax][jsx].
-Any line that start with the `<` character starts a JSX block.
-
-### MDX
-
-We love HTML, but we’ve created MDX to let you combine the benefits of Markdown
-with the benefits of JSX.
-The following example shows how they can be combined.
-It’s interactive so go ahead and change the code!
-
-<Editor children={`Hello, *world*!
-
-Below is an example of JSX embedded in Markdown.
-
-<div style={{padding: '1rem', backgroundColor: 'violet'}}>
-  Try and change the background color to \`tomato\`.
-</div>`}/>
-
-MDX supports two more features: [imports][] and [exports][].
-
-#### Imports
-
-[`import` (ES2015)][import] can be used to import components, data, and
-documents.
-
-##### Components
-
-You can import components, such as your own or from [rebass][], like so:
-
-```jsx
-import { Box, Heading, Text } from 'rebass'
-
-# Here is a JSX block
-
-It is using imported components!
-
-<Box>
-  <Heading>Here's a JSX block</Heading>
-  <Text>It's pretty neat</Text>
-</Box>
-```
-
-##### Data
-
-You can also import data that you want to display:
-
-```jsx
-import snowfallData from './snowfall.json'
-import BarChart from './charts/BarChart'
-
-# Recent snowfall trends
-
-2019 has been a particularly snowy year when compared to the last decade.
-
-<BarChart data={snowfallData} />
-```
-
-##### Documents
-
-You can embed MDX documents in other documents.
-This is also known as [transclusion][transclude].
-You can achieve this by importing an `.mdx` (or `.md`) file:
-
-```jsx
-import License from './license.md'
-import Contributing from './docs/contributing.mdx'
-
-# Hello, world!
-
-<License />
-
----
-
-<Contributing />
-```
-
-#### Exports
-
-[`export` (ES2015)][export] can be used to export data and components.
-For example, you can export metadata like which layout to use or the authors of
-a document.
-It’s a mechanism for an imported MDX file to communicate with the thing that
-imports it.
-
-Say we import our MDX file, using webpack and React, like so:
-
-```jsx
-// index.js
-import React from 'react'
-import MDXDocument, {metadata} from 'posts/post.mdx'
-
-export default () => (
-  <>
-    <MDXDocument />
-    <footer>
-      <p>By: {metadata.authors.map(author => author.name).join(', ') + '.'}</p>
-    </footer>
-  </>
-)
-```
-
-And our MDX file looks as follows (note the `export`):
-
-```js
-// posts/post.mdx
-import { sue, fred } from '../data/authors'
-
-export const metadata = {
-  authors: [sue, fred]
-}
-
-# Post about MDX
-
-MDX is a JSX in Markdown loader, parser, and renderer for ambitious projects.
-```
-
-After bundling and evaluating, we could get something like this:
-
-```html
-<h1>Post about MDX</h1>
-<p>
-  MDX is a JSX in Markdown loader, parser, and renderer for ambitious projects.
-</p>
-<footer><p>By: Sue, Fred.</p></footer>
-```
-
-This is similar to what frontmatter allows in Markdown, but instead of
-supporting only data in something like YAML, MDX lets you use richer JavaScript
-structures.
-
-##### Defining variables with exports
-
-If you need to define a variable in your MDX document, you can use an export
-to do so.
-Not only do exports emit data, they instantiate data you can reference in JSX
-blocks:
-
-```js
-export const myVariable = 'Yay!'
-
-# Hello, world!
-
-<div>{myVariable}</div>
-```
-
-## Working with components
-
-In addition to rendering components inline, you can also pass in components
-to be used instead of the default HTML elements that Markdown compiles to.
-This allows you to use your existing components and even CSS-in-JS like
-`styled-components`.
-
-The `components` object is a mapping between the HTML name and the desired
-component you’d like to render.
-
-```jsx
-// src/App.js
-import React from 'react'
-import Hello from '../hello.mdx'
-
-const MyH1 = props => <h1 style={{color: 'tomato'}} {...props} />
-const MyParagraph = props => <p style={{fontSize: '18px', lineHeight: 1.6}} />
-
-const components = {
-  h1: MyH1,
-  p: MyParagraph
-}
-
-export default () => <Hello components={components} />
-```
-
-You can also import your components from another location like your UI library:
-
-```jsx
-import React from 'react'
-import Hello from '../hello.mdx'
-
-import {Text, Heading, Code, InlineCode} from '../my-ui-library'
-
-export default () => (
-  <Hello
-    components={{
-      h1: Heading,
-      p: Text,
-      code: Code,
-      inlineCode: InlineCode
-    }}
-  />
-)
-```
-
-With the above, the `Heading` component will be rendered for any `h1`, `Text`
-for `p` elements, and so on.
-
-In addition to HTML elements, there is one special mapping: `inlineCode` can be
-used for code inside paragraphs, tables, etc.
-
-See the [Table of components][components] for supported names.
-
-### MDXProvider
-
-If you’re using an app layout that wraps your application, you can use
-the `MDXProvider` to only pass your components in one place:
-
-```jsx
-// src/App.js
-import React from 'react'
-import {MDXProvider} from '@mdx-js/react'
-
-import {Heading, Text, Pre, Code, Table} from './components'
-
-const components = {
-  h1: Heading.H1,
-  h2: Heading.H2,
-  // …
-  p: Text,
-  code: Pre,
-  inlineCode: Code
-}
-
-export default props => (
-  <MDXProvider components={components}>
-    <main {...props} />
-  </MDXProvider>
-)
-```
-
-This allows you to remove duplicated component passing and importing.
-It will typically go in layout files.
-
-#### Using the wrapper
-
-The MDXProvider has a special `wrapper` key that you can use in the component
-mapping.
-With your wrapper component you can set the layout of your document, inject
-styling, or even manipulate the children passed to the component.
-
-```js
-// src/App.js
-import React from 'react'
-import {MDXProvider} from '@mdx-js/react'
-
-const Wrapper = props => (
-  <main style={{padding: '20px', backgroundColor: 'tomato'}} {...props} />
-)
-
-export default ({children}) => (
-  <MDXProvider components={{wrapper: Wrapper}}>{children}</MDXProvider>
-)
-```
-
-If you would like to see more advanced usage, see the
-[wrapper customization guide](/guides/wrapper-customization).
-
-#### Default exports
-
-Sometimes from an MDX file you might want to override the wrapper.
-This is especially useful when you want to override layout for a single entry
-point at the page level.
-To achieve this you can use the ES default [export][] and it will wrap your MDX
-document *instead* of the wrapper passed to MDXProvider.
-
-You can declare a default export as a function:
-
-```jsx
-import Layout from './Layout'
-
-export default ({ children }) => <Layout some='metadata' >{children}</Layout>
-
-# Hello, world!
-```
-
-Or directly as a component:
-
-```jsx
-import Layout from './Layout'
-
-export default Layout
-
-# Hello, world!
-```
-
-Either works.
-Whatever you prefer!
-
-### Table of components
-
-`MDXProvider` uses [React Context][context] to provide the component mapping
-internally to MDX when it renders.
-The following components are rendered from Markdown, so these can be keys in the
-component object you pass to `MDXProvider`.
-
-<TableOfComponents/>
-
-## Installation guides
-
-Now that we’ve gone over how MDX works, you’re ready to get installing.
-
-### Scaffold out an app
-
-If you’re the type of person that wants to scaffold out an app quickly and start
-playing around you can use `npm init`:
-
-*   `npm init mdx` [`webpack`](/getting-started/webpack)
-*   `npm init mdx` [`parcel`](/getting-started/parcel)
-*   `npm init mdx` [`next`](/getting-started/next)
-*   `npm init mdx` [`gatsby`](/getting-started/gatsby)
-*   `npm init mdx` [`react-static`](/getting-started/react-static)
-
-### Do it yourself
-
-If your favorite bundler or framework isn’t listed above, or if you have a
-custom use case, you can of course do it yourself.
-The below rendering function is what we use for our MDX integration tests:
-
-```js
-const babel = require('@babel/core')
-const React = require('react')
-const {renderToStaticMarkup} = require('react-dom/server')
-const mdx = require('@mdx-js/mdx')
-const {MDXProvider, mdx: createElement} = require('@mdx-js/react')
-
-const transform = code =>
-  babel.transform(code, {
-    plugins: [
-      '@babel/plugin-transform-react-jsx',
-      '@babel/plugin-proposal-object-rest-spread'
-    ]
-  }).code
-
-const renderWithReact = async mdxCode => {
-  const jsx = await mdx(mdxCode, {skipExport: true})
-  const code = transform(jsx)
-  const scope = {mdx: createElement}
-
-  const fn = new Function(
-    'React',
-    ...Object.keys(scope),
-    `${code}; return React.createElement(MDXContent)`
-  )
-
-  const element = fn(React, ...Object.values(scope))
-  const components = {
-    h1: ({children}) =>
-      React.createElement('h1', {style: {color: 'tomato'}}, children)
-  }
-
-  const elementWithProvider = React.createElement(
-    MDXProvider,
-    {components},
-    element
-  )
-
-  return renderToStaticMarkup(elementWithProvider)
-}
-```
-
-[imports]: #imports
-
-[exports]: #exports
-
-[components]: #table-of-components
-
-[md]: https://daringfireball.net/projects/markdown/syntax
-
-[jsx]: https://reactjs.org/docs/introducing-jsx.html
-
-[import]: https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/import
-
-[export]: https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export
-
-[rebass]: https://rebassjs.org
-
-[transclude]: https://en.wikipedia.org/wiki/Transclusion
-
-[context]: https://reactjs.org/docs/context.html
+*   [Prerequisites](#prerequisites)
+*   [Bundler](#bundler)
+*   [JSX](#jsx)
+*   [Third-party integrations](#third-party-integrations)
+
+## Prerequisites
+
+MDX relies on JSX, so it’s required that your project supports JSX as well.
+Any JSX runtime (React, Preact, Vue, Ink, etc.) will do.
+Please make sure that JSX works for your project.
+
+All `@mdx-js/*` packages are written in modern JavaScript.
+[Node.js](https://nodejs.org) version 12.20, 14.14, 16.0, or later is required
+to use them.
+
+## Bundler
+
+MDX is a language that’s compiled to JavaScript.
+The easiest way to get started is to use an integration for your bundler if you
+have one:
+
+*   If you’re using [esbuild](https://esbuild.github.io),
+    please install and configure [`@mdx-js/esbuild`](/packages/esbuild/)
+*   If you’re using [Rollup](https://rollupjs.org)
+    (or [Snowpack](https://www.snowpack.dev), [Vite](https://vitejs.dev),
+    or [WMR](https://wmr.dev), which use it),
+    please install and configure [`@mdx-js/rollup`](/packages/rollup/)
+*   If you’re using [webpack](https://webpack.js.org)
+    (or [Create React App](https://github.com/facebook/create-react-app),
+    [Razzle](https://razzlejs.org),
+    [React Static](https://github.com/react-static/react-static), or
+    [Next.js](https://nextjs.org), which use it),
+    please install and configure [`@mdx-js/loader`](/packages/loader/)
+
+You can also use MDX if you’re not using a bundler:
+
+*   If you want to import MDX files in [Node.js](https://nodejs.org), you can
+    install and configure the experimental package
+    [`@mdx-js/node-loader`](/packages/node-loader/) (**recommended**) or
+    alternatively require them with the legacy package
+    [`@mdx-js/register`](/packages/register/)
+*   Otherwise, you can install and use the core compiler
+    [`@mdx-js/mdx`](/packages/mdx/) to manually compile MDX files
+
+Using something else?
+Perhaps there’s something for you in [§ Third-party integrations][third].
+
+## JSX
+
+Now you’ve set up `@mdx-js/mdx` or an integration, it’s time to configure your
+JSX runtime.
+
+*   If you’re using [React](https://reactjs.org),
+    you don’t need to do anything!
+    Optionally you can install and configure [`@mdx-js/react`](/packages/react/)
+*   If you’re using [Preact](https://preactjs.com),
+    set `options.jsxImportSource` to `'preact'`.
+    Optionally you can install and configure
+    [`@mdx-js/preact`](/packages/preact/)
+*   If you’re using [Vue 3](https://v3.vuejs.org),
+    set `options.jsx` to `false`.
+    You then have to use Babel alongside your MDX integration (possible with
+    webpack and Rollup but not esbuild)
+    and configure it to use
+    [`@vue/babel-plugin-jsx`](https://github.com/vuejs/jsx-next/tree/dev/packages/babel-plugin-jsx).
+    Optionally you can also install and configure
+    [`@mdx-js/vue`](/packages/vue/)
+*   If you’re using [Emotion](https://emotion.sh),
+    set `options.jsxImportSource` to `'@emotion/react'`
+*   If you’re using [Theme UI](https://theme-ui.com),
+    install and configure [`@mdx-js/react`](/packages/react/).
+    Then wrap your MDX content in a `<ThemeProvider />`
+
+## Third-party integrations
+
+There are also certain community driven integrations.
+As we’ve just hit a major milestone with v2, they will likely be out of date
+with our docs here.
+Some of those integrations are:
+
+*   [`gatsby-plugin-mdx`](https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/)
+    — Use MDX with Gatsby
+*   [`@parcel/transformer-mdx`](https://v2.parceljs.org/languages/mdx/)
+    — Use MDX with Parcel
+*   [`mdx-bundler`](https://github.com/kentcdodds/mdx-bundler)
+    — Bundle and evaluate MDX
+*   [`mdsvex`](https://github.com/pngwn/mdsvex)
+    — A markdown preprocessor for Svelte (not MDX, but somewhat similar)
+
+[third]: #third-party-integrations
+
+[what]: /mdx/
+
+[use]: /using-mdx/

--- a/docs/mdx.server.mdx
+++ b/docs/mdx.server.mdx
@@ -1,19 +1,26 @@
-import {Editor} from './_component/editor.client.js'
 export const navSortSelf = 1
 
 # What is MDX?
 
+This article explains what MDX is.
+See [§ Getting started][start] for how to integrate MDX into your project.
+
 ## Contents
 
+*   [Prerequisites](#prerequisites)
 *   [Markdown for the component era](#markdown-for-the-component-era)
 *   [MDX syntax](#mdx-syntax)
     *   [Markdown](#markdown)
     *   [JSX](#jsx)
     *   [ESM](#esm)
     *   [Expressions](#expressions)
-*   [MDX content](#mdx-content)
-    *   [Components](#components)
-    *   [Layout](#layout)
+
+## Prerequisites
+
+It’s important to know markdown
+([see this cheatsheet and tutorial](https://commonmark.org/help/) for help)
+and have experience with JavaScript (specifically
+[JSX](https://facebook.github.io/jsx/)) to write (and enjoy writing) MDX.
 
 ## Markdown for the component era
 
@@ -37,59 +44,64 @@ JSX and looks as follows:
 
 The heading and the block quote are markdown and those XML-like things are JSX
 instead of HTML.
+Markdown often feels more natural to type than HTML (or JSX) for the common
+things (like emphasis, headings).
+JSX is an extension to JavaScript that *looks* like HTML but makes it convenient
+to use components (reusable things).
 
 This example uses `className` on the `<div>`.
 That’s because this example was written with React in mind which expects classes
 to be added as such.
 Other frameworks, such as Vue and Preact, expect classes to be defined
 differently, so note that there are some differences in how JSX has to be
-authored depending on what framework it’s used with.
+authored depending on what tools it’s used with.
 
-A few other things from JavaScript are supported as well: expressions in braces
-(such as `{1 + 1}`) and ESM (`import` and `export`).
-
-See [§ MDX syntax][mdx-syntax] below for more on how the format works and what
-else is and isn’t supported.
-See [§ MDX content][mdx-content] below for more on what the format compiles to.
-See [§ Playground][playground] to try it out live in your browser.
+A few other things from JavaScript are supported in MDX as well: expressions in
+braces (`{1 + 1}`) and ESM (`import` and `export`).
 
 ## MDX syntax
 
 > **Note**!
-> You don’t have to use this syntax.
+> You don’t have to use this syntax with `@mdx-js/*` packages.
 > Or use it always.
 > With [`options.format`][format], you can opt-in gradually or not at all.
 
-The MDX syntax is a mix between markdown and JSX.
-Markdown often feels more natural to type than HTML (or JSX) for the common
-things (like emphasis, headings).
-JSX is an extension to JavaScript that *looks* like HTML but makes it convenient
-to use components (reusable things).
-See [this description in
-`micromark/mdx-state-machine`](https://github.com/micromark/mdx-state-machine#71-syntax)
-for a formal description of the syntax.
-
+The MDX syntax is a mix between markdown and JS(X).
 This gives us something along the lines of [literate programming][lit].
-
-MDX also gives us an odd mix of two languages: markdown is whitespace sensitive
+It also gives us an odd mix of two languages: markdown is whitespace sensitive
 and forgiving (what you type may not “work” but it won’t crash) whereas
 JavaScript is whitespace **insensitive** and **does** crash on typos.
-Weirdly enough they combine pretty well!
-
-It’s important to know markdown
-([see this cheatsheet and tutorial](https://commonmark.org/help/) for help)
-and have experience with JavaScript (specifically
-[JSX](https://facebook.github.io/jsx/)) to write (and enjoy writing) MDX.
-
+Weirdly enough we found they combine pretty well!
+See [this description in
+`micromark/mdx-state-machine`](https://github.com/micromark/mdx-state-machine#71-syntax)
+for a formal description of the MDX syntax.
 Some common gotchas with writing MDX are
 [documented here in `micromark/mdx-state-machine`
 ](https://github.com/micromark/mdx-state-machine#74-common-mdx-gotchas).
 
 ### Markdown
 
-Most of markdown ([CommonMark][]) works:
+Traditionally, markdown is used to generate HTML.
+Many developers like writing markup in markdown as it often looks more like
+what’s intended and it is typically terser.
+Instead of the following HTML:
 
-````mdx
+```html
+<blockquote>
+  <p>A blockquote with <em>some</em> emphasis.</p>
+</blockquote>
+```
+
+You can write the equivalent in markdown (or MDX) like so:
+
+```markdown
+> A blockquote with *some* emphasis.
+```
+
+Markdown is good for **content**.
+MDX supports standard markdown syntax ([CommonMark][]):
+
+````markdown
 # Heading (rank 1)
 ## Heading 2
 ### 3
@@ -117,55 +129,61 @@ a [link](https://example.com), an ![image](./image.png), some *emphasis*,
 something **strong**, and finally a little `code()`.
 ````
 
-Some other features often used with markdown are:
+MDX supports standard markdown only (CommonMark).
+Nonstandard markdown features (such as GFM, frontmatter, footnotes, math, syntax
+highlighting) can be enabled by [configuring plugins](#).
 
-*   **GFM** — autolink literals, strikethrough, tables, tasklists
-    ([see guide on how to use `remark-gfm`](#))
-*   **Frontmatter** — YAML
-    ([see guide on how to use `remark-frontmatter`](#))
-*   **Footnotes**
-    ([see guide on how to use `remark-footnotes`](#))
-*   **Math**
-    ([see guide on how to use `remark-math` and `rehype-katex`](#))
-*   **Syntax highlighting**
-    ([see guide on how to use `rehype-highlight`](#))
+Certain standard markdown features don’t work in MDX:
 
-There are many more things possible by configuring
-[remark plugins][remark-plugins] and [rehype plugins][rehype-plugins].
+*   Indented code does not work in MDX:
+    ```markdown
+        console.log(1) // this is a paragraph in MDX!
+    ```
+    The reason for that is so you can nicely indent your components:
+    ```mdx
+    <main>
+      <article>
+        # Hello!
+      </article>
+    </main>
+    ```
+*   Autolinks do not work in MDX.
+    The reason is that they sometimes (such as `<svg:rect>` and
+    `<admin@example.com>`) look *a lot* like JSX components, and we prefer
+    being unambiguous.
+    If you want links, use full links:
+    `[descriptive text](https://and-the-link-here.com)`
+*   HTML doesn’t work in MDX as it’s replaced by JSX
+*   Unescaped left angle bracket / less than (`<`) and left curly brace (`{`)
+    have to be escaped: `\<` or `\{`
 
-There are also a couple specific remark/rehype/recma plugins that work with
-MDX: see [plugins](#).
-
-#### Caveats
-
-Some markdown features don’t work in MDX:
-
-```mdx
-Indented code works in markdown, but not in MDX:
-
-    console.log(1) // this is a paragraph in MDX!
-
-The reason for that is so that you can nicely indent your components.
-
-A different one is “autolinks”:
-
-<svg:rect> and <admin@example.com> are links in markdown, but they crash
-`mdx-js/mdx`.
-The reason is that they look a lot like JSX components, and we prefer being unambiguous.
-If you want links, use [descriptive text](https://and-the-link-here.com).
-
-HTML doesn’t work, because MDX has JSX instead (see next section).
-
-And you must escape less than (`<`) and opening braces (`{`) like so: \< or \{.
-```
-
-More on this is
+More on how MDX differs from markdown is
 [documented here](https://github.com/micromark/mdx-state-machine#72-deviations-from-markdown).
 
 ### JSX
 
-Most of JSX works.
-Here’s some that looks a lot like HTML (but is JSX):
+Recently, more and more developers have started using [JSX][] to generate HTML
+markup.
+JSX is typically combined with a frontend framework like React or Vue.
+These frameworks add support for components, which let you change repeating
+things like the following markup:
+
+```html
+<h2>Hello, Venus!</h2>
+<h2>Hello, Mars!</h2>
+```
+
+…to JSX (or MDX) like this:
+
+```jsx
+<Welcome name="Venus" />
+<Welcome name="Mars" />
+```
+
+JSX is good for **components**.
+It makes repeating things more clear and allows for separation of concerns.
+MDX fully supports [JSX syntax][jsx].
+Here’s some JSX looks a lot like HTML:
 
 ```js
 <h1>Heading!</h1>
@@ -177,8 +195,9 @@ Here’s some that looks a lot like HTML (but is JSX):
 </section>
 ```
 
-You can also use components, but note that you must either define them locally
-or pass them in later (see [§ MDX content][mdx-content]):
+You can also use components in MDX.
+Note that you must either define them locally or pass them in later
+(see [§ Using MDX][use]):
 
 ```js
 <MyComponent id="123" />
@@ -193,34 +212,35 @@ Or access the `thisOne` component on the `myComponents` object: <myComponents.th
 />
 ```
 
-More on this is
-[documented here](https://github.com/micromark/mdx-state-machine#73-deviations-from-jsx).
+There are a few edge cases
+[where MDX differs from JSX](https://github.com/micromark/mdx-state-machine#73-deviations-from-jsx).
 
 ### ESM
 
-To define things from within MDX, use ESM:
+MDX supports `import` and `export` statements from JavaScript as well.
+These ESM features can be used to define things from within MDX:
 
 ```js
 import {External} from './some/place.js'
 
 export const Local = props => <span style={{color: 'red'}} {...props} />
 
-An <External /> component and <Local>a local component</Local>.
+An <External>external</External> component and a <Local>local one</Local>.
 ```
 
-ESM can also be used for other things:
+ESM can also be used for non-components (data):
 
 ```js
-import {MyChart} from './chart-component.js'
-import data from './population.js'
+import {Chart} from './chart.js'
+import population from './population.js'
 export const pi = 3.14
 
-<MyChart data={data} label={'Something with ' + pi} />
+<Chart data={population} label={'Something with ' + pi} />
 ```
 
 ### Expressions
 
-Braces can be used to embed JavaScript expressions in MDX:
+MDX also supports JavaScript expressions inside curly braces:
 
 ```mdx
 export const pi = 3.14
@@ -234,113 +254,14 @@ Expressions can be empty or contain just a comment:
 {/* A comment! */}
 ```
 
-## MDX content
-
-All content (headings, paragraphs, etc) you write are exported as the default
-export from a compiled MDX file as a component.
-
-It’s possible to pass props in.
-The special prop `components` is used to determine how to render components.
-This includes both JSX and markdown syntax.
-Say we have a `message.mdx` file:
-
-```mdx
-# Hello, *<Planet />*!
-
-Remember when we first met in {props.year}?
-```
-
-This file could be imported from JavaScript and passed components like so:
-
-```js
-import Message from './message.mdx' // Assumes an integration is used to compile MDX -> JS.
-
-<Message components={{Planet: () => 'Venus'}} year={1962} />
-```
-
-You can also change the things that come from markdown:
-
-```js
-<Message
-  components={{
-    // Map `h1` (`# heading`) to use `h2`s.
-    h1: 'h2',
-    // Rewrite `em`s (`*like so*`) to `i` with a red foreground color.
-    em: (props) => <i style={{color: 'red'}} {...props} />,
-    // Pass a layout (using the special `'wrapper'` key).
-    wrapper: ({components, ...props}) => <main {...props} />,
-    // Pass a component.
-    Planet: () => 'Venus'
-  }}
-  year={1962}
-/>
-```
-
-### Components
-
-The following keys can be passed in `components`:
-
-*   HTML equivalents for the things you write with markdown (such as `h1` for
-    `# heading`)**†**
-*   `wrapper`, which defines the layout (but local layout takes precedence)
-*   `*` anything else that is a valid JavaScript identifier (`foo`,
-    `Components`, `_`, `$x`, `a1`) for the things you write with JSX (like
-    `<So />` or `<like.so />`, note that locally defined components take
-    precedence)**‡**
-
-**†** Normally, in markdown, those are: `a`, `blockquote`, `code`, `em`, `h1`,
-`h2`, `h3`, `h4`, `h5`, `h6`, `hr`, `img`, `li`, `ol`, `p`, `pre`, `strong`, and
-`ul`.
-With [`remark-gfm`][gfm] ([see guide](#)), you can also use: `del`, `table`,
-`tbody`, `td`, `th`, `thead`, and `tr`.
-Other remark plugins that add support for new constructs and advertise that they
-work with rehype, will also work with **xdm**.
-
-**‡** The rules for whether a name in JSX (`x` in `<x>`) is a literal tag name
-or not, are as follows:
-
-*   If there’s a dot, it’s a member expression (`<a.b>` -> `h(a.b)`)
-*   Otherwise, if the name is not a valid identifier, it’s a literal (`<a-b>` ->
-    `h('a-b')`)
-*   Otherwise, if it starts with a lowercase, it’s a literal (`<a>` -> `h('a')`)
-*   Otherwise, it’s an identifier (`<A>` -> `h(A)`)
-
-### Layout
-
-Layouts are components that wrap the whole content.
-They can be defined from within MDX using a default export:
-
-```js
-export default function Layout({children}) {
-  return <main>{children}</main>;
-}
-
-All the things.
-```
-
-The layout can also be imported and *then* exported with an `export … from`:
-
-```js
-export {Layout as default} from './components.js'
-```
-
-The layout can also be passed as `components.wrapper` (but a local one takes
-precedence).
-
 [lit]: https://en.wikipedia.org/wiki/Literate_programming
 
 [commonmark]: https://commonmark.org
 
-[remark-plugins]: https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins
-
-[rehype-plugins]: https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins
-
-[gfm]: https://github.com/remarkjs/remark-gfm
+[jsx]: https://reactjs.org/docs/introducing-jsx.html
 
 [format]: /packages/mdx/#optionsformat
 
-[playground]: /playground/
+[start]: /getting-started/
 
-[mdx-syntax]: #mdx-syntax
-
-[mdx-content]: #mdx-content
+[use]: /using-mdx/

--- a/docs/playground.server.mdx
+++ b/docs/playground.server.mdx
@@ -7,10 +7,13 @@ Write some MDX code and see it render to the right.
 Below, you can also see the output JSX and the intermediary ASTs.
 This can be helpful for debugging or exploring how MDX works.
 
-<Editor children={`Hello, *world*!
+<Editor children={`export const planet = 'world'
+
+Hello, *{planet}*!
 
 Below is an example of JSX embedded in Markdown.
 
 <div style={{padding: '1rem', backgroundColor: 'violet'}}>
   Try and change the background color to \`tomato\`.
-</div>`}/>
+</div>
+`}/>

--- a/docs/using-mdx.server.mdx
+++ b/docs/using-mdx.server.mdx
@@ -1,0 +1,399 @@
+export const navSortSelf = 3
+
+# Using MDX
+
+This article explains how to use MDX files in your project.
+See [§ Getting started][start] for how to integrate MDX into your project.
+If you’re new to MDX we recommend that you start with [§ What is MDX][what].
+
+## Contents
+
+*   [How MDX works](#how-mdx-works)
+*   [MDX content](#mdx-content)
+    *   [Props](#props)
+    *   [Components](#components)
+    *   [Layout](#layout)
+*   [MDX provider](#mdx-provider)
+
+## How MDX works
+
+An integration compiles MDX syntax to JavaScript.
+Say we have an MDX document, `example.mdx`:
+
+```mdx
+export const Thing = () => <>World</>
+
+# Hello <Thing />
+```
+
+That’s *roughly* turned into the following JavaScript.
+The below might help to form a mental model:
+
+```js
+/* @jsxRuntime automatic @jsxImportSource react */
+
+export const Thing = () => <>World</>
+
+export default function MDXContent() {
+  return <h1>Hello <Thing /></h1>
+}
+```
+
+Some observations:
+
+*   The output is serialized JavaScript that still needs to be evaluated
+*   A comment is injected to configure how JSX is handled
+*   It’s a complete file with import/exports
+*   A component (`MDXContent`) is exported
+
+The *actual* output is:
+
+```js
+/* @jsxRuntime automatic @jsxImportSource react */
+import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from 'react/jsx-runtime'
+
+export const Thing = () => _jsx(_Fragment, {children: 'World'})
+
+function MDXContent(props = {}) {
+  const _components = Object.assign({h1: 'h1'}, props.components)
+  const {wrapper: MDXLayout} = _components
+  const _content = _jsx(_Fragment, {
+    children: _jsxs(_components.h1, {
+      children: ['Hello ', _jsx(Thing, {})]
+    })
+  })
+  return MDXLayout
+    ? _jsx(MDXLayout, Object.assign({}, props, {children: _content}))
+    : _content
+}
+
+export default MDXContent
+```
+
+Some more observations:
+
+*   JSX is compiled away to function calls and an import of React†
+*   The content component can be given `{components: {h1: MyComponent}}` to use
+    something else for the heading
+*   The content component can be given `{components: {wrapper: MyLayout}}` to
+    wrap the whole content
+
+† MDX is not coupled to React.
+You can also use it with [Preact](#), [Vue](#), [Emotion](#), [Theme UI](#),
+etc.
+Both the classic and automatic JSX runtimes are supported.
+
+## MDX content
+
+We just saw that MDX files are compiled to components.
+You can use that component like any other component in your framework of choice.
+Take for example this `example.mdx`:
+
+```mdx
+# Hi!
+```
+
+This file could be imported and used in a React app:
+
+```js
+import React from 'react'
+import ReactDom from 'react-dom'
+import Example from './example.mdx' // Assumes an integration is used to compile MDX -> JS.
+
+ReactDom.render(<Example />, document.querySelector('#root'))
+```
+
+The main content is exported as the default export and all other values are also
+exported.
+Take this example:
+
+```mdx
+export const Thing = () => <>World</>
+
+# Hello <Thing />
+```
+
+This could be imported like so:
+
+```js
+// A namespace import to get everything:
+import * as everything from './example.mdx'
+console.log(everything) // {Thing: [Function: Thing], default: [Function: MDXContent]}
+
+// Default export shortcut and a named import specifier:
+import Content, {Thing} from './example.mdx'
+console.log(Content) // [Function: MDXContent]
+console.log(Thing) // [Function: Thing]
+
+// Import specifier with another local name:
+import {Thing as AnotherName} from './example.mdx'
+console.log(AnotherName) // [Function: Thing]
+```
+
+### Props
+
+Components, regardless of framework, accept “props” (and object with arbitrary
+data).
+This object is available from within MDX content under the identifier `props`.
+Take for example this `example.mdx`:
+
+```mdx
+# Hello {props.name}
+
+The current year is {props.year}
+```
+
+This file could be used as:
+
+```js
+import Example from './example.mdx' // Assumes an integration is used to compile MDX -> JS.
+
+// Use a `createElement` call:
+React.createElement(Example, {name: 'Venus', year: 2021})
+
+// Use JSX:
+<Example name="Mars" year={2022} />
+```
+
+You don’t have to pass data.
+You can also define (or import) it within MDX:
+
+```jsx
+export const year = 2019
+export const fact = 'a particularly snowy year'
+
+{year} has been {fact} when compared to the last decade.
+```
+
+### Components
+
+There is one special prop: `components`.
+It takes an object mapping component names to components.
+Take this `example.mdx`:
+
+```mdx
+# Hello *<Planet />*
+```
+
+This file could be imported from JavaScript and passed components like so:
+
+```js
+import Example from './example.mdx' // Assumes an integration is used to compile MDX -> JS.
+
+<Example components={{Planet: () => <span style={{color: 'tomato'}}>Pluto</span>}} />
+```
+
+You don’t have to pass components.
+You can also define or import them within MDX:
+
+```jsx
+import {Box, Heading} from 'rebass'
+
+MDX using imported components!
+
+<Box>
+  <Heading>Here’s a heading</Heading>
+</Box>
+```
+
+Because MDX files *are* components, they can also import each other:
+
+```jsx
+import License from './license.md'
+import Contributing from './docs/contributing.mdx'
+
+# Hello world
+
+<License />
+
+---
+
+<Contributing />
+```
+
+Here are some other examples of passing components:
+
+```js
+<Example
+  components={{
+    // Map `h1` (`# heading`) to use `h2`s.
+    h1: 'h2',
+    // Rewrite `em`s (`*like so*`) to `i` with a goldenrod foreground color.
+    em: (props) => <i style={{color: 'goldenrod'}} {...props} />,
+    // Pass a layout (using the special `'wrapper'` key).
+    wrapper: ({components, ...rest}) => <main {...rest} />,
+    // Pass a component.
+    Planet: () => 'Neptune',
+    // This nested component can be used as `<theme.text>hi</theme.text>`
+    theme: {text: (props) => <span style={{color: 'grey'}} {...props} />}
+  }}
+/>
+```
+
+The following keys can be passed in `components`:
+
+*   HTML equivalents for the things you write with markdown (such as `h1` for
+    `# heading`)**†**
+*   `wrapper`, which defines the layout (but a local layout takes precedence)
+*   `*` anything else that is a valid JavaScript identifier (`foo`,
+    `Quote`, `_`, `$x`, `a1`) for the things you write with JSX (like
+    `<So />` or `<like.so />`, note that locally defined components take
+    precedence)**‡**
+
+**†** Normally, in markdown, those are: `a`, `blockquote`, `code`, `em`, `h1`,
+`h2`, `h3`, `h4`, `h5`, `h6`, `hr`, `img`, `li`, `ol`, `p`, `pre`, `strong`, and
+`ul`.
+With [`remark-gfm`][gfm] ([see guide](#)), you can also use: `del`, `table`,
+`tbody`, `td`, `th`, `thead`, and `tr`.
+Other remark plugins that add support for new constructs and advertise that they
+work with rehype, will also work with MDX.
+
+**‡** The rules for whether a name in JSX (`x` in `<x>`) is a literal tag name
+or not, are as follows:
+
+*   If there’s a dot, it’s a member expression (`<a.b>` -> `h(a.b)`),
+    which means that the `b` component is taken from object `a`
+*   Otherwise, if the name is not a valid identifier, it’s a literal (`<a-b>` ->
+    `h('a-b')`)
+*   Otherwise, if it starts with a lowercase, it’s a literal (`<a>` -> `h('a')`)
+*   Otherwise, it’s an identifier (`<A>` -> `h(A)`), which means a component `A`
+
+### Layout
+
+There is one special component: the layout.
+If it is defined, it’s used to wrap the whole content.
+A layout can be defined from within MDX using a default export:
+
+```js
+export default function Layout({children}) {
+  return <main>{children}</main>;
+}
+
+All the things.
+```
+
+The layout can also be imported and *then* exported with an `export … from`:
+
+```js
+export {Layout as default} from './components.js'
+```
+
+The layout can also be passed as `components.wrapper` (but a local one takes
+precedence).
+
+## MDX provider
+
+Passing components is typically fine.
+Take for example this `post.mdx`:
+
+```mdx
+# Hello world
+```
+
+Used like so in `app.jsx`:
+
+```javascript
+import React from 'react'
+import ReactDom from 'react-dom'
+import Post from './post.mdx' // Assumes an integration is used to compile MDX -> JS.
+import {Heading, /* … */ Table} from './components/index.js'
+
+const components = {
+  h1: Heading.H1,
+  // …
+  table: Table
+}
+
+ReactDom.render(
+  <Post components={components} />,
+  document.querySelector('#root')
+)
+```
+
+But when you’re nesting MDX files (importing them into each other) it can become
+cumbersome.
+If `post.mdx` was instead importing and using other files:
+
+```mdx
+import License from './license.md'
+import Contributing from './docs/contributing.mdx'
+
+# Hello world
+
+<License components={props.components} />
+
+---
+
+<Contributing components={props.components} />
+```
+
+To solve this, a *[context][]* can be used in React, Preact, and Vue.
+Context provides a way to pass data through the component tree without having to
+pass props down manually at every level.
+Set it up like so:
+
+1.  Install either [`@mdx-js/react`][mdx-react], [`@mdx-js/preact`][mdx-preact],
+    or [`@mdx-js/vue`][mdx-vue],
+    depending on what framework you’re using
+2.  Configure your MDX integration with
+    [`options.providerImportSource`][options-provider-import-source]
+    set to that package, so either `'@mdx-js/react'`, `'@mdx-js/preact'`, or
+    `'@mdx-js/vue'`
+3.  Import `MDXProvider` from that package.
+    Use it to wrap your top-most MDX content components and pass it your
+    `components` instead:
+
+```diff
+ import React from 'react'
+ import ReactDom from 'react-dom'
+ import Post from './post.mdx' // Assumes an integration is used to compile MDX -> JS.
+ import {Heading, /* … */ Table} from './components/index.js'
++import {MDXProvider} from '@mdx-js/react'
+
+ const components = {
+   h1: Heading.H1,
+   // …
+   table: Table
+ }
+
+ ReactDom.render(
+-  <Post components={components} />,
++  <MDXProvider components={components}>
++    <Post />
++  </MDXProvider>,
+   document.querySelector('#root')
+ )
+```
+
+Now you can remove the explicit and verbose component passing:
+
+```diff
+ import License from './license.md'
+ import Contributing from './docs/contributing.mdx'
+
+ # Hello world
+
+-<License components={props.components} />
++<License />
+
+ ---
+
+-<Contributing components={props.components} />
++<Contributing />
+```
+
+[gfm]: https://github.com/remarkjs/remark-gfm
+
+[context]: https://reactjs.org/docs/context.html
+
+[start]: /getting-started/
+
+[what]: /mdx/
+
+[mdx-react]: /packages/react/
+
+[mdx-preact]: /packages/preact/
+
+[mdx-vue]: /packages/vue/
+
+[options-provider-import-source]: /packages/mdx/#optionsproviderimportsource

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -142,6 +142,7 @@ Some more observations:
 † `@mdx-js/mdx` is not coupled to React.
 You can also use it with [Preact](#), [Vue](#), [Emotion](#), [Theme UI](#),
 etc.
+Both the classic and automatic JSX runtimes are supported.
 
 See [§ MDX content](#) below on how to use the result.
 


### PR DESCRIPTION
*   This moves most of the existing getting started docs, on components and
    content and such, over to a new “Using MDX” page and the initial “What is
    MDX?” page.
    This makes Getting started just to essence of how to get started with MDX.
    Also documents rollup, esbuild, etcetera
*   Clearer divide between “What is MDX?” and “Using MDX”.
    The first is about how to author the format.
    The second is about how to use it in a project/react/preact/vue.
*   Add sections on the MDX provider and how the compiler works to “Using MDX”

Note:

*   The navigation bar / website structure is still messy
*   Many links are not yet working

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
