### PR TITLE
Mark react as peer dependency

### DIFF
--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -48,6 +48,7 @@
   },
   "peerDependencies": {
     "webpack": ">=4"
+    "react": ">=16"
   },
   "devDependencies": {
     "@types/loader-utils": "^2.0.0",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -47,7 +47,7 @@
     "source-map": "^0.7.0"
   },
   "peerDependencies": {
-    "webpack": ">=4"
+    "webpack": ">=4",
     "react": ">=16"
   },
   "devDependencies": {


### PR DESCRIPTION
`@mdx-js/react` that is its dependency has `react as peer dependency.

So, It should have `react` as peer dependency.

I did it.