### PR TITLE
Fix broken link

### DIFF
--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -1105,7 +1105,7 @@ abide by its terms.
 
 [integrations]: https://mdxjs.com/getting-started/#integrations
 
-[using-mdx]: https://mdxjs.com/using-mdx/
+[using-mdx]: https://mdxjs.com/docs/using-mdx/
 
 [esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 


### PR DESCRIPTION
This PR fixes broken link in the "Use" section of https://mdxjs.com/packages/mdx/#use.

![image](https://user-images.githubusercontent.com/7077157/144265728-7c1168ca-2b45-4818-8108-6483047d26cf.png)

The "§ Using MDX" text in that later section links to an invalid URL (it gives 404): https://mdxjs.com/using-mdx/. The valid URL should be https://mdxjs.com/docs/using-mdx.