### PR TITLE
docs: replace deprecated Intellij plugin by official one

### DIFF
--- a/docs/docs/getting-started.server.mdx
+++ b/docs/docs/getting-started.server.mdx
@@ -156,7 +156,7 @@ adding support for MDX in your editor:
 *   With **Sublime Text**,
     try [`jonsuh/mdx-sublime`](https://github.com/jonsuh/mdx-sublime)
 *   With **JetBrains IntelliJ/WebStorm**,
-    try [`valentinnodan/mdx-intellij-plugin`](https://github.com/valentinnodan/mdx-intellij-plugin)
+    try [`JetBrains/mdx-intellij-plugin`](https://github.com/JetBrains/intellij-plugins/tree/master/mdx)
 
 <Note type="info">
   **Note**: we’re looking for help with emacs and others!


### PR DESCRIPTION
The linked repo is deprecated and redirects to this new url