### PR TITLE
Remove whitespace between unraveled text nodes

### DIFF
--- a/packages/mdx/lib/plugin/remark-mark-and-unravel.js
+++ b/packages/mdx/lib/plugin/remark-mark-and-unravel.js
@@ -1,4 +1,5 @@
 /**
+ * @typedef {import('mdast').Content} Content
  * @typedef {import('mdast').Root} Root
  *
  * @typedef {import('remark-mdx')} DoNotTouchAsThisImportItIncludesMdxInTree
@@ -47,6 +48,9 @@ export function remarkMarkAndUnravel() {
         if (all && oneOrMore) {
           offset = -1
 
+          /** @type {Array<Content>} */
+          const newChildren = []
+
           while (++offset < children.length) {
             const child = children[offset]
 
@@ -59,9 +63,18 @@ export function remarkMarkAndUnravel() {
               // @ts-expect-error: content model is fine.
               child.type = 'mdxFlowExpression'
             }
+
+            if (
+              child.type === 'text' &&
+              /^[\t\r\n ]+$/.test(String(child.value))
+            ) {
+              // Empty.
+            } else {
+              newChildren.push(child)
+            }
           }
 
-          parent.children.splice(index, 1, ...children)
+          parent.children.splice(index, 1, ...newChildren)
           return index
         }
       }


### PR DESCRIPTION
Whitespace should be fine but React still fails on it.

Closes GH-2000.

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
