### PR TITLE
Refactor to clarify how to connect providers

### DIFF
--- a/packages/preact/readme.md
+++ b/packages/preact/readme.md
@@ -36,11 +36,8 @@ MDX.
 ## When should I use this?
 
 This package is not needed for MDX to work with Preact.
-But it is nice if you enjoy context-based props passing to avoid repetition.
-This package adds support for a Preact context based interface to set components
-(sometimes known as *shortcodes*) by passing them to an `MDXProvider`, which
-then are used in all nested MDX files implicitly.
-The alternative is to pass those components to each MDX file.
+See [¶ MDX provider in § Using MDX][use-provider] for when and how to use an MDX
+provider.
 
 ## Install
 
@@ -63,7 +60,11 @@ yarn add @mdx-js/preact@next
 
 ```js
 import {MDXProvider} from '@mdx-js/preact'
-import Post from './post.mdx' // Assumes an integration is used to compile MDX -> JS.
+import Post from './post.mdx'
+// ^-- Assumes an integration is used to compile MDX to JS, such as
+// `@mdx-js/esbuild`, `@mdx-js/loader`, `@mdx-js/node-loader`, or
+// `@mdx-js/rollup`, and that it is configured with
+// `options.providerImportSource: '@mdx-js/preact'`.
 
 const components = {
   em: props => <i {...props} />

--- a/packages/react/readme.md
+++ b/packages/react/readme.md
@@ -36,11 +36,8 @@ MDX.
 ## When should I use this?
 
 This package is not needed for MDX to work with React.
-But it is nice if you enjoy context-based props passing to avoid repetition.
-This package adds support for a React context based interface to set components
-(sometimes known as *shortcodes*) by passing them to an `MDXProvider`, which
-then are used in all nested MDX files implicitly.
-The alternative is to pass those components to each MDX file.
+See [¶ MDX provider in § Using MDX][use-provider] for when and how to use an MDX
+provider.
 
 ## Install
 
@@ -63,7 +60,11 @@ yarn add @mdx-js/react@next
 
 ```js
 import {MDXProvider} from '@mdx-js/react'
-import Post from './post.mdx' // Assumes an integration is used to compile MDX -> JS.
+import Post from './post.mdx'
+// ^-- Assumes an integration is used to compile MDX to JS, such as
+// `@mdx-js/esbuild`, `@mdx-js/loader`, `@mdx-js/node-loader`, or
+// `@mdx-js/rollup`, and that it is configured with
+// `options.providerImportSource: '@mdx-js/react'`.
 
 const components = {
   em: props => <i {...props} />

--- a/packages/vue/readme.md
+++ b/packages/vue/readme.md
@@ -33,11 +33,8 @@ This package is a context based components provider for combining Vue with MDX.
 ## When should I use this?
 
 This package is not needed for MDX to work with Vue.
-But it is nice if you enjoy context-based props passing to avoid repetition.
-This package adds support for a Vue context based interface to set components
-(sometimes known as *shortcodes*) by passing them to an `MDXProvider`, which
-then are used in all nested MDX files implicitly.
-The alternative is to pass those components to each MDX file.
+See [¶ MDX provider in § Using MDX][use-provider] for when and how to use an MDX
+provider.
 
 ## Install
 
@@ -61,7 +58,11 @@ yarn add @mdx-js/vue@next
 ```js
 import {MDXProvider} from '@mdx-js/vue'
 import {createApp} from 'vue'
-import Post from './post.mdx' // Assumes an integration is used to compile MDX -> JS.
+import Post from './post.mdx'
+// ^-- Assumes an integration is used to compile MDX to JS, such as
+// `@mdx-js/esbuild`, `@mdx-js/loader`, `@mdx-js/node-loader`, or
+// `@mdx-js/rollup`, and that it is configured with
+// `options.providerImportSource: '@mdx-js/vue'`.
 
 createApp({
   data() {
@@ -107,7 +108,7 @@ Configuration (`Object`, optional).
 
 ###### `props.components`
 
-Mapping of names for JSX components to React components
+Mapping of names for JSX components to Vue components
 (`Record<string, string|Component|Components>`, optional).
 
 ##### Returns


### PR DESCRIPTION
The connection of providers (`@mdx-js/react`, `@mdx-js/preact`, or `@mdx-js/vue`) doesn’t happen with them, but in the integration (`@mdx-js/esbuild`, `@mdx-js/loader`, `@mdx-js/node-loader`, or `@mdx-js/rollup`), or `@mdx-js/mdx` itself.
This adds an explanation of that in § Use and also removes some info in favor of an (already linked) article that explains it in more detail.

Closes GH-1837.

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
