### PR TITLE
fix: mark `webpack` as optional peer dependency

### DIFF
--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -49,6 +49,11 @@
   "peerDependencies": {
     "webpack": ">=4"
   },
+  "peerDependenciesMeta": {
+    "webpack": {
+       "optional": true
+     }
+  },
   "devDependencies": {
     "@types/loader-utils": "^2.0.0",
     "@types/react": "^18.0.0",


### PR DESCRIPTION
Next.js comes with pre-bundled `webpack` and it shows a warning when installing `@mdx-js/loader`.

This PR also addresses the comment here: https://github.com/vercel/next.js/pull/39167/files#r939687561
