### PR TITLE
Add resizable editor/layout to playground

### DIFF
--- a/docs/_asset/index.css
+++ b/docs/_asset/index.css
@@ -757,7 +757,9 @@ button.success {
   mask-image: paint(squircle);
   --squircle-radius: 10px;
   border-radius: 10px;
+}
 
+.frame-resizeable {
   display: flex;
   flex-direction: column;
   overflow: auto;
@@ -936,6 +938,10 @@ button.success {
   flex-grow: 1;
   margin: calc(0.125 * (1em + 1ex));
   background-color: var(--fg);
+}
+
+.playground-editor-options-tab-panel label {
+  margin-block: calc(0.5em);
 }
 
 .playground-result-badge::after {

--- a/docs/_asset/index.css
+++ b/docs/_asset/index.css
@@ -941,7 +941,7 @@ button.success {
 }
 
 .playground-editor-options-tab-panel label {
-  margin-block: calc(0.5em);
+  margin-block: 0.5em;
 }
 
 .playground-result-badge::after {

--- a/docs/_asset/index.css
+++ b/docs/_asset/index.css
@@ -301,11 +301,6 @@ pre code,
   background-color: #fafafa !important; /* Color from one-light */
 }
 
-.frame-body-box-fixed-height {
-  height: 20rem;
-  overflow-y: auto;
-}
-
 .frame-body-box {
   padding: calc(1em + 1ex);
 }
@@ -762,10 +757,21 @@ button.success {
   mask-image: paint(squircle);
   --squircle-radius: 10px;
   border-radius: 10px;
+
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+
+  min-height: 10rem;
+  height: 24rem;
+  resize: vertical;
 }
 
 .frame-tab-bar {
+  flex-shrink: 0;
   display: flex;
+  flex-direction: row;
+  align-items: stretch;
   margin-block-start: calc(1em + 1ex);
   list-style-type: none;
   margin: 0;
@@ -776,10 +782,6 @@ button.success {
 .frame-tab-bar-scroll {
   overflow-x: auto;
   overflow-y: hidden;
-  flex: 1;
-  flex-direction: row;
-  align-items: stretch;
-  flex-grow: 1;
   mask-image: linear-gradient(
     to right,
     hsl(0deg 0% 100% / 30%),
@@ -789,9 +791,52 @@ button.success {
   );
 }
 
+.react-tabs__tab-panel {
+}
+
+.react-tabs__tab-panel--selected {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Preview / Options */
+.react-tabs__tab-panel--selected.tab-panel-scrollable {
+  overflow: auto;
+}
+
 .frame-body {
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
+}
+
+.react-tabs__tab-panel--selected > .frame-body {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.react-tabs__tab-panel--selected:not(.tab-panel-scrollable) > .frame-body {
+  overflow: hidden;
+}
+
+.frame-body > div,
+.frame-body > pre {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.frame-body > div > div.cm-editor {
+  flex-grow: 1;
+  overflow: hidden;
+}
+
+.frame-body > pre > code {
+  overflow-x: auto;
+  overflow-y: auto;
 }
 
 .frame-tab-bar + pre {
@@ -921,11 +966,6 @@ button.success {
   font-family: var(--mono);
   font-feature-settings: normal;
   font-size: 1rem;
-}
-
-.ͼ1 .cm-scroller,
-.ͼ1 .cm-content {
-  min-height: 20rem;
 }
 
 .ͼo {

--- a/docs/_asset/index.css
+++ b/docs/_asset/index.css
@@ -823,7 +823,7 @@ button.success {
   overflow: hidden;
 }
 
-.frame-body > div,
+.frame-body > .playground-editor-code-mirror,
 .frame-body > pre {
   flex-grow: 1;
   display: flex;

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -146,7 +146,7 @@ export function Editor({children}) {
           </Tab>
         </TabList>
         <TabPanel>
-          <div className="frame-body frame-body-box-fixed-height">
+          <div className="frame-body">
             <noscript>
               <pre>
                 <code className="hljs language-md">
@@ -161,8 +161,8 @@ export function Editor({children}) {
             />
           </div>
         </TabPanel>
-        <TabPanel>
-          <form className="frame-body frame-body-box frame-body-box-fixed-height">
+        <TabPanel className="tab-panel-scrollable">
+          <form className="frame-body frame-body-box">
             <label>
               <input
                 checked={state.gfm}
@@ -238,16 +238,16 @@ export function Editor({children}) {
           })}
         </TabList>
 
-        <TabPanel>
+        <TabPanel className="tab-panel-scrollable">
           <noscript>Enable JavaScript for the rendered result.</noscript>
-          <div className="frame-body frame-body-box-fixed-height frame-body-box">
+          <div className="frame-body frame-body-box">
             <ErrorBoundary FallbackComponent={ErrorFallback}>
               {state.file && state.file.result ? <Preview /> : null}
             </ErrorBoundary>
           </div>
         </TabPanel>
         <TabPanel>
-          <div className="frame-body frame-body-box-fixed-height">
+          <div className="frame-body">
             {state.file ? (
               stats.fatal ? (
                 <pre>
@@ -267,7 +267,7 @@ export function Editor({children}) {
           </div>
         </TabPanel>
         <TabPanel>
-          <div className="frame-body frame-body-box-fixed-height">
+          <div className="frame-body">
             {state.file && state.file.data.mdast ? (
               <pre>
                 <code className="hljs language-js">
@@ -284,7 +284,7 @@ export function Editor({children}) {
           </div>
         </TabPanel>
         <TabPanel>
-          <div className="frame-body frame-body-box-fixed-height">
+          <div className="frame-body">
             {state.file && state.file.data.hast ? (
               <pre>
                 <code className="hljs language-js">
@@ -301,7 +301,7 @@ export function Editor({children}) {
           </div>
         </TabPanel>
         <TabPanel>
-          <div className="frame-body frame-body-box-fixed-height">
+          <div className="frame-body">
             {state.file && state.file.data.esast ? (
               <pre>
                 <code className="hljs language-js">

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -130,7 +130,7 @@ export function Editor({children}) {
 
   return (
     <div>
-      <Tabs className="frame">
+      <Tabs className="frame frame-resizeable">
         <TabList className="frame-tab-bar frame-tab-bar-scroll">
           <Tab
             className="frame-tab-item frame-tab-item-dark"
@@ -161,7 +161,7 @@ export function Editor({children}) {
             />
           </div>
         </TabPanel>
-        <TabPanel className="tab-panel-scrollable">
+        <TabPanel className="tab-panel-scrollable playground-editor-options-tab-panel">
           <form className="frame-body frame-body-box">
             <label>
               <input
@@ -202,7 +202,7 @@ export function Editor({children}) {
         </TabPanel>
       </Tabs>
 
-      <Tabs className="frame">
+      <Tabs className="frame frame-resizeable">
         <TabList className="frame-tab-bar frame-tab-bar-scroll">
           {[
             'Run',

--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -86,7 +86,10 @@ function ErrorFallback({error, resetErrorBoundary}) {
 
 const MemoizedCodeMirror = memo((props) => (
   <ErrorBoundary FallbackComponent={ErrorFallback}>
-    <CodeMirror {...props} />
+    <CodeMirror
+      {...props}
+      elementProps={{className: 'playground-editor-code-mirror'}}
+    />
   </ErrorBoundary>
 ))
 


### PR DESCRIPTION
When working with the playground and larger MDX content, I find it quite annoying to not being able to increase the size of the editors/AST explorer/preview

Also some CSS looked a bit messy/legacy and hardcoded, and there are some existing bugs like the horizontal scrollbar not appearing immediately:

<img width="979" alt="CleanShot 2023-05-04 at 18 42 19@2x" src="https://user-images.githubusercontent.com/749374/236270394-039e4847-0d33-48d8-ac86-d74776bfcccc.png">


----

I tried to do some cleanup, fix some bugs, and to make the height resizeable

<img width="1027" alt="CleanShot 2023-05-04 at 18 44 26@2x" src="https://user-images.githubusercontent.com/749374/236270574-cc23f109-3e14-492a-8d03-1aa5863aff5c.png">

![CleanShot 2023-05-04 at 18 45 27](https://user-images.githubusercontent.com/749374/236270827-3f93633d-bfb3-488b-b215-6e9776faf0c8.png)

![CleanShot 2023-05-04 at 18 46 54](https://user-images.githubusercontent.com/749374/236271121-201018f4-155d-438d-b2ec-80770c884bb7.png)

![CleanShot 2023-05-04 at 18 47 28](https://user-images.githubusercontent.com/749374/236271283-2ba7f77b-3fa8-4c11-ae8b-6caa4e213e29.png)

---

Not sure some of the CSS changes do not have any other unwanted impact on other pages, are they only used in the playground?

---

## Test links

Playground:
- before: https://mdxjs.com/playground/
- after: https://mdx-7kndugcie-mdx.vercel.app/playground/
- local: http://localhost:3000/playground/
