### PR TITLE
Fix type of children prop for react provider

### DIFF
--- a/packages/react/lib/index.js
+++ b/packages/react/lib/index.js
@@ -8,7 +8,7 @@
  *   Mapping of names for JSX components to React components.
  * @property {boolean} [disableParentContext=false]
  *   Turn off outer component context.
- * @property {ReactNode[]} [children]
+ * @property {ReactNode} [children]
  *   Children.
  *
  * @callback MergeComponents


### PR DESCRIPTION
Currently the `<MDXProvider />` component expects at least 2 children, but it’s also acceptable to use just one child.

[playground link](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQFA3AB2MWUBeWcAwiZA1kwAViYdAG8acSXFwALYABsAJpQYB+AFyYqMAHTY8MAHIRFWANw0AvnVO55ySnAIBXBvmAQGXHp-4wAFGDCqJrc4L6CwQCUmvr4etoAovJYIH4WNAD0mXAgzvIwwGAp0nJKKjQAPGG8fgB8ElLZcAwQpQrK-I2S1T58THCZDVKDOb7tSt1wveH9MMMjUjO1A0NTlZk1EfNVm331NEA)
