### PR TITLE
Add better errors when referencing missing components

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,8 @@
       "react/prop-types": "off",
       "unicorn/prefer-node-protocol": "off",
       "capitalized-comments": "off",
-      "complexity": "off"
+      "complexity": "off",
+      "max-depth": "off"
     },
     "overrides": [
       {

--- a/packages/mdx/lib/condition.browser.js
+++ b/packages/mdx/lib/condition.browser.js
@@ -1,0 +1,1 @@
+export const development = false

--- a/packages/mdx/lib/condition.js
+++ b/packages/mdx/lib/condition.js
@@ -1,0 +1,3 @@
+import process from 'node:process'
+
+export const development = process.env.NODE_ENV === 'development'

--- a/packages/mdx/lib/core.js
+++ b/packages/mdx/lib/core.js
@@ -31,6 +31,7 @@ import {rehypeRecma} from './plugin/rehype-recma.js'
 import {rehypeRemoveRaw} from './plugin/rehype-remove-raw.js'
 import {remarkMarkAndUnravel} from './plugin/remark-mark-and-unravel.js'
 import {nodeTypes} from './node-types.js'
+import {development as defaultDevelopment} from './condition.js'
 
 const removedOptions = [
   'filepath',
@@ -53,6 +54,7 @@ const removedOptions = [
  */
 export function createProcessor(options = {}) {
   const {
+    development = defaultDevelopment,
     jsx,
     format,
     outputFormat,
@@ -102,7 +104,7 @@ export function createProcessor(options = {}) {
   pipeline
     .use(rehypeRecma)
     .use(recmaDocument, {...rest, outputFormat})
-    .use(recmaJsxRewrite, {providerImportSource, outputFormat})
+    .use(recmaJsxRewrite, {development, providerImportSource, outputFormat})
 
   if (!jsx) {
     pipeline.use(recmaJsxBuild, {outputFormat})

--- a/packages/mdx/lib/plugin/recma-jsx-build.js
+++ b/packages/mdx/lib/plugin/recma-jsx-build.js
@@ -7,6 +7,7 @@
 
 import {buildJsx} from 'estree-util-build-jsx'
 import {specifiersToDeclarations} from '../util/estree-util-specifiers-to-declarations.js'
+import {toIdOrMemberExpression} from '../util/estree-util-to-id-or-member-expression.js'
 
 /**
  * A plugin to build JSX into function calls.
@@ -33,13 +34,10 @@ export function recmaJsxBuild(options = {}) {
       tree.body[0] = {
         type: 'VariableDeclaration',
         kind: 'const',
-        declarations: specifiersToDeclarations(tree.body[0].specifiers, {
-          type: 'MemberExpression',
-          object: {type: 'Identifier', name: 'arguments'},
-          property: {type: 'Literal', value: 0},
-          computed: true,
-          optional: false
-        })
+        declarations: specifiersToDeclarations(
+          tree.body[0].specifiers,
+          toIdOrMemberExpression(['arguments', 0])
+        )
       }
     }
   }

--- a/packages/mdx/lib/util/estree-util-to-binary-addition.js
+++ b/packages/mdx/lib/util/estree-util-to-binary-addition.js
@@ -1,0 +1,23 @@
+/**
+ * @typedef {import('estree-jsx').Expression} Expression
+ */
+
+/**
+ * @param {Expression[]} expressions
+ */
+export function toBinaryAddition(expressions) {
+  let index = -1
+  /** @type {Expression|undefined} */
+  let left
+
+  while (++index < expressions.length) {
+    const right = expressions[index]
+    left = left ? {type: 'BinaryExpression', left, operator: '+', right} : right
+  }
+
+  // Just for types.
+  /* c8 ignore next */
+  if (!left) throw new Error('Expected non-empty `expressions` to be passed')
+
+  return left
+}

--- a/packages/mdx/lib/util/estree-util-to-id-or-member-expression.js
+++ b/packages/mdx/lib/util/estree-util-to-id-or-member-expression.js
@@ -1,0 +1,64 @@
+/**
+ * @typedef {import('estree-jsx').Identifier} Identifier
+ * @typedef {import('estree-jsx').Literal} Literal
+ * @typedef {import('estree-jsx').JSXIdentifier} JSXIdentifier
+ * @typedef {import('estree-jsx').MemberExpression} MemberExpression
+ * @typedef {import('estree-jsx').JSXMemberExpression} JSXMemberExpression
+ */
+
+import {name as isIdentifierName} from 'estree-util-is-identifier-name'
+
+export const toIdOrMemberExpression = toIdOrMemberExpressionFactory(
+  'Identifier',
+  'MemberExpression'
+)
+
+export const toJsxIdOrMemberExpression =
+  // @ts-expect-error: fine
+  /** @type {(ids: Array.<string|number>) => JSXIdentifier|JSXMemberExpression)} */
+  (toIdOrMemberExpressionFactory('JSXIdentifier', 'JSXMemberExpression'))
+
+/**
+ * @param {string} [idType]
+ * @param {string} [memberType]
+ */
+function toIdOrMemberExpressionFactory(idType, memberType) {
+  return toIdOrMemberExpression
+  /**
+   * @param {Array.<string|number>} ids
+   * @returns {Identifier|MemberExpression}
+   */
+  function toIdOrMemberExpression(ids) {
+    let index = -1
+    /** @type {Identifier|Literal|MemberExpression|undefined} */
+    let object
+
+    while (++index < ids.length) {
+      const name = ids[index]
+      /** @type {Identifier|Literal} */
+      // @ts-expect-error: JSX is fine.
+      const id =
+        typeof name === 'string' && isIdentifierName(name)
+          ? {type: idType, name}
+          : {type: 'Literal', value: name}
+      // @ts-expect-error: JSX is fine.
+      object = object
+        ? {
+            type: memberType,
+            object,
+            property: id,
+            computed: id.type === 'Literal',
+            optional: false
+          }
+        : id
+    }
+
+    // Just for types.
+    /* c8 ignore next 3 */
+    if (!object) throw new Error('Expected non-empty `ids` to be passed')
+    if (object.type === 'Literal')
+      throw new Error('Expected identifier as left-most value')
+
+    return object
+  }
+}

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -34,6 +34,12 @@
   "sideEffects": false,
   "main": "index.js",
   "types": "index.d.ts",
+  "browser": {
+    "./lib/condition.js": "./lib/condition.browser.js"
+  },
+  "react-native": {
+    "./lib/condition.js": "./lib/condition.browser.js"
+  },
   "files": [
     "lib/",
     "index.d.ts",

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -378,6 +378,77 @@ export default MDXContent
 
 </details>
 
+###### `options.development`
+
+Whether to add extra information to error messages in generated code
+(`boolean?`, default: `false`).
+The default can be set to `true` in Node.js through environment variables: set
+`NODE_ENV=development`.
+
+<details>
+<summary>Example</summary>
+
+Say we had some MDX that references a component that can be passed or provided
+at runtime:
+
+```mdx
+**Note**<NoteIcon />: some stuff.
+```
+
+And a module to evaluate that:
+
+```js
+import {promises as fs} from 'node:fs'
+import * as runtime from 'react/jsx-runtime'
+import {evaluate} from '@mdx-js/mdx'
+
+main()
+
+async function main() {
+  const path = 'example.mdx'
+  const value = await fs.readFile(path)
+  const MDXContent = (await evaluate({path, value}, runtime)).default
+  console.log(MDXContent())
+}
+```
+
+Running that would normally (production) yield:
+
+```txt
+Error: Expected component `NoteIcon` to be defined: you likely forgot to import, pass, or provide it.
+    at _missingMdxReference (eval at run (…/@mdx-js/mdx/lib/run.js:18:10), <anonymous>:27:9)
+    at _createMdxContent (eval at run (…/@mdx-js/mdx/lib/run.js:18:10), <anonymous>:15:20)
+    at MDXContent (eval at run (…/@mdx-js/mdx/lib/run.js:18:10), <anonymous>:9:9)
+    at main (…/example.js:11:15)
+```
+
+But if we change add `development: true` to our example:
+
+```diff
+@@ -7,6 +7,6 @@ main()
+ async function main() {
+   const path = 'example.mdx'
+   const value = await fs.readFile(path)
+-  const MDXContent = (await evaluate({path, value}, runtime)).default
++  const MDXContent = (await evaluate({path, value}, {development: true, ...runtime})).default
+   console.log(MDXContent({}))
+ }
+```
+
+And we’d run it again, we’d get:
+
+```txt
+Error: Expected component `NoteIcon` to be defined: you likely forgot to import, pass, or provide it.
+It’s referenced in your code at `1:9-1:21` in `example.mdx`
+provide it.
+    at _missingMdxReference (eval at run (…/@mdx-js/mdx/lib/run.js:18:10), <anonymous>:27:9)
+    at _createMdxContent (eval at run (…/@mdx-js/mdx/lib/run.js:18:10), <anonymous>:15:20)
+    at MDXContent (eval at run (…/@mdx-js/mdx/lib/run.js:18:10), <anonymous>:9:9)
+    at main (…/example.js:11:15)
+```
+
+</details>
+
 ###### `options.SourceMapGenerator`
 
 The `SourceMapGenerator` class from [`source-map`][source-map] (optional).

--- a/packages/node-loader/readme.md
+++ b/packages/node-loader/readme.md
@@ -116,9 +116,10 @@ Create a Node ESM loader to compile MDX to JS.
 ```js
 import {createLoader} from '@mdx-js/node-loader'
 
-const {getFormat, transformSource} = createLoader(/* Options… */)
+// Load is for Node 17+, the rest for 12-16.
+const {load, getFormat, transformSource} = createLoader(/* Options… */)
 
-export {getFormat, transformSource}
+export {load, getFormat, transformSource}
 ```
 
 This example can then be used with `node --experimental-loader=my-loader.js`.


### PR DESCRIPTION
Previously, React or other JSX runtimes threw rather hard to read errors
when a component was undefined (because it wasn’t imported, passed, or
provided), essentially only pointing to *something* missing.
Now we throw proper errors when a component is missing at runtime,
including what exact component (or object) is undefined.

In addition, this adds a `development` option, which defaults to
`false` but can be configured explicitly or turned on with
`NODE_ENV=development`.
When it’s `true`, the exact place that references the missing component
or object, and which file did that, is included in the error message.

Related-to: mdx-js/mdx#1775.
Backports: wooorm/xdm@62e6f30.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
