### PR TITLE
hopefully fixes issue #1772

### DIFF
--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -119,6 +119,17 @@ export const Editor = ({children}) => {
   )
   const stats = state.file ? statistics(state.file) : {}
 
+  //Create a preview component that can handle errors with try-catch block; hopefully catching invalid JS expressions errors
+  const Preview = useCallback(() => {
+    try {
+      return state.file.result();
+    } catch (error) {
+      return (<pre>
+        <code>{String(error.message)}</code>
+      </pre>);
+    }
+  }, [state.file.result]);
+
   return (
     <div>
       <Tabs className="frame">
@@ -234,7 +245,7 @@ export const Editor = ({children}) => {
           <div className="frame-body frame-body-box-fixed-height frame-body-box">
             {state.file && state.file.result ? (
               <ErrorBoundary FallbackComponent={FallbackComponent}>
-                {state.file.result()}
+                <Preview />
               </ErrorBoundary>
             ) : null}
           </div>


### PR DESCRIPTION
reference https://github.com/mdx-js/mdx/issues/1772

Add a Javascript try/catch to prevent the Playground page from crashing from incomplete JavaScript expressions in Preview.

Closes https://github.com/mdx-js/mdx/issues/1772

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
