### PR TITLE
Add more options to playground, directives, format, etc

### DIFF
--- a/docs/_asset/index.css
+++ b/docs/_asset/index.css
@@ -753,6 +753,17 @@ button.success {
   margin-block: calc(1 / 1.2 * (1em + 1ex));
 }
 
+.playground-editor fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+}
+
+.playground-editor fieldset label {
+  display: inline;
+}
+
 .frame {
   /* gray-1 is used for unselected tabs, but gray-2 is really too much
    * This is a perfect mix between the two: */

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -22,10 +22,23 @@ import {lowlight} from 'lowlight/lib/core.js'
 import javascript from 'highlight.js/lib/languages/javascript'
 import json from 'highlight.js/lib/languages/json'
 import markdown from 'highlight.js/lib/languages/markdown'
+import {visit as visitEstree} from 'estree-util-visit'
 
 lowlight.registerLanguage('js', javascript)
 lowlight.registerLanguage('json', json)
 lowlight.registerLanguage('md', markdown)
+
+export function removePositionEsast(tree) {
+  visitEstree(tree, remove)
+  return tree
+
+  function remove(node) {
+    delete node.loc
+    delete node.start
+    delete node.end
+    delete node.range
+  }
+}
 
 function useMdx(defaults) {
   const [state, setState] = useState({...defaults, file: null})
@@ -61,7 +74,7 @@ function useMdx(defaults) {
         if (!config.position) {
           removePosition(file.data.mdast, {force: true})
           removePosition(file.data.hast, {force: true})
-          removePosition(file.data.esast, {force: true})
+          removePositionEsast(file.data.esast)
         }
       } catch (error) {
         const message =

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -10,6 +10,7 @@ import remarkGfm from 'remark-gfm'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkDirective from 'remark-directive'
 import remarkMath from 'remark-math'
+import {removePosition} from 'unist-util-remove-position'
 import CodeMirror from 'rodemirror'
 import {basicSetup} from 'codemirror'
 import {markdown as langMarkdown} from '@codemirror/lang-markdown'
@@ -56,6 +57,12 @@ function useMdx(defaults) {
             recmaPlugins: [capture('esast')]
           })
         ).default
+
+        if (!config.position) {
+          removePosition(file.data.mdast, {force: true})
+          removePosition(file.data.hast, {force: true})
+          removePosition(file.data.esast, {force: true})
+        }
       } catch (error) {
         const message =
           error instanceof VFileMessage ? error : new VFileMessage(error)
@@ -108,6 +115,7 @@ export function Editor({children}) {
   const extensions = useMemo(() => [basicSetup, oneDark, langMarkdown()], [])
   const [state, setConfig] = useMdx({
     formatMd: false,
+    position: false,
     gfm: false,
     frontmatter: false,
     directive: false,
@@ -228,6 +236,19 @@ export function Editor({children}) {
               Use{' '}
               <a href="https://mdxjs.com/packages/mdx/#optionsformat">
                 <code>format: &apos;md&apos;</code>
+              </a>
+            </label>
+            <label>
+              <input
+                checked={state.position}
+                type="checkbox"
+                onChange={() =>
+                  setConfig({...state, position: !state.position})
+                }
+              />{' '}
+              Use{' '}
+              <a href="https://github.com/syntax-tree/unist#position">
+                <code>position</code>
               </a>
             </label>
           </form>

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -10,6 +10,7 @@ import remarkGfm from 'remark-gfm'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkDirective from 'remark-directive'
 import remarkMath from 'remark-math'
+import {visit as visitEstree} from 'estree-util-visit'
 import {removePosition} from 'unist-util-remove-position'
 import CodeMirror from 'rodemirror'
 import {basicSetup} from 'codemirror'
@@ -22,7 +23,6 @@ import {lowlight} from 'lowlight/lib/core.js'
 import javascript from 'highlight.js/lib/languages/javascript'
 import json from 'highlight.js/lib/languages/json'
 import markdown from 'highlight.js/lib/languages/markdown'
-import {visit as visitEstree} from 'estree-util-visit'
 
 lowlight.registerLanguage('js', javascript)
 lowlight.registerLanguage('json', json)

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -29,18 +29,6 @@ lowlight.registerLanguage('js', javascript)
 lowlight.registerLanguage('json', json)
 lowlight.registerLanguage('md', markdown)
 
-function removePositionEsast(tree) {
-  visitEstree(tree, remove)
-  return tree
-
-  function remove(node) {
-    delete node.loc
-    delete node.start
-    delete node.end
-    delete node.range
-  }
-}
-
 function useMdx(defaults) {
   const [state, setState] = useState({...defaults, file: null})
   const {run: setConfig} = useDebounceFn(
@@ -415,4 +403,16 @@ export function Editor({children}) {
       </Tabs>
     </div>
   )
+}
+
+function removePositionEsast(tree) {
+  visitEstree(tree, remove)
+  return tree
+
+  function remove(node) {
+    delete node.loc
+    delete node.start
+    delete node.end
+    delete node.range
+  }
 }

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -29,7 +29,7 @@ lowlight.registerLanguage('js', javascript)
 lowlight.registerLanguage('json', json)
 lowlight.registerLanguage('md', markdown)
 
-export function removePositionEsast(tree) {
+function removePositionEsast(tree) {
   visitEstree(tree, remove)
   return tree
 

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -5,7 +5,7 @@ import {VFile} from 'vfile'
 import {VFileMessage} from 'vfile-message'
 import {statistics} from 'vfile-statistics'
 import {reporter} from 'vfile-reporter'
-import {evaluate} from '@mdx-js/mdx'
+import {evaluate, nodeTypes} from '@mdx-js/mdx'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
 import remarkFrontmatter from 'remark-frontmatter'
@@ -60,7 +60,8 @@ function useMdx(defaults) {
       remarkPlugins.push(capture('mdast'))
 
       const rehypePlugins = []
-      if (config.rehypeRaw) rehypePlugins.push(rehypeRaw)
+      if (config.rehypeRaw)
+        rehypePlugins.push([rehypeRaw, {passThrough: nodeTypes}])
       rehypePlugins.push(capture('hast'))
 
       try {

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -7,6 +7,7 @@ import {statistics} from 'vfile-statistics'
 import {reporter} from 'vfile-reporter'
 import {evaluate} from '@mdx-js/mdx'
 import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkDirective from 'remark-directive'
 import remarkMath from 'remark-math'
@@ -52,13 +53,15 @@ function useMdx(defaults) {
       }
 
       const remarkPlugins = []
-
       if (config.gfm) remarkPlugins.push(remarkGfm)
       if (config.frontmatter) remarkPlugins.push(remarkFrontmatter)
       if (config.math) remarkPlugins.push(remarkMath)
       if (config.directive) remarkPlugins.push(remarkDirective)
-
       remarkPlugins.push(capture('mdast'))
+
+      const rehypePlugins = []
+      if (config.rehypeRaw) rehypePlugins.push(rehypeRaw)
+      rehypePlugins.push(capture('hast'))
 
       try {
         file.result = (
@@ -66,7 +69,7 @@ function useMdx(defaults) {
             ...runtime,
             useDynamicImport: true,
             remarkPlugins,
-            rehypePlugins: [capture('hast')],
+            rehypePlugins,
             recmaPlugins: [capture('esast')]
           })
         ).default
@@ -133,6 +136,7 @@ export function Editor({children}) {
     frontmatter: false,
     directive: false,
     math: false,
+    rehypeRaw: false,
     value: defaultValue
   })
   const onUpdate = useCallback(
@@ -270,6 +274,19 @@ export function Editor({children}) {
               Use{' '}
               <a href="https://github.com/remarkjs/remark-directive">
                 <code>remark-directive</code>
+              </a>
+            </label>
+            <label>
+              <input
+                checked={state.rehypeRaw}
+                type="checkbox"
+                onChange={() =>
+                  setConfig({...state, rehypeRaw: !state.rehypeRaw})
+                }
+              />{' '}
+              Use{' '}
+              <a href="https://github.com/rehypejs/rehype-raw">
+                <code>rehype-raw</code>
               </a>
             </label>
           </form>

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -142,7 +142,7 @@ export function Editor({children}) {
   }, [state])
 
   return (
-    <div>
+    <div className="playground-editor">
       <Tabs className="frame">
         <TabList className="frame-tab-bar frame-tab-bar-scroll">
           <Tab
@@ -176,6 +176,41 @@ export function Editor({children}) {
         </TabPanel>
         <TabPanel>
           <form className="frame-body frame-body-box frame-body-box-fixed-height">
+            <fieldset>
+              <label>
+                <input
+                  type="radio"
+                  name="language"
+                  checked={!state.formatMd}
+                  onChange={() => {
+                    setConfig({...state, formatMd: false})
+                  }}
+                />{' '}
+                Use <code>MDX</code>
+              </label>
+              <span style={{margin: '1em'}}>{' | '}</span>
+              <label>
+                <input
+                  type="radio"
+                  name="language"
+                  checked={state.formatMd}
+                  onChange={() => {
+                    setConfig({...state, formatMd: true})
+                  }}
+                />{' '}
+                Use <code>CommonMark</code>
+              </label>
+            </fieldset>
+            <label>
+              <input
+                checked={state.position}
+                type="checkbox"
+                onChange={() =>
+                  setConfig({...state, position: !state.position})
+                }
+              />{' '}
+              Show positional info
+            </label>
             <label>
               <input
                 checked={state.gfm}
@@ -223,30 +258,6 @@ export function Editor({children}) {
               <a href="https://github.com/remarkjs/remark-directive">
                 <code>remark-directive</code>
               </a>
-            </label>
-            <hr />
-            <label>
-              <input
-                checked={state.formatMd}
-                type="checkbox"
-                onChange={() =>
-                  setConfig({...state, formatMd: !state.formatMd})
-                }
-              />{' '}
-              Use{' '}
-              <a href="https://mdxjs.com/packages/mdx/#optionsformat">
-                <code>format: &apos;md&apos;</code>
-              </a>
-            </label>
-            <label>
-              <input
-                checked={state.position}
-                type="checkbox"
-                onChange={() =>
-                  setConfig({...state, position: !state.position})
-                }
-              />{' '}
-              Show positional info
             </label>
           </form>
         </TabPanel>

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -8,6 +8,7 @@ import {reporter} from 'vfile-reporter'
 import {evaluate} from '@mdx-js/mdx'
 import remarkGfm from 'remark-gfm'
 import remarkFrontmatter from 'remark-frontmatter'
+import remarkDirective from 'remark-directive'
 import remarkMath from 'remark-math'
 import CodeMirror from 'rodemirror'
 import {basicSetup} from 'codemirror'
@@ -29,7 +30,8 @@ function useMdx(defaults) {
   const [state, setState] = useState({...defaults, file: null})
   const {run: setConfig} = useDebounceFn(
     async (config) => {
-      const file = new VFile({basename: 'example.mdx', value: config.value})
+      const basename = config.formatMd ? 'example.md' : 'example.mdx'
+      const file = new VFile({basename, value: config.value})
 
       const capture = (name) => () => (tree) => {
         file.data[name] = tree
@@ -40,6 +42,7 @@ function useMdx(defaults) {
       if (config.gfm) remarkPlugins.push(remarkGfm)
       if (config.frontmatter) remarkPlugins.push(remarkFrontmatter)
       if (config.math) remarkPlugins.push(remarkMath)
+      if (config.directive) remarkPlugins.push(remarkDirective)
 
       remarkPlugins.push(capture('mdast'))
 
@@ -104,8 +107,10 @@ export function Editor({children}) {
   const defaultValue = children
   const extensions = useMemo(() => [basicSetup, oneDark, langMarkdown()], [])
   const [state, setConfig] = useMdx({
+    formatMd: false,
     gfm: false,
     frontmatter: false,
+    directive: false,
     math: false,
     value: defaultValue
   })
@@ -196,6 +201,33 @@ export function Editor({children}) {
               Use{' '}
               <a href="https://github.com/remarkjs/remark-math/tree/main/packages/remark-math">
                 <code>remark-math</code>
+              </a>
+            </label>
+            <label>
+              <input
+                checked={state.directive}
+                type="checkbox"
+                onChange={() =>
+                  setConfig({...state, directive: !state.directive})
+                }
+              />{' '}
+              Use{' '}
+              <a href="https://github.com/remarkjs/remark-directive">
+                <code>remark-directive</code>
+              </a>
+            </label>
+            <hr />
+            <label>
+              <input
+                checked={state.formatMd}
+                type="checkbox"
+                onChange={() =>
+                  setConfig({...state, formatMd: !state.formatMd})
+                }
+              />{' '}
+              Use{' '}
+              <a href="https://mdxjs.com/packages/mdx/#optionsformat">
+                <code>format: &apos;md&apos;</code>
               </a>
             </label>
           </form>

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -246,10 +246,7 @@ export function Editor({children}) {
                   setConfig({...state, position: !state.position})
                 }
               />{' '}
-              Use{' '}
-              <a href="https://github.com/syntax-tree/unist#position">
-                <code>position</code>
-              </a>
+              Show positional info
             </label>
           </form>
         </TabPanel>

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-plugin-react-hooks": "^4.0.0",
         "eslint-plugin-security": "^1.0.0",
         "estree-util-value-to-estree": "^2.0.0",
+        "estree-util-visit": "^1.2.1",
         "globby": "^13.0.0",
         "hast-to-hyperscript": "^10.0.0",
         "hast-util-select": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "remark-toc": "^8.0.0",
         "rodemirror": "^2.0.0",
         "type-coverage": "^2.0.0",
-        "typescript": "^4.0.0",
+        "typescript": "^5.0.0",
         "unified": "^10.0.0",
         "unist-builder": "^3.0.0",
         "unist-util-visit": "^4.0.0",
@@ -17172,16 +17172,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/uglify-js": {
@@ -19269,6 +19269,19 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
+    "node_modules/xo/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/xo/node_modules/yallist": {
       "version": "4.0.0",
       "dev": true,
@@ -19557,7 +19570,9 @@
       "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
+        "@types/estree": "^1.0.0",
         "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^2.0.0",
         "@types/mdx": "^2.0.0",
         "estree-util-build-jsx": "^2.0.0",
         "estree-util-is-identifier-name": "^2.0.0",
@@ -19569,6 +19584,7 @@
         "remark-mdx": "^2.0.0",
         "remark-parse": "^10.0.0",
         "remark-rehype": "^10.0.0",
+        "source-map": "^0.7.0",
         "unified": "^10.0.0",
         "unist-util-position-from-estree": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
@@ -19588,7 +19604,6 @@
         "remark-frontmatter": "^4.0.0",
         "remark-gfm": "^3.0.0",
         "remark-math": "^5.0.0",
-        "source-map": "^0.7.0",
         "source-map-support": "^0.5.0",
         "unist-util-remove-position": "^4.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "rehype-slug": "^5.0.0",
         "rehype-stringify": "^9.0.0",
         "remark-cli": "^11.0.0",
+        "remark-directive": "^2.0.1",
         "remark-frontmatter": "^4.0.0",
         "remark-gemoji": "^7.0.0",
         "remark-gfm": "^3.0.0",
@@ -9081,6 +9082,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-directive": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-2.2.4.tgz",
+      "integrity": "sha512-sK3ojFP+jpj1n7Zo5ZKvoxP1MvLyzVG63+gm40Z/qI00avzdPCYxt7RBMgofwAva9gBjbDBWVRB/i+UD+fUCzQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "mdast-util-from-markdown": "^1.3.0",
+        "mdast-util-to-markdown": "^1.5.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^5.1.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
@@ -9788,6 +9808,25 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-2.2.0.tgz",
+      "integrity": "sha512-LWc2mGlJlPEcESz4IHNJR/tpJfWJEEFHGM+6vgCZGXkKMXc/y8rCKB07x5ZNnafIFe0/sjt6DIIihk78/Egj5Q==",
+      "dev": true,
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "parse-entities": "^4.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-frontmatter": {
@@ -14092,6 +14131,22 @@
         "@types/mdast": "^3.0.0",
         "mdast-comment-marker": "^2.0.0",
         "mdast-util-to-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-directive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-2.0.1.tgz",
+      "integrity": "sha512-oosbsUAkU/qmUE78anLaJePnPis4ihsE7Agp0T/oqTzvTea8pOiaYEtfInU/+xMOVTS9PN5AhGOiaIVe4GD8gw==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-directive": "^2.0.0",
+        "micromark-extension-directive": "^2.0.0",
         "unified": "^10.0.0"
       },
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "typescript": "^5.0.0",
         "unified": "^10.0.0",
         "unist-builder": "^3.0.0",
+        "unist-util-remove-position": "^4.0.2",
         "unist-util-visit": "^4.0.0",
         "uvu": "^0.5.0",
         "vfile": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "rehype-slug": "^5.0.0",
         "rehype-stringify": "^9.0.0",
         "remark-cli": "^11.0.0",
-        "remark-directive": "^2.0.1",
+        "remark-directive": "^2.0.0",
         "remark-frontmatter": "^4.0.0",
         "remark-gemoji": "^7.0.0",
         "remark-gfm": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "unified": "^10.0.0",
     "unist-builder": "^3.0.0",
     "unist-util-visit": "^4.0.0",
+    "estree-util-visit": "^1.2.1",
     "unist-util-remove-position": "^4.0.2",
     "uvu": "^0.5.0",
     "vfile": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "rehype-slug": "^5.0.0",
     "rehype-stringify": "^9.0.0",
     "remark-cli": "^11.0.0",
-    "remark-directive": "^2.0.1",
+    "remark-directive": "^2.0.0",
     "remark-frontmatter": "^4.0.0",
     "remark-gemoji": "^7.0.0",
     "remark-gfm": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "unified": "^10.0.0",
     "unist-builder": "^3.0.0",
     "unist-util-visit": "^4.0.0",
+    "unist-util-remove-position": "^4.0.2",
     "uvu": "^0.5.0",
     "vfile": "^5.0.0",
     "vfile-message": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "rehype-slug": "^5.0.0",
     "rehype-stringify": "^9.0.0",
     "remark-cli": "^11.0.0",
+    "remark-directive": "^2.0.1",
     "remark-frontmatter": "^4.0.0",
     "remark-gemoji": "^7.0.0",
     "remark-gfm": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "remark-toc": "^8.0.0",
     "rodemirror": "^2.0.0",
     "type-coverage": "^2.0.0",
-    "typescript": "^4.0.0",
+    "typescript": "^5.0.0",
     "unified": "^10.0.0",
     "unist-builder": "^3.0.0",
     "unist-util-visit": "^4.0.0",


### PR DESCRIPTION
This PR adds new useful options to have in the playground:

- format md: to easily test the output in CommonMark mode
- directive: to parse syntax such as `:::warning`
- rehype-raw: useful to reparse raw html string nodes to proper hast tree
- position: to easily strip noise from output AST

Note: I think it's better to not have positions in the AST by default, this creates useless noise and I doubt people use positions in the playground anyway.

![CleanShot 2023-05-11 at 16 17 11](https://github.com/mdx-js/mdx/assets/749374/cc75c3fa-022c-416d-a910-f78c7b7bb7d8)

