### PR TITLE
Add `run`, `runSync` exports

### DIFF
--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -7,4 +7,5 @@
 export {createProcessor} from './lib/core.js'
 export {compile, compileSync} from './lib/compile.js'
 export {evaluate, evaluateSync} from './lib/evaluate.js'
+export {run, runSync} from './lib/run.js'
 export {nodeTypes} from './lib/node-types.js'


### PR DESCRIPTION
### Can you expand on the problem you’re having

I was replacing `mdx-bundler`, where I used the following feature:

```ts
import { getMDXComponent } from 'mdx-bundler/client';
```

In the setup I have the following routing in NextJS:

```text
<root>/src/pages/adrs/[slug].tsx
```

Notice the `[slug]`, which means that part of the routing is dynamic. I am doing
the following in my `getStaticProps`:

```tsx
// server-side NextJS
export const getStaticProps: GetStaticProps<SlugProps, RouteParam> = async (props) => {
  const source = await readFile(`${props.params!.slug}/index.mdx`, {
    // Eventually this become a configuration, the intention is that you can
    // have something like https://docusaurus.io/ tool
    atRootDir: '@/routes/adrs/routes/[slug]/routes', 
  });
  const post = await mdx.compile(source, {
    outputFormat: 'function-body', // notice the usage of function-body
    // ...
  });
  
  return {
    props: {
      post: {
        code: post.value,
      },
    },
  };
};
```

So then in the client, I can use `props.post.code` eventually in my client.

```tsx
import { getMDXModule } from '@mdx-js/react';

export function MDX(props: MDXProps) {
  const Component = React.useMemo(() => getMDXModule(props.source), [props.source]);
  return <Component.default components={props.slots} />;
}

export function Slug(props: SlugProps) {
  return <MDX source={props.post.code} />;
}
```

#### How this solves that, and whether there are potential alternatives?

I am not sure if there is a better alternative and way to do this.

The directory containing `the ADRs will be outside my app`, so I am not sure
if I should use `import(...)` directly `from the client side`. How does the file system lookup would work? I am not sure

Happy to hear from alternatives, the end-goal is to allow people to use such
setup for documentation like `docusaurus` but specific to ADRs and the tool.

### Should this feature be here? In this package? Could it be somewhere else? Where?

Since everything is related to MDX and React, it feels the right place. And
it feels that `mdx@v2` was definitely taking into consideration this since at least I found `function-body` in it that feels it could be used for use cases
(I would like to understand why it is there for you don't mind.)

I am personally biased towards adding it to the package because it is
tree-shaking friendly, and the code shouldn't change much, and it was quite
handy for those few cases that people want to reach for sending the string from
SSR.

It could be definitely in another package, the complexity is to know that you
need to pass `react/jsx-runtime` and do the trick with `new Function`, once
you know how to do it, it is simple, but probably a lot of time researching.

I can take the lead on publishing a package, but my personal bias is more about
helping the future person that didn't know how to solve the problem or that
such an external package exists.

No preferences in the grand scheme of things

---

Full credit to: https://github.com/kentcdodds/mdx-bundler and @kentcdodds on this one.
