### PR TITLE
Fix `vue.config.js` example

### DIFF
--- a/docs/docs/getting-started.server.mdx
+++ b/docs/docs/getting-started.server.mdx
@@ -369,9 +369,11 @@ you’re using that, for more info.
         .use('babel-loader')
           .loader('babel-loader')
           .options({plugins: ['@vue/babel-plugin-jsx'], /* Other options… */})
+          .end()
         .use('@mdx-js/loader')
           .loader('@mdx-js/loader')
           .options({jsx: true, /* otherOptions… */})
+          .end()
     }
   }
   ```


### PR DESCRIPTION
This fixes a typo in the `vue.config.js` example.

Closes GH-1718.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
