### PR TITLE
Fix docs on how to use solid

### DIFF
--- a/docs/docs/getting-started.server.mdx
+++ b/docs/docs/getting-started.server.mdx
@@ -125,7 +125,7 @@ your JSX runtime.
     install and configure [`@mdx-js/react`][mdx-react].
     Then wrap your MDX content in a `<ThemeProvider />`
 *   If you’re using **Solid**,
-    set [`options.jsxImportSource`][options-jsximportsource] to `'solid-js'`
+    set [`options.jsxImportSource`][options-jsximportsource] to `'solid-js/h'`
 
 Other JSX runtimes are supported by setting
 [`options.jsxImportSource`][options-jsximportsource].
@@ -899,12 +899,12 @@ for more info.
   ```js path="example.js"
   import {compile} from '@mdx-js/mdx'
 
-  const js = String(await compile('# hi', {jsxImportSource: 'solid-js', /* otherOptions… */}))
+  const js = String(await compile('# hi', {jsxImportSource: 'solid-js/h', /* otherOptions… */}))
   ```
 </details>
 
 Solid is supported when [`options.jsxImportSource`][options-jsximportsource] is
-set to `'solid-js'`.
+set to `'solid-js/h'`.
 
 See also [¶ Vite][vite] and [¶ Rollup][rollup] which you might be using, for
 more info.


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

I found a outdated documentation: it says to use mdx in solid-js, set [options.jsxImportSource](https://mdxjs.com/packages/mdx/#optionsjsximportsource) to 'solid-js', but I tried it and failed.

That's because solid-js have modified its exports. For example, `solid-js/jsx-dev-runtime` is `solid-js/h/jsx-dev-runtime` now.

Here's a [repro](https://github.com/BeiyanYunyi/solid-mdx-repro/). Clone, modify `vite/markdown.ts`, change `solid/h` to `solid`, then `pnpm build` to reproduce the problem.