### PR TITLE
[docs] Update on-demand docs to avoid DEV JSX runtime

### DIFF
--- a/docs/guides/mdx-on-demand.server.mdx
+++ b/docs/guides/mdx-on-demand.server.mdx
@@ -28,7 +28,11 @@ On the server:
 ```js path="server.js"
 import {compile} from '@mdx-js/mdx'
 
-const code = String(await compile('# hi', {outputFormat: 'function-body' /* …otherOptions */ }))
+const code = String(await compile('# hi', {
+  outputFormat: 'function-body',
+  development: false, // Avoid use of the jsxDEV runtime
+  /* …otherOptions */ 
+}))
 // To do: send `code` to the client somehow.
 ```
 
@@ -82,7 +86,11 @@ export default function Page({code}) {
 
 export async function getStaticProps() {
   const code = String(
-    await compile('# hi', {outputFormat: 'function-body' /* …otherOptions */})
+    await compile('# hi', {
+      outputFormat: 'function-body',
+      development: false, // Avoid use of the jsxDEV runtime
+      /* …otherOptions */
+    })
   )
   return {props: {code}}
 }


### PR DESCRIPTION
The example code above will (since version 2.2) throw an error because `_jsxDEV is not a function`.

To avoid that, we need to pass the `development: false` option, so I've updated these docs to do so.

See: https://github.com/mdx-js/mdx/discussions/2203
