### PR TITLE
Fix casing of babel option in `getting-started.server.mdx`

### DIFF
--- a/docs/docs/getting-started.server.mdx
+++ b/docs/docs/getting-started.server.mdx
@@ -434,12 +434,12 @@ if you’re using that, for more info.
   // other things through to the normal Babel parser.
   function babelParserWithMdx(value, options) {
     if (
-      options.sourceFilename &&
-      /\.mdx?$/.test(path.extname(options.sourceFilename))
+      options.sourceFileName &&
+      /\.mdx?$/.test(path.extname(options.sourceFileName))
     ) {
       // Babel does not support async parsers, unfortunately.
       return compileSync(
-        {value, path: options.sourceFilename},
+        {value, path: options.sourceFileName},
         // Tell `@mdx-js/mdx` to return a Babel tree instead of serialized JS.
         {recmaPlugins: [recmaBabel], /* jsxImportSource: …, otherOptions… */}
       ).result


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

Fixes a small typo in the babel config where the `sourceFilename` is actually `sourceFileName` in the latest babel version.
