### PR TITLE
Fix to add `_missingMdxReference` in some more cases

### DIFF
--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -516,7 +516,7 @@ test('compile', async () => {
     assert.match(
       exception.message,
       /Expected component `a.b` to be defined/,
-      'should throw if a required member is not passed'
+      'should throw if a used member is not defined locally'
     )
   }
 

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -504,6 +504,7 @@ test('compile', async () => {
     )
   }
 
+  // TODO: this is incorrect behavior, will be fixed in GH-1986
   try {
     renderToStaticMarkup(
       React.createElement(
@@ -520,6 +521,7 @@ test('compile', async () => {
     )
   }
 
+  // TODO: this is incorrect behavior, will be fixed in GH-1986
   try {
     renderToStaticMarkup(
       React.createElement(

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -532,7 +532,7 @@ test('compile', async () => {
     assert.match(
       exception.message,
       /x is not defined/,
-      'should throw if a required member is not passed'
+      'should throw if a used member is not defined locally (JSX in a function)'
     )
   }
 

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -506,6 +506,38 @@ test('compile', async () => {
 
   try {
     renderToStaticMarkup(
+      React.createElement(
+        await run(compileSync('export const a = {}\n\n<a.b />'))
+      )
+    )
+    assert.unreachable()
+  } catch (/** @type {unknown} */ error) {
+    const exception = /** @type {Error} */ (error)
+    assert.match(
+      exception.message,
+      /Expected component `a.b` to be defined/,
+      'should throw if a required member is not passed'
+    )
+  }
+
+  try {
+    renderToStaticMarkup(
+      React.createElement(
+        await run(compileSync('<a render={(x) => <x.y />} />'))
+      )
+    )
+    assert.unreachable()
+  } catch (/** @type {unknown} */ error) {
+    const exception = /** @type {Error} */ (error)
+    assert.match(
+      exception.message,
+      /x is not defined/,
+      'should throw if a required member is not passed'
+    )
+  }
+
+  try {
+    renderToStaticMarkup(
       React.createElement(await run(compileSync('<X />', {development: true})))
     )
     assert.unreachable()


### PR DESCRIPTION
While working on #1986 I found that `_missingMdxReference` checks are not injected sometimes. For example:

```mdx
export const a = {}

<a.b />
```

compiles to

```jsx
/*@jsxRuntime automatic @jsxImportSource react*/
const {jsx: _jsx} = arguments[0];
const a = {};
function MDXContent(props = {}) {
  const {wrapper: MDXLayout} = props.components || ({});
  return MDXLayout ? _jsx(MDXLayout, Object.assign({}, props, {
    children: _jsx(_createMdxContent, {})
  })) : _createMdxContent();
  function _createMdxContent() {
    return _jsx(a.b, {});
  }
}
return {
  a,
  default: MDXContent
};
```

but if I add some markdown content

```mdx
Hello, world!

export const a = {}

<a.b />
```

compiles to

```jsx
/*@jsxRuntime automatic @jsxImportSource react*/
const {Fragment: _Fragment, jsx: _jsx, jsxs: _jsxs} = arguments[0];
const a = {};
function MDXContent(props = {}) {
  const {wrapper: MDXLayout} = props.components || ({});
  return MDXLayout ? _jsx(MDXLayout, Object.assign({}, props, {
    children: _jsx(_createMdxContent, {})
  })) : _createMdxContent();
  function _createMdxContent() {
    const _components = Object.assign({
      p: "p"
    }, props.components);
    if (!a) _missingMdxReference("a", false);
    if (!a.b) _missingMdxReference("a.b", true);
    return _jsxs(_Fragment, {
      children: [_jsx(_components.p, {
        children: "Hello, world!"
      }), "\n", "\n", _jsx(a.b, {})]
    });
  }
}
return {
  a,
  default: MDXContent
};
function _missingMdxReference(id, component) {
  throw new Error("Expected " + (component ? "component" : "object") + " `" + id + "` to be defined: you likely forgot to import, pass, or provide it.");
}
```

This happens because all transforms are inside [this `if` statement](https://github.com/mdx-js/mdx/blob/427bcad073b36637b250ba7dffe1b33f75c003ec/packages/mdx/lib/plugin/recma-jsx-rewrite.js#L266).

```
if (defaults.length > 0 || actual.length > 0) {
```

I fixed it by moving code that injects `_missingMdxReference` statements outside of this `if`.