### PR TITLE
Add providerImportSource instructions in React docs

### DIFF
--- a/packages/react/readme.md
+++ b/packages/react/readme.md
@@ -86,8 +86,13 @@ directly:
 
 See [¶ React in § Getting started][start-react] for how to get started with MDX
 and React.
+
 See [¶ MDX provider in § Using MDX][use-provider] for how to use an MDX
 provider.
+
+If using a custom webpack setup and you wish to use an MDX provider,
+make sure to setup the `providerImportSource` in your webpack config.
+See [the migration docs for an example][mdx-loader-migration-guide].
 
 ## API
 
@@ -221,8 +226,10 @@ abide by its terms.
 
 [start-react]: https://mdxjs.com/getting-started/#react
 
-[use-provider]: https://mdxjs.com/using-mdx/#mdx-provider
+[use-provider]: https://mdxjs.com/docs/using-mdx/#mdx-provider
 
 [security]: https://mdxjs.com/getting-started/#security
 
 [typescript]: https://www.typescriptlang.org
+
+[mdx-loader-migration-guide]: https://mdxjs.com/migrating/v2/#mdx-jsloader


### PR DESCRIPTION
Hi there,

Thanks for this great lib!

I had an issue just now when trying to use the `MDXProvider` in a next js app. I had a custom webpack config setup but the components passed to the provider were having no effect.

I found this issue, which provided the answer for me: https://github.com/mdx-js/mdx/issues/1774. However, the React docs do not mention this, and because someone else had clearly had the same issue previously, I figured it would make sense to add this information into the docs.

I also spotted a broken link in the same part of the docs I was editing (the link to `use-provider` was broken), so I fixed that too.

