### PR TITLE
Add `schema.org` ldjson about language to home page

### DIFF
--- a/docs/_component/home.server.js
+++ b/docs/_component/home.server.js
@@ -9,6 +9,11 @@ export const Home = (props) => {
     <div className="page home">
       <NavSiteSkip />
       <main>
+        {props.meta.schemaOrg && (
+          <script type="application/ld+json">
+            {JSON.stringify(props.meta.schemaOrg)}
+          </script>
+        )}
         <article>
           <div className="content body">{children}</div>
         </article>

--- a/docs/index.server.mdx
+++ b/docs/index.server.mdx
@@ -6,7 +6,29 @@ export const info = {
     {name: 'John Otander', github: 'johno', twitter: '4lpine'}
   ],
   published: new Date('2017-12-23'),
-  modified: new Date('2021-11-01')
+  modified: new Date('2021-11-01'),
+  schemaOrg: {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "additionalType": "ComputerLanguage",
+    "name": "MDX",
+    "description": "an authorable format for writing JSX in markdown documents",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Windows, MacOS, Linux",
+    "url": "https://mdxjs.com",
+    "sameAs": [
+      "https://www.wikidata.org/wiki/Q95971592",
+      "https://www.wikidata.org/wiki/Q27966906",
+      "https://www.wikidata.org/wiki/Q95961071",
+      "https://en.wikipedia.org/wiki/MDX_(markup_language)",
+      "https://github.com/mdx-js/mdx"
+    ],
+    "offers": {
+      "@type": "Offer",
+      "price": "0.00",
+      "priceCurrency": "USD"
+    }
+  }
 }
 export const year = 2018
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

leverage https://schema.org and structured data.
Specifically https://schema.org/SoftwareApplication and https://schema.org/ComputerLanguage to annotated the home page so search engines know how MDX relates to other parts of the knowledge graph and can show a smart card.

Currently only the home page is annotated with Software Application.
In the future we may want to add other smart card enabled types https://developers.google.com/search/docs/advanced/appearance/overview, like HowTo, FAQ, Article, and Event.

This can be tested using https://search.google.com/test/rich-results pointing to the home page