### PR TITLE
Fix broken link

### DIFF
--- a/docs/docs/using-mdx.server.mdx
+++ b/docs/docs/using-mdx.server.mdx
@@ -455,7 +455,7 @@ No component is used for `h1`.
 
 [vue]: /docs/getting-started/#vue
 
-[toc]: /docs/table-of-components/
+[toc]: /table-of-components/
 
 [support]: /community/support/
 


### PR DESCRIPTION
**Issue**: toc url at https://mdxjs.com/docs/using-mdx/#components was returning 404 Not Found.
**Reason**: link was pointing to the wrong URL
**Deatails**: Clicking on the URL was returning 404 Not found as it was pointing towards `docs/table-of-components/` instead of `table-of-components/`
**Solution**: Removed `docs/` from the URL in the respective documentation file.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
