### PR TITLE
Ignore `react-dom`, `react-server-dom-webpack` in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "extends": ["config:base", ":preserveSemverRanges"],
-  "schedule": "before 3am on Monday"
+  "schedule": "before 3am on Monday",
+  "packageRules": [
+    {
+      "matchPackageNames": ["react-dom", "react-server-dom-webpack"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
These package are experimental and contain RSC. Switching to a random public react version as proposed by https://github.com/mdx-js/mdx/pull/1790 and such just breaks everything

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
