### PR TITLE
v1/loader: Upgrade loader-utils to ^2.0.4

### DIFF
--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -34,6 +34,6 @@
   "dependencies": {
     "@mdx-js/mdx": "1.6.22",
     "@mdx-js/react": "1.6.22",
-    "loader-utils": "^2.0.3"
+    "loader-utils": "^2.0.4"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -34,6 +34,6 @@
   "dependencies": {
     "@mdx-js/mdx": "1.6.22",
     "@mdx-js/react": "1.6.22",
-    "loader-utils": "2.0.0"
+    "loader-utils": "^2.0.3"
   }
 }


### PR DESCRIPTION
The pinned version on 1.x is flagged with security vulnerabilities.

1. https://security.snyk.io/vuln/SNYK-JS-LOADERUTILS-3043105
2. https://security.snyk.io/vuln/SNYK-JS-LOADERUTILS-3105943