### PR TITLE
Update loader, rename ` module` to `mod` to avoid confusing with global `module` object

### DIFF
--- a/packages/loader/index.cjs
+++ b/packages/loader/index.cjs
@@ -10,7 +10,7 @@
 module.exports = function (code) {
   const callback = this.async()
   // Note that `import()` caches, so this should be fast enough.
-  import('./lib/index.js').then((module) =>
-    module.loader.call(this, code, callback)
+  import('./lib/index.js').then((mod) =>
+    mod.loader.call(this, code, callback)
   )
 }


### PR DESCRIPTION
Update loader, rename ` module` to `mod` to avoid confusing with global `module` object