### PR TITLE
Add missing type dependencies

### DIFF
--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -46,8 +46,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@types/estree-jsx": "^1.0.0",
     "@types/estree": "^1.0.0",
+    "@types/estree-jsx": "^1.0.0",
     "@types/hast": "^2.0.0",
     "@types/mdx": "^2.0.0",
     "estree-util-build-jsx": "^2.0.0",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -47,6 +47,8 @@
   ],
   "dependencies": {
     "@types/estree-jsx": "^1.0.0",
+    "@types/estree": "^1.0.0",
+    "@types/hast": "^2.0.0",
     "@types/mdx": "^2.0.0",
     "estree-util-build-jsx": "^2.0.0",
     "estree-util-is-identifier-name": "^2.0.0",
@@ -58,6 +60,7 @@
     "remark-mdx": "^2.0.0",
     "remark-parse": "^10.0.0",
     "remark-rehype": "^10.0.0",
+    "source-map": "^0.7.0",
     "unified": "^10.0.0",
     "unist-util-position-from-estree": "^1.0.0",
     "unist-util-stringify-position": "^3.0.0",
@@ -77,7 +80,6 @@
     "remark-frontmatter": "^4.0.0",
     "remark-gfm": "^3.0.0",
     "remark-math": "^5.0.0",
-    "source-map": "^0.7.0",
     "source-map-support": "^0.5.0",
     "unist-util-remove-position": "^4.0.0"
   },


### PR DESCRIPTION
- While `@mdx-js/mdx` doesn't directly depend on estree, the types that TypeScript generates do: look at the first line [here](https://unpkg.com/browse/@mdx-js/mdx@2.3.0/lib/plugin/recma-document.d.ts).

- It however directly depends on `hast` in its types ([here](https://github.com/mdx-js/mdx/blob/main/packages/mdx/lib/plugin/rehype-recma.js#L3)).

- Same for `source-map`, which is directly referenced [here](https://github.com/mdx-js/mdx/blob/main/packages/mdx/lib/plugin/recma-stringify.js#L3) and thus must be in `dependencies` rather than `devDependencies`

Fixes the following errors:

```
@mdx-js/mdx/lib/plugin/recma-document.d.ts(1,78): error TS2307: Cannot find module 'estree' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/recma-document.d.ts(1,216): error TS2307: Cannot find module 'estree' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/recma-document.d.ts(1,242): error TS2307: Cannot find module 'estree' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/recma-jsx-rewrite.d.ts(1,80): error TS2307: Cannot find module 'estree' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/recma-jsx-rewrite.d.ts(1,220): error TS2307: Cannot find module 'estree' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/recma-jsx-rewrite.d.ts(1,246): error TS2307: Cannot find module 'estree' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/recma-stringify.d.ts(1,79): error TS2307: Cannot find module 'estree' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/recma-stringify.d.ts(1,105): error TS2307: Cannot find module 'estree' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/recma-stringify.d.ts(3,48): error TS2307: Cannot find module 'source-map' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/rehype-recma.d.ts(1,76): error TS2307: Cannot find module 'hast' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/rehype-recma.d.ts(1,196): error TS2307: Cannot find module 'hast' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/rehype-recma.d.ts(1,217): error TS2307: Cannot find module 'estree' or its corresponding type declarations.
@mdx-js/mdx/lib/plugin/rehype-recma.d.ts(3,27): error TS2307: Cannot find module 'hast' or its corresponding type declarations.
```

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
