### PR TITLE
Add inferring of `development` options from webpack loader mode

### DIFF
--- a/packages/loader/lib/index.js
+++ b/packages/loader/lib/index.js
@@ -35,7 +35,10 @@ const cache = new WeakMap()
 export function loader(value, callback) {
   /** @type {Defaults} */
   const defaults = this.sourceMap ? {SourceMapGenerator} : {}
-  const options = /** @type {CompileOptions} */ (this.getOptions())
+  const options = {
+    development: this.mode === 'development',
+    .../** @type {CompileOptions} */ (this.getOptions())
+  }
   const config = {...defaults, ...options}
   const hash = getOptionsHash(options)
   // Some loaders set `undefined` (see `TypeStrong/ts-loader`).

--- a/packages/loader/test/index.test.js
+++ b/packages/loader/test/index.test.js
@@ -138,6 +138,12 @@ webpack.mdx:1:22: Unexpected end of file in expression, expected a corresponding
     'should compile (preact)'
   )
 
+  assert.ok(
+    // @ts-expect-error Type definitions don’t define __source.
+    modPreact.default.default({}).__source,
+    'should infer the development option from webpack’s mode'
+  )
+
   assert.match(
     String(await fs.readFile(new URL('preact.cjs', base))),
     /\/\/# sourceMappingURL/,

--- a/packages/loader/test/index.test.js
+++ b/packages/loader/test/index.test.js
@@ -95,6 +95,13 @@ webpack.mdx:1:22: Unexpected end of file in expression, expected a corresponding
     'should compile (react)'
   )
 
+  const reactOutput = await fs.readFile(new URL('react.cjs', base), 'utf8')
+  assert.not.match(
+    reactOutput,
+    /react_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_\d+__\.jsxDEV/,
+    'should infer the development option from webpack’s production mode'
+  )
+
   await fs.unlink(new URL('react.cjs', base))
 
   // Preact and source maps
@@ -138,14 +145,15 @@ webpack.mdx:1:22: Unexpected end of file in expression, expected a corresponding
     'should compile (preact)'
   )
 
-  assert.ok(
-    // @ts-expect-error Type definitions don’t define __source.
-    modPreact.default.default({}).__source,
-    'should infer the development option from webpack’s mode'
+  const preactOutput = await fs.readFile(new URL('preact.cjs', base), 'utf8')
+  assert.match(
+    preactOutput,
+    /preact_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_\d+__\.jsxDEV/,
+    'should infer the development option from webpack’s development mode'
   )
 
   assert.match(
-    String(await fs.readFile(new URL('preact.cjs', base))),
+    preactOutput,
     /\/\/# sourceMappingURL/,
     'should add a source map if requested'
   )


### PR DESCRIPTION
Closes #2198