### PR TITLE
Add js extension to mdx/types import

### DIFF
--- a/packages/esbuild/test/index.test.js
+++ b/packages/esbuild/test/index.test.js
@@ -3,7 +3,7 @@
  * @typedef {import('esbuild').Message} Message
  * @typedef {import('hast').Root} Root
  * @typedef {import('vfile').VFile} VFile
- * @typedef {import('mdx/types').MDXContent} MDXContent
+ * @typedef {import('mdx/types.js').MDXContent} MDXContent
  *
  * @typedef {import('remark-mdx')}
  */

--- a/packages/loader/test/index.test.js
+++ b/packages/loader/test/index.test.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('mdx/types').MDXContent} MDXContent
+ * @typedef {import('mdx/types.js').MDXContent} MDXContent
  * @typedef {import('preact').FunctionComponent<unknown>} PreactComponent
  * @typedef {import('vue').Component} VueComponent
  * @typedef {import('vue').SetupContext} SetupContext

--- a/packages/mdx/lib/evaluate.js
+++ b/packages/mdx/lib/evaluate.js
@@ -2,7 +2,7 @@
  * @typedef {import('vfile').VFileCompatible} VFileCompatible
  * @typedef {import('./util/resolve-evaluate-options.js').EvaluateOptions} EvaluateOptions
  *
- * @typedef {import('mdx/types').MDXModule} ExportMap
+ * @typedef {import('mdx/types.js').MDXModule} ExportMap
  */
 
 import {compile, compileSync} from './compile.js'

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -1,6 +1,6 @@
 /**
- * @typedef {import('mdx/types').MDXModule} MDXModule
- * @typedef {import('mdx/types').MDXContent} MDXContent
+ * @typedef {import('mdx/types.js').MDXModule} MDXModule
+ * @typedef {import('mdx/types.js').MDXContent} MDXContent
  * @typedef {import('hast').Root} Root
  * @typedef {import('../lib/compile.js').VFileCompatible} VFileCompatible
  */

--- a/packages/node-loader/test/index.test.js
+++ b/packages/node-loader/test/index.test.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('mdx/types').MDXContent} MDXContent
+ * @typedef {import('mdx/types.js').MDXContent} MDXContent
  */
 
 import {promises as fs} from 'fs'

--- a/packages/preact/lib/index.js
+++ b/packages/preact/lib/index.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import('preact').ComponentChildren} ComponentChildren
- * @typedef {import('mdx/types').MDXComponents} Components
+ * @typedef {import('mdx/types.js').MDXComponents} Components
  *
  * @typedef Props
  *   Configuration.

--- a/packages/react/lib/index.js
+++ b/packages/react/lib/index.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import('react').ReactNode} ReactNode
- * @typedef {import('mdx/types').MDXComponents} Components
+ * @typedef {import('mdx/types.js').MDXComponents} Components
  *
  * @typedef Props
  *   Configuration.

--- a/packages/register/test/index.test.cjs
+++ b/packages/register/test/index.test.cjs
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('mdx/types').MDXContent} MDXContent
+ * @typedef {import('mdx/types.js').MDXContent} MDXContent
  */
 
 'use strict'

--- a/packages/rollup/test/index.test.js
+++ b/packages/rollup/test/index.test.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('mdx/types').MDXContent} MDXContent
+ * @typedef {import('mdx/types.js').MDXContent} MDXContent
  */
 
 import {promises as fs} from 'fs'

--- a/packages/vue/lib/index.js
+++ b/packages/vue/lib/index.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('mdx/types').MDXComponents} Components
+ * @typedef {import('mdx/types.js').MDXComponents} Components
  */
 
 import {provide, inject, createVNode, Fragment} from 'vue'

--- a/packages/vue/test/test.js
+++ b/packages/vue/test/test.js
@@ -1,7 +1,7 @@
 /**
- * @typedef {import('mdx/types').MDXComponents} Components
- * @typedef {import('mdx/types').MDXContent} MDXContent
- * @typedef {import('mdx/types').MDXModule} MDXModule
+ * @typedef {import('mdx/types.js').MDXComponents} Components
+ * @typedef {import('mdx/types.js').MDXContent} MDXContent
+ * @typedef {import('mdx/types.js').MDXModule} MDXModule
  * @typedef {import('vue').Component} AnyComponent
  */
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,13 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020"],
-    "module": "Node16",
+    "module": "ES2020",
+    "moduleResolution": "node",
     "allowJs": true,
     "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
+    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "strict": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "strict": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020"],
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "module": "Node16",
     "allowJs": true,
     "checkJs": true,
     "declaration": true,


### PR DESCRIPTION
Because `@mdx-js/mdx`'s package.json includes `"type": "module"`, imports within it which reference a file must include file extensions, including type only imports. This breaks downstream TypeScript users who have `"module": "Node16"` in their `tsconfig.json` file.

```
node_modules/@mdx-js/mdx/lib/evaluate.d.ts:23:32 - error TS2307: Cannot find module 'mdx/types' 
  or its corresponding type declarations.

23 export type ExportMap = import('mdx/types').MDXModule;
                                  ~~~~~~~~~~~
```

Yes, the `.js` looks odd since we're importing a declaration file from `@types/mdx` here, but it is correct, since in a TS-native setup, it would be describing a `.js` file alongside the declaration file.

cc: @gaurishh