### PR TITLE
Fix installing `@mdx-js/register` on Node 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2787,6 +2787,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -4039,6 +4040,7 @@
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.23.tgz",
       "integrity": "sha512-CGZSokFwidI50GOAmkz/7z3QdMzTQqAiUOzt95PuhKgi6VVztn9D03ZCzzi93uUWlp/v6A9osvNWpIvqHvKjTA==",
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^1.7.1"
@@ -6422,7 +6424,8 @@
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "node_modules/file-url": {
       "version": "4.0.0",
@@ -11570,7 +11573,8 @@
     "node_modules/node-addon-api": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "optional": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.1",
@@ -21969,8 +21973,7 @@
       "version": "2.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
-        "@mdx-js/mdx": "^2.0.0-rc.1",
-        "deasync": "^0.1.0"
+        "@mdx-js/mdx": "^2.0.0-rc.1"
       },
       "devDependencies": {
         "@types/react": "^17.0.0",
@@ -21981,6 +21984,9 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      },
+      "optionalDependencies": {
+        "deasync": "^0.1.0"
       }
     },
     "packages/register/node_modules/react": {
@@ -25016,6 +25022,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -26013,6 +26020,7 @@
       "version": "0.1.23",
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.23.tgz",
       "integrity": "sha512-CGZSokFwidI50GOAmkz/7z3QdMzTQqAiUOzt95PuhKgi6VVztn9D03ZCzzi93uUWlp/v6A9osvNWpIvqHvKjTA==",
+      "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "node-addon-api": "^1.7.1"
@@ -27770,7 +27778,8 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "file-url": {
       "version": "4.0.0",
@@ -31548,7 +31557,8 @@
     "node-addon-api": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "optional": true
     },
     "node-fetch": {
       "version": "2.6.1",

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -35,7 +35,9 @@
     "index.cjs"
   ],
   "dependencies": {
-    "@mdx-js/mdx": "^2.0.0-rc.1",
+    "@mdx-js/mdx": "^2.0.0-rc.1"
+  },
+  "optionalDependencies": {
     "deasync": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes installing `@mdx-js/register` on Node 17, as it uses a package (`deasync`) that has native bindings which aren’t yet available for Node 17.
The repo currently can’t be `npm install`ed due to this on Node 17.
We might want to remove `@mdx-js/register`, as the node loader does similar things but better.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
