### PR TITLE
Add missing `import` to site example

### DIFF
--- a/docs/guides/syntax-highlighting.server.mdx
+++ b/docs/guides/syntax-highlighting.server.mdx
@@ -153,6 +153,8 @@ to interpret the `meta` field.
 For example, it’s possible to pass that string as a prop with a rehype plugin:
 
 ```js path="rehype-meta-as-attributes.js"
+import {visit} from 'unist-util-visit';
+
 /** @type {import('unified').Plugin<Array<void>, import('hast').Root>} */
 function rehypeMetaAsAttributes() {
   return (tree) => {

--- a/docs/guides/syntax-highlighting.server.mdx
+++ b/docs/guides/syntax-highlighting.server.mdx
@@ -153,7 +153,7 @@ to interpret the `meta` field.
 For example, it’s possible to pass that string as a prop with a rehype plugin:
 
 ```js path="rehype-meta-as-attributes.js"
-import {visit} from 'unist-util-visit';
+import {visit} from 'unist-util-visit'
 
 /** @type {import('unified').Plugin<Array<void>, import('hast').Root>} */
 function rehypeMetaAsAttributes() {


### PR DESCRIPTION
Add missing import to the custom rehype plugin - rehypeMetaAsAttributes -  example

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
