### PR TITLE
Fix to improve example

### DIFF
--- a/docs/guides/frontmatter.server.mdx
+++ b/docs/guides/frontmatter.server.mdx
@@ -93,7 +93,7 @@ title: Hi, World!
 ```
 
 That’s exactly what the remark plugin
-[`remark-mdx-frontmatter`][remark-mdx-frontmatter] does. 
+[`remark-mdx-frontmatter`][remark-mdx-frontmatter] does.
 
 remark plugins can be passed in
 [`options.remarkPlugins`][options-remark-plugins].

--- a/docs/guides/frontmatter.server.mdx
+++ b/docs/guides/frontmatter.server.mdx
@@ -89,11 +89,11 @@ Like so:
 title: Hi, World!
 ---
 
-# {frontmatter.title}
+# {title}
 ```
 
 That’s exactly what the remark plugin
-[`remark-mdx-frontmatter`][remark-mdx-frontmatter] does.
+[`remark-mdx-frontmatter`][remark-mdx-frontmatter] does. 
 
 remark plugins can be passed in
 [`options.remarkPlugins`][options-remark-plugins].


### PR DESCRIPTION
Hi,
`remark-mdx-frontmatter` by default exposes frontmatter properties in global namespace. I've found the example with `frontmatter.title` confusing and have a suggestion to present example with default plugin options.

If you would like to leave current example, then the idea might be to add the information about `options.name` to `remark-mdx-frontmatter` to make this example work. 

Cheers