### PR TITLE
[Vite] Add  note `info: peerDependency requirement`

### DIFF
--- a/docs/docs/getting-started.server.mdx
+++ b/docs/docs/getting-started.server.mdx
@@ -346,14 +346,10 @@ If you use more modern JavaScript features than what your users support,
 [configure Vite’s
 `build.target`](https://vitejs.dev/guide/build.html#browser-compatibility).
 
-<details>
-  <summary>Possible Compatibility Issue</summary>
-  As for [vite](https://github.com/vitejs/vite) 3, `rollup@^2.79.1` is applied.
-  You might notice that there was a warning of peer dependency problem. Please
-  ignore it or add `rollup` manually to your devDependencies with 
-  **version `^2.79.1`**. This avoids possible incompatibility, for when the 
-  version of `rollup` is not specified, `rollup@>=3` will be install by default.
-</details>
+<Note type="info">
+  **note**: Vite 3 requires the older `rollup@<3`. Make sure `rollup@3` is not
+  installed.
+</Note>
 
 See also [¶ Rollup][rollup], which is used in Vite, and see [¶ Vue][vue], if
 you’re using that, for more info.

--- a/docs/docs/getting-started.server.mdx
+++ b/docs/docs/getting-started.server.mdx
@@ -347,8 +347,8 @@ If you use more modern JavaScript features than what your users support,
 `build.target`](https://vitejs.dev/guide/build.html#browser-compatibility).
 
 <Note type="info">
-  **note**: Vite 3 requires the older `rollup@<3`. Make sure `rollup@3` is not
-  installed.
+  **Note**: Vite 3 requires the older `rollup@2`.
+  Make sure `rollup@3` is not installed.
 </Note>
 
 See also [¶ Rollup][rollup], which is used in Vite, and see [¶ Vue][vue], if

--- a/docs/docs/getting-started.server.mdx
+++ b/docs/docs/getting-started.server.mdx
@@ -346,6 +346,15 @@ If you use more modern JavaScript features than what your users support,
 [configure Vite’s
 `build.target`](https://vitejs.dev/guide/build.html#browser-compatibility).
 
+<details>
+  <summary>Possible Compatibility Issue</summary>
+  As for [vite](https://github.com/vitejs/vite) 3, `rollup@^2.79.1` is applied.
+  You might notice that there was a warning of peer dependency problem. Please
+  ignore it or add `rollup` manually to your devDependencies with 
+  **version `^2.79.1`**. This avoids possible incompatibility, for when the 
+  version of `rollup` is not specified, `rollup@>=3` will be install by default.
+</details>
+
 See also [¶ Rollup][rollup], which is used in Vite, and see [¶ Vue][vue], if
 you’re using that, for more info.
 


### PR DESCRIPTION
Type conflicts can be caused by installing `rollup` with version `>=3` as peer dependency unconsciously.

Possible prevention of #2105

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
