### PR TITLE
Fix site build on Windows

### DIFF
--- a/website/prerender.js
+++ b/website/prerender.js
@@ -43,7 +43,7 @@ async function main() {
     Object.keys(manifest)
       .filter((d) => path.basename(d) !== 'index.client.js')
       .map(async (d) => {
-        cache[manifest[d]['*'].id] = await import(fileURLToPath(d))
+        cache[manifest[d]['*'].id] = await import(d)
       })
   )
 


### PR DESCRIPTION
It's redundant & causes Windows-incompatibility for absolute paths, because drive letters are misinterpreted as URL protocols

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

Solves https://github.com/mdx-js/mdx/issues/2008 