### PR TITLE
Add link to official `mdx-js/vscode-mdx`

### DIFF
--- a/docs/docs/getting-started.server.mdx
+++ b/docs/docs/getting-started.server.mdx
@@ -144,6 +144,7 @@ Once everything is set up in your project, you can enhance the experience by
 adding support for MDX in your editor:
 
 *   With **VS Code**,
+*   try the official extension [`mdx-js/vscode-mdx`](https://github.com/mdx-js/vscode-mdx) and/or
     try [`silvenon/vscode-mdx`](https://github.com/silvenon/vscode-mdx)
     and/or [`xyc/vscode-mdx-preview`](https://github.com/xyc/vscode-mdx-preview)
 *   With **Vim**,

--- a/docs/docs/getting-started.server.mdx
+++ b/docs/docs/getting-started.server.mdx
@@ -144,8 +144,7 @@ Once everything is set up in your project, you can enhance the experience by
 adding support for MDX in your editor:
 
 *   With **VS Code**,
-*   try the official extension [`mdx-js/vscode-mdx`](https://github.com/mdx-js/vscode-mdx) and/or
-    try [`silvenon/vscode-mdx`](https://github.com/silvenon/vscode-mdx)
+    try [`mdx-js/vscode-mdx`](https://github.com/mdx-js/vscode-mdx)
     and/or [`xyc/vscode-mdx-preview`](https://github.com/xyc/vscode-mdx-preview)
 *   With **Vim**,
     try [`jxnblk/vim-mdx-js`](https://github.com/jxnblk/vim-mdx-js)


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
This adds a link to the "official vscode extension" https://github.com/mdx-js/vscode-mdx; https://github.com/silvenon/vscode-mdx is currently deprecated and links to that extension.