### PR TITLE
Add missing dependency

### DIFF
--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@mdx-js/mdx": "^2.0.0",
     "@rollup/pluginutils": "^4.0.0",
-    "source-map": "^0.7.0"
+    "source-map": "^0.7.0",
+    "vfile": "^5.0.0"
   },
   "peerDependencies": {
     "rollup": ">=2"


### PR DESCRIPTION
`@mdx-js/rollup` [depends on vfile](https://github.com/mdx-js/mdx/blob/main/packages/rollup/lib/index.js#L16) but I think it's just working in some cases at the moment because of the transitive dependency via `@mdx-js/mdx`.

My project has another transitive dependency on vfile@^4.0.0, which is the one yarn puts in the root `node_modules` and that `@mdx-js/rollup@2.0.0` ends up importing, then 💥 because it's the old commonjs version.

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
