### PR TITLE
Add blog post for old conference page

### DIFF
--- a/docs/blog/conf.server.mdx
+++ b/docs/blog/conf.server.mdx
@@ -1,0 +1,126 @@
+import {Note} from '../_component/note.server.js'
+export const info = {
+  author: [
+    {name: 'John Otander', github: 'johno', twitter: '4lpine'}
+  ],
+  published: new Date('2020-07-31'),
+  modified: new Date('2021-11-01')
+}
+
+<Note type="legacy">
+  **Note**: This is an old blog post.
+  The below is kept as is for historical purposes.
+</Note>
+
+# MDXConf
+
+MDXConf is a free and online conference for the MDX community.
+Whether you’re just learning about MDX or an expert, there’ll be something for
+you! {/* more */}
+
+August 24th, 2020 at 8am PDT/3pm UST <br/> Online • Free
+
+## Watch
+
+The conference is now over, but you can still watch the recordings!
+
+[Watch the talks →](https://egghead.io/playlists/mdx-conf-3fc2)
+
+## About
+
+Join us for the first MDX conference!
+We’ll stream it directly to you, for free.
+
+MDX has grown rapidly since the [first commit][] two and a half years ago.
+We’d like to celebrate our accomplishments so far, and talk about what lies
+ahead.
+We’ve got lots of plans.
+
+Learn how MDX increases developer productivity, improves educational
+content authoring, and even peek behind the curtains to see how MDX works.
+
+## Speakers
+
+### [Chris Biscardi](https://twitter.com/chrisbiscardi)
+
+[![](https://github.com/ChristopherBiscardi.png?size=200)](https://twitter.com/chrisbiscardi)
+
+Keynote: The past, present, and future of MDX
+
+### [Monica Powell](https://twitter.com/waterproofheart)
+
+[![](https://github.com/M0nica.png?size=200)](https://twitter.com/waterproofheart)
+
+Migrating to MDX
+
+### [Laurie Barth](https://twitter.com/laurieontech)
+
+[![](https://github.com/laurieontech.png?size=200)](https://twitter.com/laurieontech)
+
+MDX v2 syntax
+
+### [Cole Bemis](https://twitter.com/colebemis)
+
+[![](https://github.com/colebemis.png?size=200)](https://twitter.com/colebemis)
+
+Demystifying MDX
+
+### [Prince Wilson](https://twitter.com/maxcell)
+
+[![](https://github.com/maxcell.png?size=200)](https://twitter.com/maxcell)
+
+Personal site playgrounds
+
+### [Kathleen McMahon](https://twitter.com/resource11)
+
+[![](https://github.com/resource11.png?size=200)](https://twitter.com/resource11)
+
+Digital gardening with MDX magic
+
+### [Rodrigo Pombo](https://twitter.com/pomber)
+
+[![](https://github.com/pomber.png?size=200)](https://twitter.com/pomber)
+
+The X in MDX
+
+### [Jonathan Bakebwa](https://twitter.com/codebender828)
+
+[![](https://github.com/codebender828.png?size=200)](https://twitter.com/codebender828)
+
+MDX and Vue/Nuxt
+
+## Sign up
+
+<Note type="legacy">
+  **Note**: Sign up is closed.
+</Note>
+
+## FAQ
+
+### What if I can’t make it on August 24th?
+
+We’ll miss you, but you won’t miss out!
+All talks will be recorded and released the day of the conference.
+You can catch up with the talks, or rewatch them, whenever convenient.
+
+### Will the talks be transcribed?
+
+Yes.
+
+### Is there a code of conduct?
+
+Absolutely.
+We’re dedicated to providing a harassment-free experience for everyone.
+We will not tolerate harassment of participants in any form.
+We’ve adopted the [Party Corgi Network’s Code of Conduct][coc].
+We will have moderators to ensure that the code of conduct is followed.
+
+### Do you have a different question?
+
+Reach out to us on [Twitter][].
+
+[first commit]: https://github.com/mdx-js/mdx/commit/dee47dc20b08d534132e3b966cdccf3b88c7bca5
+
+[twitter]: https://twitter.com/mdx_js
+
+[coc]: https://github.com/partycorgi/partycorgi/blob/corgi/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Should be somewhere on the site that we had a conf. And the videos should be shown.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
