### PR TITLE
Add `recma-mdx-displayname` to list of plugins

### DIFF
--- a/docs/docs/extending-mdx.server.mdx
+++ b/docs/docs/extending-mdx.server.mdx
@@ -5,7 +5,7 @@ export const info = {
     {name: 'Titus Wormer', github: 'wooorm', twitter: 'wooorm'}
   ],
   published: new Date('2021-10-06'),
-  modified: new Date('2021-11-01')
+  modified: new Date('2023-01-18')
 }
 
 # Extending MDX
@@ -68,6 +68,8 @@ You can use this template:
 See also the [list of remark plugins][remark-plugins] and
 [list of rehype plugins][rehype-plugins].
 
+*   [`domdomegg/recma-mdx-displayname-plugin`](https://github.com/domdomegg/recma-mdx-displayname-plugin)
+    — add a `displayName` to MDXContent elements, to enable switching on them in production
 *   [`remcohaszing/recma-nextjs-static-props`](https://github.com/remcohaszing/recma-nextjs-static-props)
     — generate [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching/get-static-props)
     exposing top level identifiers in Next.js

--- a/docs/docs/extending-mdx.server.mdx
+++ b/docs/docs/extending-mdx.server.mdx
@@ -68,8 +68,9 @@ You can use this template:
 See also the [list of remark plugins][remark-plugins] and
 [list of rehype plugins][rehype-plugins].
 
-*   [`domdomegg/recma-mdx-displayname-plugin`](https://github.com/domdomegg/recma-mdx-displayname-plugin)
-    — add a `displayName` to MDXContent elements, to enable switching on them in production
+*   [`domdomegg/recma-mdx-displayname`](https://github.com/domdomegg/recma-mdx-displayname)
+    — add a `displayName` to MDXContent elements, to enable switching
+    on them in production
 *   [`remcohaszing/recma-nextjs-static-props`](https://github.com/remcohaszing/recma-nextjs-static-props)
     — generate [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching/get-static-props)
     exposing top level identifiers in Next.js

--- a/docs/docs/extending-mdx.server.mdx
+++ b/docs/docs/extending-mdx.server.mdx
@@ -69,7 +69,7 @@ See also the [list of remark plugins][remark-plugins] and
 [list of rehype plugins][rehype-plugins].
 
 *   [`domdomegg/recma-mdx-displayname`](https://github.com/domdomegg/recma-mdx-displayname)
-    — add a `displayName` to MDXContent elements, to enable switching
+    — add a `displayName` to `MDXContent` components, to enable switching
     on them in production
 *   [`remcohaszing/recma-nextjs-static-props`](https://github.com/remcohaszing/recma-nextjs-static-props)
     — generate [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching/get-static-props)


### PR DESCRIPTION
Added MDX plugin to MDX plugins list in docs. Updated modified date.

Have added it as it specifically works with MDX (as per line 96). Have inserted it alpha sorted on project name (as per line 88).