### PR TITLE
fix: vfile import

### DIFF
--- a/packages/rollup/lib/index.js
+++ b/packages/rollup/lib/index.js
@@ -13,7 +13,7 @@
  */
 
 import {SourceMapGenerator} from 'source-map'
-import vfile from 'vfile'
+import VFile from 'vfile'
 import {createFilter} from '@rollup/pluginutils'
 import {createFormatAwareProcessors} from '@mdx-js/mdx/lib/util/create-format-aware-processors.js'
 
@@ -34,7 +34,7 @@ export function rollup(options = {}) {
   return {
     name: '@mdx-js/rollup',
     async transform(value, path) {
-      const file = new vfile.VFile({value, path})
+      const file = new VFile({value, path})
 
       if (
         file.extname &&

--- a/packages/rollup/lib/index.js
+++ b/packages/rollup/lib/index.js
@@ -13,7 +13,7 @@
  */
 
 import {SourceMapGenerator} from 'source-map'
-import {VFile} from 'vfile'
+import vfile from 'vfile'
 import {createFilter} from '@rollup/pluginutils'
 import {createFormatAwareProcessors} from '@mdx-js/mdx/lib/util/create-format-aware-processors.js'
 
@@ -34,7 +34,7 @@ export function rollup(options = {}) {
   return {
     name: '@mdx-js/rollup',
     async transform(value, path) {
-      const file = new VFile({value, path})
+      const file = new vfile.VFile({value, path})
 
       if (
         file.extname &&


### PR DESCRIPTION
`vfile` is not an es module, and it only has a default export. So named import throw errors:

```
file:///Users/guoyunhe/Git/cratedx/node_modules/@mdx-js/rollup/lib/index.js:16
import {VFile} from 'vfile'
        ^^^^^
SyntaxError: Named export 'VFile' not found. The requested module 'vfile' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'vfile';
const {VFile} = pkg;
```

This PR uses the default export to fix the errors.

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
