### PR TITLE
Fix to not add `_missingMdxReference` when thing is in scope

### DIFF
--- a/packages/mdx/lib/plugin/recma-jsx-rewrite.js
+++ b/packages/mdx/lib/plugin/recma-jsx-rewrite.js
@@ -146,9 +146,9 @@ export function recmaJsxRewrite(options = {}) {
                 !isInScope ||
                 // If the parent scope is `_createMdxContent`, then this
                 // references a component we can add a check statement for.
-                (parentNode &&
-                  parentNode.type === 'FunctionDeclaration' &&
-                  isNamedFunction(parentNode, '_createMdxContent'))
+                (parentScope &&
+                  parentScope.node.type === 'FunctionDeclaration' &&
+                  isNamedFunction(parentScope.node, '_createMdxContent'))
               ) {
                 fnScope.references[fullId] = {node, component: true}
               }

--- a/packages/mdx/lib/plugin/recma-jsx-rewrite.js
+++ b/packages/mdx/lib/plugin/recma-jsx-rewrite.js
@@ -142,7 +142,6 @@ export function recmaJsxRewrite(options = {}) {
               const parentScope = /** @type {Scope|null} */ (
                 currentScope.parent
               )
-              const parentNode = parentScope && parentScope.node
               if (
                 !isInScope ||
                 // If the parent scope is `_createMdxContent`, then this

--- a/packages/mdx/lib/plugin/recma-jsx-rewrite.js
+++ b/packages/mdx/lib/plugin/recma-jsx-rewrite.js
@@ -136,11 +136,24 @@ export function recmaJsxRewrite(options = {}) {
             const fullId = ids.join('.')
             const id = name.name
 
+            const isInScope = inScope(currentScope, id)
+
             if (!own.call(fnScope.references, fullId)) {
-              fnScope.references[fullId] = {node, component: true}
+              const parentScope = /** @type {Scope|null} */ (
+                currentScope.parent
+              )
+              const parentNode = parentScope && parentScope.node
+              if (
+                !isInScope ||
+                (parentNode &&
+                  parentNode.type === 'FunctionDeclaration' &&
+                  isNamedFunction(parentNode, '_createMdxContent'))
+              ) {
+                fnScope.references[fullId] = {node, component: true}
+              }
             }
 
-            if (!fnScope.objects.includes(id) && !inScope(currentScope, id)) {
+            if (!fnScope.objects.includes(id) && !isInScope) {
               fnScope.objects.push(id)
             }
           }

--- a/packages/mdx/lib/plugin/recma-jsx-rewrite.js
+++ b/packages/mdx/lib/plugin/recma-jsx-rewrite.js
@@ -145,6 +145,7 @@ export function recmaJsxRewrite(options = {}) {
               const parentNode = parentScope && parentScope.node
               if (
                 !isInScope ||
+                // If the parent is a _createMdxContent function, it's a top-level component in MDX.
                 (parentNode &&
                   parentNode.type === 'FunctionDeclaration' &&
                   isNamedFunction(parentNode, '_createMdxContent'))

--- a/packages/mdx/lib/plugin/recma-jsx-rewrite.js
+++ b/packages/mdx/lib/plugin/recma-jsx-rewrite.js
@@ -145,7 +145,8 @@ export function recmaJsxRewrite(options = {}) {
               const parentNode = parentScope && parentScope.node
               if (
                 !isInScope ||
-                // If the parent is a _createMdxContent function, it's a top-level component in MDX.
+                // If the parent scope is `_createMdxContent`, then this
+                // references a component we can add a check statement for.
                 (parentNode &&
                   parentNode.type === 'FunctionDeclaration' &&
                   isNamedFunction(parentNode, '_createMdxContent'))

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -504,7 +504,6 @@ test('compile', async () => {
     )
   }
 
-  // TODO: this is incorrect behavior, will be fixed in GH-1986
   try {
     renderToStaticMarkup(
       React.createElement(
@@ -521,11 +520,10 @@ test('compile', async () => {
     )
   }
 
-  // TODO: this is incorrect behavior, will be fixed in GH-1986
   try {
     renderToStaticMarkup(
       React.createElement(
-        await run(compileSync('<a render={(x) => <x.y />} />'))
+        await run(compileSync('<a render={() => <x.y />} />'))
       )
     )
     assert.unreachable()
@@ -533,10 +531,20 @@ test('compile', async () => {
     const exception = /** @type {Error} */ (error)
     assert.match(
       exception.message,
-      /x is not defined/,
+      /Expected object `x` to be defined/,
       'should throw if a used member is not defined locally (JSX in a function)'
     )
   }
+
+  assert.equal(
+    renderToStaticMarkup(
+      React.createElement(
+        await run(compileSync('<a render={(x) => <x.y />} />'))
+      )
+    ),
+    '<a></a>',
+    'should render if a used member is defined locally (JSX in a function)'
+  )
 
   try {
     renderToStaticMarkup(


### PR DESCRIPTION
When using object members as components, for example `<x.y />`, MDX always adds the following checks:

```js
if (!x) _missingMdxReference("x", false);
if (!x.y) _missingMdxReference("x.y", true);
```

It works for basic cases, but breaks when used inside a function expression and `x` is assigned locally:

```mdx
Hello, world!

{(() => {
    const x = { y: () => '' }
    return <x.y />
})()}
```

This example throws `x is not defined` error because the variable is locally scoped. The solution I propose is to add `_missingMdxReference` only when an object (in this case `x`) is not in scope.