### PR TITLE
Fix playground AST views w/ clone

### DIFF
--- a/docs/_component/editor.client.js
+++ b/docs/_component/editor.client.js
@@ -37,7 +37,7 @@ function useMdx(defaults) {
       const file = new VFile({basename, value: config.value})
 
       const capture = (name) => () => (tree) => {
-        file.data[name] = tree
+        file.data[name] = structuredClone(tree)
       }
 
       const remarkPlugins = []


### PR DESCRIPTION
```js
const capture = (name) => () => (tree) => {
        file.data[name] = tree
      }
```

In our playground page, we use `capture` in `remarkPlugins` and `rehypePlugins` to capture the ast on different step. But after generate the mdast or hast, the `evaluate` function will keep going and later plugins will do some mutation on the ast object, which result to what we showed to user of mdast/hast in not correct on that step. So I just `structuredClone` the ast as a snapshot when capture and then save to `file`.

When compile `<A b={<B><C /></B>}></A>`, this mr generate `<C />` as `JSXElement`, the old version generate as `CallExpression` with callee of `_jsx`.