### PR TITLE
Fix support for `baseUrl` rewriting `import.meta.url`

### DIFF
--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -360,8 +360,8 @@ return {no, default: MDXContent}
 
 ###### `options.baseUrl`
 
-Resolve relative `import` (and `export … from`) from this URL (`string?`,
-example: `import.meta.url`).
+Resolve `import`s (and `export … from`, and `import.meta.url`) from this URL
+(`string?`, example: `import.meta.url`).
 
 Relative specifiers are non-absolute URLs that start with `/`, `./`, or `../`.
 For example: `/index.js`, `./folder/file.js`, or `../main.js`.

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -536,6 +536,7 @@ test('compile', async () => {
     )
   }
 
+  console.log('\nnote: the following warning is expected!\n')
   assert.equal(
     renderToStaticMarkup(
       React.createElement(
@@ -545,6 +546,7 @@ test('compile', async () => {
     '<a></a>',
     'should render if a used member is defined locally (JSX in a function)'
   )
+  console.log('\nnote: the preceding warning is expected!\n')
 
   try {
     renderToStaticMarkup(

--- a/packages/mdx/test/evaluate.js
+++ b/packages/mdx/test/evaluate.js
@@ -290,6 +290,17 @@ test('evaluate', async () => {
     'should support an `export all from`, but prefer explicit exports, w/ `useDynamicImport`'
   )
 
+  assert.equal(
+    (
+      await evaluate(
+        'export const x = new URL("example.png", import.meta.url).href',
+        {baseUrl: 'https://example.com', ...runtime}
+      )
+    ).x,
+    'https://example.com/example.png',
+    'should support rewriting `import.meta.url` w/ `baseUrl`'
+  )
+
   assert.throws(
     () => {
       evaluateSync('export * from "a"', runtime)


### PR DESCRIPTION
MDX can compile *and* run code, at the same time (called “evaluation”). To evaluate imports and exports in that code, it has to know *from where* to do that, which is a location on the users computer that is not the folder that contains `@mdx-js/mdx` in `node_modules`. That’s what the `baseUrl` option is used for.

Previously though, the URL given as `baseUrl` was not used to replace `import.meta.url` in MDX code. As they are equivalent, this commit introduces that behavior.

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
