### PR TITLE
Fix some more playground errors

### DIFF
--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -241,7 +241,9 @@ export const Editor = ({children}) => {
         <TabPanel>
           <noscript>Enable JavaScript for the rendered result.</noscript>
           <div className="frame-body frame-body-box-fixed-height frame-body-box">
-            {state.file && state.file.result ? <Preview /> : null}
+            <ErrorBoundary FallbackComponent={ErrorFallback}>
+              {state.file && state.file.result ? <Preview /> : null}
+            </ErrorBoundary>
           </div>
         </TabPanel>
         <TabPanel>


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

Closes #1956

Looks like this bug got re-introduced when we removed the Preview ErrorBoundary in favor of a try... catch. Having both would catch both types of bugs.

Bug caught by the try...catch:

* Referencing components that's not within scope: `<Test />`
* Unclosed components: `<Test>`

Bugs caught by ErrorBoundary:

* syntax errors in dom, such as `<div style=""></div>`