### PR TITLE
Fix resolve base in esbuild loader

### DIFF
--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -212,7 +212,7 @@ export function esbuild(options = {}) {
       assert(file.dirname, 'expected `dirname` to be defined')
 
       // V8 on Erbium.
-      /* c8 ignore next 2 */
+      /* c8 ignore next 9 */
       return {
         contents: value,
         errors,

--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -14,9 +14,9 @@
  */
 
 import assert from 'node:assert'
-import {promises as fs} from 'fs'
+import {promises as fs} from 'node:fs'
 import path from 'node:path'
-import process from 'process'
+import process from 'node:process'
 import {URL} from 'url'
 import got from 'got'
 import {VFile} from 'vfile'

--- a/packages/esbuild/test/index.test.js
+++ b/packages/esbuild/test/index.test.js
@@ -82,7 +82,7 @@ test('@mdx-js/esbuild', async () => {
 
   await fs.unlink(new URL('./esbuild-resolve.mdx', import.meta.url))
   await fs.unlink(new URL('./esbuild-resolve.js', import.meta.url))
-  await fs.rm(new URL('./folder/', import.meta.url), {recursive: true})
+  await fs.rmdir(new URL('./folder/', import.meta.url), {recursive: true})
 
   // Markdown.
   await fs.writeFile(new URL('./esbuild.md', import.meta.url), '\ta')

--- a/packages/mdx/lib/condition.js
+++ b/packages/mdx/lib/condition.js
@@ -1,3 +1,3 @@
-import process from 'node:process'
+import process from 'process'
 
 export const development = process.env.NODE_ENV === 'development'


### PR DESCRIPTION
Closes GH-1821.
Related-to: wooorm/xdm@db74ddc

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
