### PR TITLE
Add `remark-mdx-math-enhanced` to list of plugins

### DIFF
--- a/docs/docs/extending-mdx.server.mdx
+++ b/docs/docs/extending-mdx.server.mdx
@@ -77,7 +77,7 @@ See also the [list of remark plugins][remark-plugins] and
 *   [`remcohaszing/remark-mdx-frontmatter`](https://github.com/remcohaszing/remark-mdx-frontmatter)
     — change frontmatter (YAML) metadata to exports
 *   [`goodproblems/remark-mdx-math-enhanced`](https://github.com/goodproblems/remark-mdx-math-enhanced)
-    — Enhance math environments by allowing dynamic JS expressions
+    — Enhance math envs by adding support for embedded JS expressions with full access to props, exports, etc
 
 {/*
 please use alpha sorting on **project** name!

--- a/docs/docs/extending-mdx.server.mdx
+++ b/docs/docs/extending-mdx.server.mdx
@@ -76,6 +76,8 @@ See also the [list of remark plugins][remark-plugins] and
     — change image sources to JavaScript imports
 *   [`remcohaszing/remark-mdx-frontmatter`](https://github.com/remcohaszing/remark-mdx-frontmatter)
     — change frontmatter (YAML) metadata to exports
+*   [`goodproblems/remark-mdx-math-enhanced`](https://github.com/goodproblems/remark-mdx-math-enhanced)
+    — Enhance math environments by allowing dynamic JS expressions
 
 {/*
 please use alpha sorting on **project** name!

--- a/docs/docs/extending-mdx.server.mdx
+++ b/docs/docs/extending-mdx.server.mdx
@@ -77,7 +77,7 @@ See also the [list of remark plugins][remark-plugins] and
 *   [`remcohaszing/remark-mdx-frontmatter`](https://github.com/remcohaszing/remark-mdx-frontmatter)
     — change frontmatter (YAML) metadata to exports
 *   [`goodproblems/remark-mdx-math-enhanced`](https://github.com/goodproblems/remark-mdx-math-enhanced)
-    — Enhance math envs by adding support for embedded JS expressions with full access to props, exports, etc
+    — enhance math with JavaScript inside it
 
 {/*
 please use alpha sorting on **project** name!

--- a/docs/guides/math.server.mdx
+++ b/docs/guides/math.server.mdx
@@ -79,7 +79,7 @@ async function main() {
   ```
 </Note>
 
-<Note>
+<Note type="info">
   **Note:** see also
   [`remark-mdx-math-enhanced`](https://github.com/goodproblems/remark-mdx-math-enhanced),
   which you can use to support JavaScript expressions inside of math (such as to

--- a/docs/guides/math.server.mdx
+++ b/docs/guides/math.server.mdx
@@ -80,7 +80,10 @@ async function main() {
 </Note>
 
 <Note>
-  **Note:** If you have a use case that requires dynamic JS expressions inside of math environments (e.g. accessing props, making calculations, etc) you may want to check out [remark-mdx-math-enhanced](https://github.com/goodproblems/remark-mdx-math-enhanced) 
+  **Note:** see also
+  [`remark-mdx-math-enhanced`](https://github.com/goodproblems/remark-mdx-math-enhanced),
+  which you can use to support JavaScript expressions inside of math (such as to
+  access props or to make calculations)
 </Note>
 
 [commonmark]: https://spec.commonmark.org/current/

--- a/docs/guides/math.server.mdx
+++ b/docs/guides/math.server.mdx
@@ -79,6 +79,10 @@ async function main() {
   ```
 </Note>
 
+<Note>
+  **Note:** If you have a use case that requires dynamic JS expressions inside of math environments (e.g. accessing props, making calculations, etc) you may want to check out [remark-mdx-math-enhanced](https://github.com/goodproblems/remark-mdx-math-enhanced) 
+</Note>
+
 [commonmark]: https://spec.commonmark.org/current/
 
 [remark-math]: https://github.com/remarkjs/remark-math/tree/main/packages/remark-math


### PR DESCRIPTION
Was [suggested](https://github.com/micromark/micromark/discussions/111#discussioncomment-2628486) by @wooorm to add my new [remark-mdx-math-enhanced](https://github.com/goodproblems/remark-mdx-math-enhanced) plugin to the list. Thanks!