### PR TITLE
Fix unnecessary top-level context changes

### DIFF
--- a/packages/react/lib/index.js
+++ b/packages/react/lib/index.js
@@ -65,14 +65,17 @@ export function withMDXComponents(Component) {
  */
 export function useMDXComponents(components) {
   const contextComponents = React.useContext(MDXContext)
-
-  // Custom merge via a function prop
-  if (typeof components === 'function') {
-    return components(contextComponents)
-  }
-
-  return {...contextComponents, ...components}
+  // Memoize to avoid unnecessary top-level context changes
+  return React.useMemo(() => {
+    // Custom merge via a function prop
+    if (typeof components === 'function') {
+      return components(contextComponents)
+    }
+    return {...contextComponents, ...components}
+  }, [contextComponents, components])
 }
+
+const emptyObject = {}
 
 /**
  * Provider for MDX context
@@ -84,7 +87,7 @@ export function MDXProvider({components, children, disableParentContext}) {
   let allComponents = useMDXComponents(components)
 
   if (disableParentContext) {
-    allComponents = components || {}
+    allComponents = components || emptyObject
   }
 
   return React.createElement(

--- a/packages/react/lib/index.js
+++ b/packages/react/lib/index.js
@@ -75,6 +75,7 @@ export function useMDXComponents(components) {
   }, [contextComponents, components])
 }
 
+/** @type {Components} */
 const emptyObject = {}
 
 /**


### PR DESCRIPTION
MDXProvider often sits at the top of the trees. **The object spread here is unfortunate because it means the provider value will always be new,** and so React would need to spend time propagating the context (even though nothing really changed). This also has implications on Selective Hydration in React 18: if top-level context updates before hydration is fully finished, we have to show Suspense fallbacks — which isn't a great experience when it's unnecessary. https://github.com/facebook/react/issues/22692.

This change should fix it.

## How to test

I typed this change on GH so you'll need to double-check but hopefully this looks good.

Locally, I tested something similar with manual editing in `node_modules`, and it worked.

My actual "test case" is in https://github.com/reactjs/reactjs.org/pull/4256. When I do this fix together with https://github.com/vercel/next.js/pull/33861, HTML from code-split chunks is no longer forced to turn into a fallback. I've artificially increased the bundle load delay in this video to make the hydration noticeable. When code blocks become colored, it's hydrated:

https://user-images.githubusercontent.com/810438/151968822-d13c61f9-1ad6-49c2-8260-73d9a9d53580.mov

Before the change, the code blocks would turn into placeholders before turning back into codeblocks.