### PR TITLE
Fix playground example

### DIFF
--- a/docs/playground.server.mdx
+++ b/docs/playground.server.mdx
@@ -14,7 +14,7 @@ Below is an example of markdown in JSX.
 
 <div style={{padding: '1rem', backgroundColor: 'violet'}}>
   Try and change the background color to \`tomato\`.
-</div>`
+</div>
 
 # Playground
 

--- a/docs/playground.server.mdx
+++ b/docs/playground.server.mdx
@@ -12,8 +12,9 @@ export const info = {
 export const playgroundSource = `Hello, world!
 Below is an example of markdown in JSX.
 
-<div style={{padding: '1rem', backgroundColor: 'violet'}} />
-Try and change the background color to \`tomato\`.`
+<div style={{padding: '1rem', backgroundColor: 'violet'}}>
+  Try and change the background color to \`tomato\`.
+</div>`
 
 # Playground
 

--- a/docs/playground.server.mdx
+++ b/docs/playground.server.mdx
@@ -12,7 +12,7 @@ export const info = {
 export const playgroundSource = `Hello, world!
 Below is an example of markdown in JSX.
 
-<div style={{padding: '1rem', backgroundColor: 'violet'}}>
+<div style={{padding: '1rem', backgroundColor: 'violet'}} />
 Try and change the background color to \`tomato\`.`
 
 # Playground

--- a/docs/playground.server.mdx
+++ b/docs/playground.server.mdx
@@ -14,7 +14,7 @@ Below is an example of markdown in JSX.
 
 <div style={{padding: '1rem', backgroundColor: 'violet'}}>
   Try and change the background color to \`tomato\`.
-</div>
+</div>`
 
 # Playground
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

Playground's default piece of code is broken because `<div />` wasn't closed.

<img width="1049" alt="Screen Shot 2022-02-02 at 12 47 42" src="https://user-images.githubusercontent.com/9027363/152187807-22da492a-39d7-4aaa-acf1-0dd33f1eccf9.png">

