### PR TITLE
Use subtests for esbuild, mdx, and remark-mdx

### DIFF
--- a/packages/esbuild/test/index.js
+++ b/packages/esbuild/test/index.js
@@ -102,6 +102,7 @@ test('@mdx-js/esbuild', async (t) => {
       plugins: [esbuildMdx()]
     })
 
+    /** @type {MDXContent} */
     const Content =
       /* @ts-expect-error file is dynamically generated */
       (await import('./esbuild-md.js')).default // type-coverage:ignore-line
@@ -128,6 +129,7 @@ test('@mdx-js/esbuild', async (t) => {
       plugins: [esbuildMdx({mdExtensions: [], mdxExtensions: ['.md']})]
     })
 
+    /** @type {MDXContent} */
     const Content =
       /* @ts-expect-error file is dynamically generated */
       (await import('./esbuild-md-as-mdx.js')).default // type-coverage:ignore-line
@@ -471,6 +473,7 @@ test('@mdx-js/esbuild', async (t) => {
       bundle: true
     })
 
+    /** @type {MDXContent} */
     const Content =
       /** @ts-expect-error file is dynamically generated */
       (await import('./esbuild-compile-from-memory.js')).default // type-coverage:ignore-line
@@ -499,6 +502,7 @@ test('@mdx-js/esbuild', async (t) => {
         bundle: true
       })
 
+      /** @type {MDXContent} */
       const Content =
         /** @ts-expect-error file is dynamically generated */
         (await import('./esbuild-compile-from-memory-empty.js')).default // type-coverage:ignore-line
@@ -531,6 +535,7 @@ test('@mdx-js/esbuild', async (t) => {
       plugins: [esbuildMdx({allowDangerousRemoteMdx: true})]
     })
 
+    /** @type {MDXContent} */
     const Content =
       /* @ts-expect-error file is dynamically generated */
       (await import('./esbuild-with-remote-md.js')).default // type-coverage:ignore-line
@@ -568,6 +573,7 @@ test('@mdx-js/esbuild', async (t) => {
       plugins: [esbuildMdx({allowDangerousRemoteMdx: true})]
     })
 
+    /** @type {MDXContent} */
     const Content =
       /* @ts-expect-error file is dynamically generated */
       (await import('./esbuild-with-remote-mdx.js')).default // type-coverage:ignore-line

--- a/packages/esbuild/test/index.js
+++ b/packages/esbuild/test/index.js
@@ -17,7 +17,7 @@ import {renderToStaticMarkup} from 'react-dom/server'
 import esbuildMdx from '../index.js'
 
 test('@mdx-js/esbuild', async (t) => {
-  await t.test('MDX', async () => {
+  await t.test('should compile MDX', async () => {
     await fs.writeFile(
       new URL('esbuild.mdx', import.meta.url),
       'export const Message = () => <>World!</>\n\n# Hello, <Message />'
@@ -47,7 +47,7 @@ test('@mdx-js/esbuild', async (t) => {
   await fs.rm(new URL('esbuild.mdx', import.meta.url), {force: true})
   await fs.rm(new URL('esbuild.js', import.meta.url), {force: true})
 
-  await t.test('Resolve directory', async () => {
+  await t.test('should resolve directory and compile', async () => {
     await fs.writeFile(
       new URL('esbuild-resolve.mdx', import.meta.url),
       'import Content from "./folder/file.mdx"\n\n<Content/>'
@@ -76,11 +76,7 @@ test('@mdx-js/esbuild', async (t) => {
       /* @ts-expect-error file is dynamically generated */
       (await import('./esbuild-resolve.js')).default // type-coverage:ignore-line
 
-    assert.equal(
-      renderToStaticMarkup(React.createElement(Content)),
-      '0.1',
-      'should compile'
-    )
+    assert.equal(renderToStaticMarkup(React.createElement(Content)), '0.1')
   })
 
   await fs.rm(new URL('esbuild-resolve.mdx', import.meta.url), {force: true})
@@ -90,7 +86,7 @@ test('@mdx-js/esbuild', async (t) => {
     recursive: true
   })
 
-  await t.test('Markdown', async () => {
+  await t.test('should compile `.md`', async () => {
     await fs.writeFile(new URL('esbuild.md', import.meta.url), '\ta')
 
     await esbuild.build({
@@ -109,15 +105,14 @@ test('@mdx-js/esbuild', async (t) => {
 
     assert.equal(
       renderToStaticMarkup(React.createElement(Content)),
-      '<pre><code>a\n</code></pre>',
-      'should compile `.md`'
+      '<pre><code>a\n</code></pre>'
     )
   })
 
   await fs.rm(new URL('esbuild.md', import.meta.url), {force: true})
   await fs.rm(new URL('esbuild-md.js', import.meta.url), {force: true})
 
-  await t.test('`.md` as MDX extension', async () => {
+  await t.test('should compile `.md` as MDX w/ configuration', async () => {
     await fs.writeFile(new URL('esbuild.md', import.meta.url), '\ta')
 
     await esbuild.build({
@@ -134,17 +129,13 @@ test('@mdx-js/esbuild', async (t) => {
       /* @ts-expect-error file is dynamically generated */
       (await import('./esbuild-md-as-mdx.js')).default // type-coverage:ignore-line
 
-    assert.equal(
-      renderToStaticMarkup(React.createElement(Content)),
-      '<p>a</p>',
-      'should compile `.md` as MDX w/ configuration'
-    )
+    assert.equal(renderToStaticMarkup(React.createElement(Content)), '<p>a</p>')
   })
 
   await fs.rm(new URL('esbuild.md', import.meta.url), {force: true})
   await fs.rm(new URL('esbuild-md-as-mdx.js', import.meta.url), {force: true})
 
-  await t.test('File not in `extnames`', async () => {
+  await t.test('should not handle `.md` files w/ `format: mdx`', async () => {
     await fs.writeFile(new URL('esbuild.md', import.meta.url), 'a')
     await fs.writeFile(new URL('esbuild.mdx', import.meta.url), 'a')
 
@@ -157,10 +148,11 @@ test('@mdx-js/esbuild', async (t) => {
         ),
         plugins: [esbuildMdx({format: 'mdx'})]
       }),
-      /No loader is configured for "\.md" files/,
-      'should not handle `.md` files w/ `format: mdx`'
+      /No loader is configured for "\.md" files/
     )
+  })
 
+  await t.test('should not handle `.mdx` files w/ `format: md`', async () => {
     console.log('\nnote: the following error is expected!\n')
     await assert.rejects(
       esbuild.build({
@@ -170,8 +162,7 @@ test('@mdx-js/esbuild', async (t) => {
         ),
         plugins: [esbuildMdx({format: 'md'})]
       }),
-      /No loader is configured for "\.mdx" files/,
-      'should not handle `.mdx` files w/ `format: md`'
+      /No loader is configured for "\.mdx" files/
     )
   })
 
@@ -516,36 +507,38 @@ test('@mdx-js/esbuild', async (t) => {
     {force: true}
   )
 
-  await t.test('Remote markdown', async () => {
-    await fs.writeFile(
-      new URL('esbuild-with-remote-md.mdx', import.meta.url),
-      'import Content from "https://raw.githubusercontent.com/mdx-js/mdx/main/packages/esbuild/test/files/md-file.md"\n\n<Content />'
-    )
+  await t.test(
+    'should compile remote markdown files w/ `allowDangerousRemoteMdx`',
+    async () => {
+      await fs.writeFile(
+        new URL('esbuild-with-remote-md.mdx', import.meta.url),
+        'import Content from "https://raw.githubusercontent.com/mdx-js/mdx/main/packages/esbuild/test/files/md-file.md"\n\n<Content />'
+      )
 
-    await esbuild.build({
-      entryPoints: [
-        fileURLToPath(new URL('esbuild-with-remote-md.mdx', import.meta.url))
-      ],
-      outfile: fileURLToPath(
-        new URL('esbuild-with-remote-md.js', import.meta.url)
-      ),
-      bundle: true,
-      define: {'process.env.NODE_ENV': '"development"'},
-      format: 'esm',
-      plugins: [esbuildMdx({allowDangerousRemoteMdx: true})]
-    })
+      await esbuild.build({
+        entryPoints: [
+          fileURLToPath(new URL('esbuild-with-remote-md.mdx', import.meta.url))
+        ],
+        outfile: fileURLToPath(
+          new URL('esbuild-with-remote-md.js', import.meta.url)
+        ),
+        bundle: true,
+        define: {'process.env.NODE_ENV': '"development"'},
+        format: 'esm',
+        plugins: [esbuildMdx({allowDangerousRemoteMdx: true})]
+      })
 
-    /** @type {MDXContent} */
-    const Content =
-      /* @ts-expect-error file is dynamically generated */
-      (await import('./esbuild-with-remote-md.js')).default // type-coverage:ignore-line
+      /** @type {MDXContent} */
+      const Content =
+        /* @ts-expect-error file is dynamically generated */
+        (await import('./esbuild-with-remote-md.js')).default // type-coverage:ignore-line
 
-    assert.equal(
-      renderToStaticMarkup(React.createElement(Content)),
-      '<p>Some content.</p>',
-      'should compile remote markdown files w/ `allowDangerousRemoteMdx`'
-    )
-  })
+      assert.equal(
+        renderToStaticMarkup(React.createElement(Content)),
+        '<p>Some content.</p>'
+      )
+    }
+  )
 
   await fs.rm(new URL('esbuild-with-remote-md.mdx', import.meta.url), {
     force: true
@@ -554,36 +547,38 @@ test('@mdx-js/esbuild', async (t) => {
     force: true
   })
 
-  await t.test('Remote MDX importing more markdown', async () => {
-    await fs.writeFile(
-      new URL('esbuild-with-remote-mdx.mdx', import.meta.url),
-      'import Content from "https://raw.githubusercontent.com/mdx-js/mdx/main/packages/esbuild/test/files/mdx-file-importing-markdown.mdx"\n\n<Content />'
-    )
+  await t.test(
+    'should compile remote MD, MDX, and JS files w/ `allowDangerousRemoteMdx`',
+    async () => {
+      await fs.writeFile(
+        new URL('esbuild-with-remote-mdx.mdx', import.meta.url),
+        'import Content from "https://raw.githubusercontent.com/mdx-js/mdx/main/packages/esbuild/test/files/mdx-file-importing-markdown.mdx"\n\n<Content />'
+      )
 
-    await esbuild.build({
-      entryPoints: [
-        fileURLToPath(new URL('esbuild-with-remote-mdx.mdx', import.meta.url))
-      ],
-      outfile: fileURLToPath(
-        new URL('esbuild-with-remote-mdx.js', import.meta.url)
-      ),
-      bundle: true,
-      define: {'process.env.NODE_ENV': '"development"'},
-      format: 'esm',
-      plugins: [esbuildMdx({allowDangerousRemoteMdx: true})]
-    })
+      await esbuild.build({
+        entryPoints: [
+          fileURLToPath(new URL('esbuild-with-remote-mdx.mdx', import.meta.url))
+        ],
+        outfile: fileURLToPath(
+          new URL('esbuild-with-remote-mdx.js', import.meta.url)
+        ),
+        bundle: true,
+        define: {'process.env.NODE_ENV': '"development"'},
+        format: 'esm',
+        plugins: [esbuildMdx({allowDangerousRemoteMdx: true})]
+      })
 
-    /** @type {MDXContent} */
-    const Content =
-      /* @ts-expect-error file is dynamically generated */
-      (await import('./esbuild-with-remote-mdx.js')).default // type-coverage:ignore-line
+      /** @type {MDXContent} */
+      const Content =
+        /* @ts-expect-error file is dynamically generated */
+        (await import('./esbuild-with-remote-mdx.js')).default // type-coverage:ignore-line
 
-    assert.equal(
-      renderToStaticMarkup(React.createElement(Content)),
-      '<h1>heading</h1>\n<p>A <span style="color:red">little pill</span>.</p>\n<p>Some content.</p>',
-      'should compile remote MD, MDX, and JS files w/ `allowDangerousRemoteMdx`'
-    )
-  })
+      assert.equal(
+        renderToStaticMarkup(React.createElement(Content)),
+        '<h1>heading</h1>\n<p>A <span style="color:red">little pill</span>.</p>\n<p>Some content.</p>'
+      )
+    }
+  )
 
   await fs.rm(new URL('esbuild-with-remote-mdx.mdx', import.meta.url), {
     force: true

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -33,1131 +33,1369 @@ import {MDXProvider} from '../../react/index.js'
 /** @type {import('react-dom/server').renderToStaticMarkup} */
 const renderToStaticMarkup = renderToStaticMarkup_
 
-test('compile', async () => {
-  assert.throws(
-    // @ts-expect-error: removed option.
-    () => compile('# hi!', {filepath: 'example.mdx'}),
-    /`options.filepath` is no longer supported/,
-    'should throw when a removed option is passed'
-  )
+test('compile', async (t) => {
+  await t.test('should throw when a removed option is passed', () => {
+    assert.throws(
+      // @ts-expect-error: removed option.
+      () => compile('# hi!', {filepath: 'example.mdx'}),
+      /`options.filepath` is no longer supported/
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(await compile('# hi!')))
-    ),
-    '<h1>hi!</h1>',
-    'should compile'
-  )
+  await t.test('should compile', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(await compile('# hi!')))
+      ),
+      '<h1>hi!</h1>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(await compile(new VFile('# hi?'))))
-    ),
-    '<h1>hi?</h1>',
-    'should compile a vfile'
-  )
+  await t.test('should compile a vfile', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(await compile(new VFile('# hi?'))))
+      ),
+      '<h1>hi?</h1>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('# hi!')))),
-    '<h1>hi!</h1>',
-    'should compile (sync)'
-  )
+  await t.test(
+    'should compile (sync)',
 
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('')))),
-    '',
-    'should compile an empty document'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('x', {
-            remarkPlugins: [() => () => ({type: 'root', children: []})]
-          })
-        )
-      )
-    ),
-    '',
-    'should compile an empty document (remark)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('y', {
-            rehypePlugins: [() => () => ({type: 'root', children: []})]
-          })
-        )
-      )
-    ),
-    '',
-    'should compile an empty document (rehype)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('y', {
-            rehypePlugins: [() => () => ({type: 'doctype', name: 'html'})]
-          })
-        )
-      )
-    ),
-    '',
-    'should compile a document (rehype, non-representable)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('y', {
-            rehypePlugins: [
-              () => () => ({type: 'element', tagName: 'x', children: []})
-            ]
-          })
-        )
-      )
-    ),
-    '<x></x>',
-    'should compile a non-element document (rehype, single element)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('y', {
-            rehypePlugins: [
-              () => () => ({type: 'element', tagName: 'a-b', children: []})
-            ]
-          })
-        )
-      )
-    ),
-    '<a-b></a-b>',
-    'should compile custom elements'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('!', {jsxRuntime: 'automatic'}))
-      )
-    ),
-    '<p>!</p>',
-    'should support the automatic runtime (`@jsxRuntime`)'
-  )
-
-  assert.equal(
-    render(
-      h(await run(compileSync('?', {jsxImportSource: 'preact/compat'})), {})
-    ),
-    '<p>?</p>',
-    'should support an import source (`@jsxImportSource`)'
-  )
-
-  assert.equal(
-    render(
-      h(
-        await run(
-          compileSync('<>%</>', {
-            jsxRuntime: 'classic',
-            pragma: 'preact.createElement',
-            pragmaFrag: 'preact.Fragment',
-            pragmaImportSource: 'preact/compat'
-          })
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('# hi!')))
         ),
-        {}
+        '<h1>hi!</h1>'
       )
-    ),
-    '%',
-    'should support `pragma`, `pragmaFrag` for `preact/compat`'
+    }
   )
 
-  assert.equal(
-    render(
-      h(await run(compileSync('<>1</>', {jsxImportSource: 'preact'})), {})
-    ),
-    '1',
-    'should support `jsxImportSource` for `preact`'
-  )
+  await t.test(
+    'should compile an empty document',
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          String(compileSync('<>+</>', {jsxImportSource: '@emotion/react'}))
-        )
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(React.createElement(await run(compileSync('')))),
+        ''
       )
-    ),
-    '+',
-    'should support `jsxImportSource` for `emotion`'
+    }
   )
 
-  assert.throws(
-    () => {
-      compileSync('import React from "react"\n\n.', {
-        jsxRuntime: 'classic',
-        pragmaImportSource: '@emotion/react',
-        pragma: ''
-      })
-    },
-    /Missing `pragma` in classic runtime with `pragmaImportSource`/,
-    'should *not* support `jsxClassicImportSource` w/o `pragma`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('<X />')), {
-        components: {
-          /** @param {Record<string, unknown>} props */
-          X(props) {
-            return React.createElement('span', props, '!')
-          }
-        }
-      })
-    ),
-    '<span>!</span>',
-    'should support passing in `components` to `MDXContent`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('<x.y />')), {
-        components: {
-          x: {
-            /** @param {Record<string, unknown>} props */
-            y(props) {
-              return React.createElement('span', props, '?')
-            }
-          }
-        }
-      })
-    ),
-    '<span>?</span>',
-    'should support passing in `components` (for members) to `MDXContent`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('<X /> and <X.Y />')), {
-        components: {
-          X: Object.assign(
-            /** @param {Record<string, unknown>} props */
-            (props) => React.createElement('span', props, '!'),
-            {
-              /** @param {Record<string, unknown>} props */
-              Y(props) {
-                return React.createElement('span', props, '?')
-              }
-            }
-          )
-        }
-      })
-    ),
-    '<p><span>!</span> and <span>?</span></p>',
-    'should support passing in `components` directly and as an object w/ members'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('*a*')), {
-        components: {
-          em(props) {
-            return React.createElement('i', props)
-          }
-        }
-      })
-    ),
-    '<p><i>a</i></p>',
-    'should support overwriting components by passing them to `MDXContent`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('export var X = () => <em>a</em>\n\n*a*, <X>b</X>')
-        ),
-        {
-          components: {
-            em(props) {
-              return React.createElement('i', props)
-            }
-          }
-        }
-      )
-    ),
-    '<p><i>a</i>, <em>a</em></p>',
-    'should *not* support overwriting components in exports'
-  )
-
-  await assert.rejects(
-    async () =>
+  await t.test('should compile an empty document (remark)', async () => {
+    assert.equal(
       renderToStaticMarkup(
         React.createElement(
-          await run(compileSync('export var X = () => <Y />\n\n<X />'))
+          await run(
+            compileSync('x', {
+              remarkPlugins: [() => () => ({type: 'root', children: []})]
+            })
+          )
         )
       ),
-    /Y is not defined/,
-    'should throw on missing components in exported components'
-  )
+      ''
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        MDXProvider,
-        {
-          components: {
-            Y() {
-              return React.createElement('span', {}, '!')
-            }
-          }
-        },
+  await t.test('should compile an empty document (rehype)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
         React.createElement(
           await run(
-            compileSync('export var X = () => <Y />\n\n<X />', {
-              providerImportSource: '@mdx-js/react'
+            compileSync('y', {
+              rehypePlugins: [() => () => ({type: 'root', children: []})]
             })
           )
         )
-      )
-    ),
-    '<span>!</span>',
-    'should support provided components in exported components'
-  )
+      ),
+      ''
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync(
-            'export function Foo({Box = "div"}) { return <Box>a</Box>; }\n\n<Foo />'
-          )
-        )
-      )
-    ),
-    '<div>a</div>',
-    'should support custom components in exported components'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        MDXProvider,
-        {
-          components: {
-            y: {
-              z() {
-                return React.createElement('span', {}, '!')
-              }
-            }
-          }
-        },
-        React.createElement(
-          await run(
-            compileSync('export var X = () => <y.z />\n\n<X />', {
-              providerImportSource: '@mdx-js/react'
-            })
-          )
-        )
-      )
-    ),
-    '<span>!</span>',
-    'should support provided component objects in exported components'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('a')), {
-        components: {
-          /**
-           * @param {Record<string, unknown>} props
-           */
-          wrapper(props) {
-            const {components, ...rest} = props
-            return React.createElement('div', rest)
-          }
-        }
-      })
-    ),
-    '<div><p>a</p></div>',
-    'should support setting the layout by passing it (as `wrapper`) to `MDXContent`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync(
-            'import React from "react"\nexport default class extends React.Component { render() { return <>{this.props.children}</> } }\n\na'
-          )
-        )
-      )
-    ),
-    '<p>a</p>',
-    'should support setting the layout through a class component'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync(
-            'export default function Layout({components, ...props}) { return <section {...props} /> }\n\na'
+  await t.test(
+    'should compile a document (rehype, non-representable)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync('y', {
+                rehypePlugins: [() => () => ({type: 'doctype', name: 'html'})]
+              })
+            )
           )
         ),
-        {
-          components: {
-            /**
-             * @param {Record<string, unknown>} props
-             */
-            wrapper(props) {
-              const {components, ...rest} = props
-              return React.createElement('article', rest)
-            }
-          }
-        }
+        ''
       )
-    ),
-    '<section><p>a</p></section>',
-    'should *not* support overwriting the layout by passing one (as `wrapper`) to `MDXContent`'
+    }
   )
 
-  assert.throws(
-    () => {
+  await t.test(
+    'should compile a non-element document (rehype, single element)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync('y', {
+                rehypePlugins: [
+                  () => () => ({type: 'element', tagName: 'x', children: []})
+                ]
+              })
+            )
+          )
+        ),
+        '<x></x>'
+      )
+    }
+  )
+
+  await t.test('should compile custom elements', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(
+            compileSync('y', {
+              rehypePlugins: [
+                () => () => ({type: 'element', tagName: 'a-b', children: []})
+              ]
+            })
+          )
+        )
+      ),
+      '<a-b></a-b>'
+    )
+  })
+
+  await t.test(
+    'should support the automatic runtime (`@jsxRuntime`)',
+
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(compileSync('!', {jsxRuntime: 'automatic'}))
+          )
+        ),
+        '<p>!</p>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support an import source (`@jsxImportSource`)',
+    async () => {
+      assert.equal(
+        render(
+          h(await run(compileSync('?', {jsxImportSource: 'preact/compat'})), {})
+        ),
+        '<p>?</p>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support `pragma`, `pragmaFrag` for `preact/compat`',
+
+    async () => {
+      assert.equal(
+        render(
+          h(
+            await run(
+              compileSync('<>%</>', {
+                jsxRuntime: 'classic',
+                pragma: 'preact.createElement',
+                pragmaFrag: 'preact.Fragment',
+                pragmaImportSource: 'preact/compat'
+              })
+            ),
+            {}
+          )
+        ),
+        '%'
+      )
+    }
+  )
+
+  await t.test(
+    'should support `jsxImportSource` for `preact`',
+
+    async () => {
+      assert.equal(
+        render(
+          h(await run(compileSync('<>1</>', {jsxImportSource: 'preact'})), {})
+        ),
+        '1'
+      )
+    }
+  )
+
+  await t.test('should support `jsxImportSource` for `emotion`', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(
+            String(compileSync('<>+</>', {jsxImportSource: '@emotion/react'}))
+          )
+        )
+      ),
+      '+'
+    )
+  })
+
+  await t.test(
+    'should *not* support `jsxClassicImportSource` w/o `pragma`',
+    async () => {
+      assert.throws(() => {
+        compileSync('import React from "react"\n\n.', {
+          jsxRuntime: 'classic',
+          pragmaImportSource: '@emotion/react',
+          pragma: ''
+        })
+      }, /Missing `pragma` in classic runtime with `pragmaImportSource`/)
+    }
+  )
+
+  await t.test(
+    'should support passing in `components` to `MDXContent`',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('<X />')), {
+            components: {
+              /** @param {Record<string, unknown>} props */
+              X(props) {
+                return React.createElement('span', props, '!')
+              }
+            }
+          })
+        ),
+        '<span>!</span>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support passing in `components` (for members) to `MDXContent`',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('<x.y />')), {
+            components: {
+              x: {
+                /** @param {Record<string, unknown>} props */
+                y(props) {
+                  return React.createElement('span', props, '?')
+                }
+              }
+            }
+          })
+        ),
+        '<span>?</span>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support passing in `components` directly and as an object w/ members',
+
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('<X /> and <X.Y />')), {
+            components: {
+              X: Object.assign(
+                /** @param {Record<string, unknown>} props */
+                (props) => React.createElement('span', props, '!'),
+                {
+                  /** @param {Record<string, unknown>} props */
+                  Y(props) {
+                    return React.createElement('span', props, '?')
+                  }
+                }
+              )
+            }
+          })
+        ),
+        '<p><span>!</span> and <span>?</span></p>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support overwriting components by passing them to `MDXContent`',
+
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('*a*')), {
+            components: {
+              em(props) {
+                return React.createElement('i', props)
+              }
+            }
+          })
+        ),
+        '<p><i>a</i></p>'
+      )
+    }
+  )
+
+  await t.test(
+    'should *not* support overwriting components in exports',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync('export var X = () => <em>a</em>\n\n*a*, <X>b</X>')
+            ),
+            {
+              components: {
+                em(props) {
+                  return React.createElement('i', props)
+                }
+              }
+            }
+          )
+        ),
+        '<p><i>a</i>, <em>a</em></p>'
+      )
+    }
+  )
+
+  await t.test(
+    'should throw on missing components in exported components',
+    async () => {
+      await assert.rejects(
+        async () =>
+          renderToStaticMarkup(
+            React.createElement(
+              await run(compileSync('export var X = () => <Y />\n\n<X />'))
+            )
+          ),
+        /Y is not defined/
+      )
+    }
+  )
+
+  await t.test(
+    'should support provided components in exported components',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            MDXProvider,
+            {
+              components: {
+                Y() {
+                  return React.createElement('span', {}, '!')
+                }
+              }
+            },
+            React.createElement(
+              await run(
+                compileSync('export var X = () => <Y />\n\n<X />', {
+                  providerImportSource: '@mdx-js/react'
+                })
+              )
+            )
+          )
+        ),
+        '<span>!</span>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support custom components in exported components',
+
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync(
+                'export function Foo({Box = "div"}) { return <Box>a</Box>; }\n\n<Foo />'
+              )
+            )
+          )
+        ),
+        '<div>a</div>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support provided component objects in exported components',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            MDXProvider,
+            {
+              components: {
+                y: {
+                  z() {
+                    return React.createElement('span', {}, '!')
+                  }
+                }
+              }
+            },
+            React.createElement(
+              await run(
+                compileSync('export var X = () => <y.z />\n\n<X />', {
+                  providerImportSource: '@mdx-js/react'
+                })
+              )
+            )
+          )
+        ),
+        '<span>!</span>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support setting the layout by passing it (as `wrapper`) to `MDXContent`',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('a')), {
+            components: {
+              /**
+               * @param {Record<string, unknown>} props
+               */
+              wrapper(props) {
+                const {components, ...rest} = props
+                return React.createElement('div', rest)
+              }
+            }
+          })
+        ),
+        '<div><p>a</p></div>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support setting the layout through a class component',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync(
+                'import React from "react"\nexport default class extends React.Component { render() { return <>{this.props.children}</> } }\n\na'
+              )
+            )
+          )
+        ),
+        '<p>a</p>'
+      )
+    }
+  )
+
+  await t.test(
+    'should *not* support overwriting the layout by passing one (as `wrapper`) to `MDXContent`',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync(
+                'export default function Layout({components, ...props}) { return <section {...props} /> }\n\na'
+              )
+            ),
+            {
+              components: {
+                /**
+                 * @param {Record<string, unknown>} props
+                 */
+                wrapper(props) {
+                  const {components, ...rest} = props
+                  return React.createElement('article', rest)
+                }
+              }
+            }
+          )
+        ),
+        '<section><p>a</p></section>'
+      )
+    }
+  )
+
+  await t.test('should *not* support multiple layouts (1)', async () => {
+    assert.throws(() => {
       compileSync(
         'export default function a() {}\n\nexport default function b() {}\n\n.'
       )
-    },
-    /Cannot specify multiple layouts \(previous: 1:1-1:31\)/,
-    'should *not* support multiple layouts (1)'
-  )
+    }, /Cannot specify multiple layouts \(previous: 1:1-1:31\)/)
+  })
 
-  assert.throws(
-    () => {
+  await t.test('should *not* support multiple layouts (2)', async () => {
+    assert.throws(() => {
       compileSync(
         'export default function a() {}\n\nexport {Layout as default} from "./components.js"\n\n.'
       )
-    },
-    /Cannot specify multiple layouts \(previous: 1:1-1:31\)/,
-    'should *not* support multiple layouts (2)'
+    }, /Cannot specify multiple layouts \(previous: 1:1-1:31\)/)
+  })
+
+  await t.test(
+    'should support an identifier as an export default',
+    async () => {
+      await assert.rejects(async () => {
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('export default a')))
+        )
+      }, new ReferenceError('a is not defined'))
+    }
   )
 
-  await assert.rejects(
+  await t.test(
+    'should throw if a required component is not passed',
     async () => {
-      renderToStaticMarkup(
-        React.createElement(await run(compileSync('export default a')))
-      )
-    },
-    new ReferenceError('a is not defined'),
-    'should support an identifier as an export default'
+      await assert.rejects(async () => {
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('<X />')))
+        )
+      }, /Expected component `X` to be defined/)
+    }
   )
 
-  await assert.rejects(
-    async () => {
-      renderToStaticMarkup(React.createElement(await run(compileSync('<X />'))))
-    },
-    /Expected component `X` to be defined/,
-    'should throw if a required component is not passed'
-  )
-
-  await assert.rejects(
-    async () => {
+  await t.test('should throw if a required member is not passed', async () => {
+    await assert.rejects(async () => {
       renderToStaticMarkup(
         React.createElement(await run(compileSync('<a.b />')))
       )
-    },
-    /Expected object `a` to be defined/,
-    'should throw if a required member is not passed'
-  )
+    }, /Expected object `a` to be defined/)
+  })
 
-  await assert.rejects(
+  await t.test(
+    'should throw if a used member is not defined locally',
+
     async () => {
-      renderToStaticMarkup(
-        React.createElement(
-          await run(compileSync('export const a = {}\n\n<a.b />'))
+      await assert.rejects(async () => {
+        renderToStaticMarkup(
+          React.createElement(
+            await run(compileSync('export const a = {}\n\n<a.b />'))
+          )
         )
-      )
-    },
-    /Expected component `a.b` to be defined/,
-    'should throw if a used member is not defined locally'
+      }, /Expected component `a.b` to be defined/)
+    }
   )
 
-  await assert.rejects(
+  await t.test(
+    'should throw if a used member is not defined locally (JSX in a function)',
     async () => {
-      renderToStaticMarkup(
-        React.createElement(
-          await run(compileSync('<a render={() => <x.y />} />'))
+      await assert.rejects(async () => {
+        renderToStaticMarkup(
+          React.createElement(
+            await run(compileSync('<a render={() => <x.y />} />'))
+          )
         )
-      )
-    },
-    /Expected object `x` to be defined/,
-    'should throw if a used member is not defined locally (JSX in a function)'
+      }, /Expected object `x` to be defined/)
+    }
   )
 
-  console.log('\nnote: the following warning is expected!\n')
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('<a render={(x) => <x.y />} />'))
-      )
-    ),
-    '<a></a>',
-    'should render if a used member is defined locally (JSX in a function)'
-  )
-  console.log('\nnote: the preceding warning is expected!\n')
-
-  const developmentSourceNode = (
-    await run(
-      compileSync(
-        {value: '<div />', path: 'path/to/file.js'},
-        {development: true}
-      ).value
-    )
-  )({})
-
-  assert.deepEqual(
-    // @ts-expect-error React attaches source information on this property,
-    // but it’s private and untyped.
-    developmentSourceNode._source,
-    {fileName: 'path/to/file.js', lineNumber: 1, columnNumber: 1},
-    'should expose source information in the automatic jsx dev runtime'
-  )
-
-  await assert.rejects(
+  await t.test(
+    'should render if a used member is defined locally (JSX in a function) (The warning is expected)',
     async () => {
-      renderToStaticMarkup(
-        React.createElement(
-          await run(compileSync('<X />', {development: true}))
+      console.log('\nnote: the following warning is expected!\n')
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(compileSync('<a render={(x) => <x.y />} />'))
+          )
+        ),
+        '<a></a>'
+      )
+      console.log('\nnote: the preceding warning is expected!\n')
+    }
+  )
+
+  await t.test(
+    'should expose source information in the automatic jsx dev runtime',
+    async () => {
+      const developmentSourceNode = (
+        await run(
+          compileSync(
+            {value: '<div />', path: 'path/to/file.js'},
+            {development: true}
+          ).value
         )
+      )({})
+
+      assert.deepEqual(
+        // @ts-expect-error React attaches source information on this property,
+        // but it’s private and untyped.
+        developmentSourceNode._source,
+        {fileName: 'path/to/file.js', lineNumber: 1, columnNumber: 1}
       )
-    },
-    /It’s referenced in your code at `1:1-1:6/,
-    'should pass more info to errors w/ `development: true`'
+    }
   )
 
-  await assert.rejects(
+  await t.test(
+    'should pass more info to errors w/ `development: true`',
     async () => {
-      renderToStaticMarkup(
-        React.createElement(
-          await run(
-            compileSync(
-              {value: 'asd <a.b />', path: 'folder/example.mdx'},
-              {development: true}
+      await assert.rejects(async () => {
+        renderToStaticMarkup(
+          React.createElement(
+            await run(compileSync('<X />', {development: true}))
+          )
+        )
+      }, /It’s referenced in your code at `1:1-1:6/)
+    }
+  )
+
+  await t.test(
+    'should show what file contains the error w/ `development: true`, and `path`',
+    async () => {
+      await assert.rejects(async () => {
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync(
+                {value: 'asd <a.b />', path: 'folder/example.mdx'},
+                {development: true}
+              )
             )
           )
         )
-      )
-    },
-    /It’s referenced in your code at `1:5-1:12` in `folder\/example.mdx`/,
-    'should show what file contains the error w/ `development: true`, and `path`'
+      }, /It’s referenced in your code at `1:5-1:12` in `folder\/example.mdx`/)
+    }
   )
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        MDXProvider,
-        {
-          components: {
-            em(props) {
-              return React.createElement('i', props)
-            }
-          }
-        },
-        React.createElement(
-          await run(compileSync('*z*', {providerImportSource: '@mdx-js/react'}))
-        )
-      )
-    ),
-    '<p><i>z</i></p>',
-    'should support setting components through context with a `providerImportSource`'
-  )
-
-  await assert.rejects(
+  await t.test(
+    'should support setting components through context with a `providerImportSource`',
     async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            MDXProvider,
+            {
+              components: {
+                em(props) {
+                  return React.createElement('i', props)
+                }
+              }
+            },
+            React.createElement(
+              await run(
+                compileSync('*z*', {providerImportSource: '@mdx-js/react'})
+              )
+            )
+          )
+        ),
+        '<p><i>z</i></p>'
+      )
+    }
+  )
+
+  await t.test(
+    'should throw if a required component is not passed or given to `MDXProvider`',
+    async () => {
+      await assert.rejects(async () => {
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync('<X />', {providerImportSource: '@mdx-js/react'})
+            )
+          )
+        )
+      }, /Expected component `X` to be defined/)
+    }
+  )
+
+  await t.test(
+    'should support `createProcessor`',
+
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(createProcessor().processSync('x')))
+        ),
+        '<p>x</p>'
+      )
+    }
+  )
+
+  await t.test('should support `format: md`', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(createProcessor({format: 'md'}).processSync('\tx'))
+        )
+      ),
+      '<pre><code>x\n</code></pre>'
+    )
+  })
+
+  await t.test('should support `format: mdx`', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(createProcessor({format: 'mdx'}).processSync('\tx'))
+        )
+      ),
+      '<p>x</p>'
+    )
+  })
+
+  await t.test('should not support `format: detect`', async () => {
+    assert.throws(() => {
+      // @ts-expect-error incorrect `detect`.
+      createProcessor({format: 'detect'})
+    }, new Error("Incorrect `format: 'detect'`: `createProcessor` can support either `md` or `mdx`; it does not support detecting the format"))
+  })
+
+  await t.test(
+    'should detect as `mdx` by default',
+
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(await compile({value: '\tx'})))
+        ),
+        '<p>x</p>'
+      )
+    }
+  )
+
+  await t.test('should detect `.md` as `md`', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(await compile({value: '\tx', path: 'y.md'}))
+        )
+      ),
+      '<pre><code>x\n</code></pre>'
+    )
+  })
+
+  await t.test('should detect `.mdx` as `mdx`', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(await compile({value: '\tx', path: 'y.mdx'}))
+        )
+      ),
+      '<p>x</p>'
+    )
+  })
+
+  await t.test('should not “detect” `.md` w/ `format: mdx`', async () => {
+    assert.equal(
       renderToStaticMarkup(
         React.createElement(
           await run(
-            compileSync('<X />', {providerImportSource: '@mdx-js/react'})
+            await compile({value: '\tx', path: 'y.md'}, {format: 'mdx'})
           )
         )
-      )
-    },
-    /Expected component `X` to be defined/,
-    'should throw if a required component is not passed or given to `MDXProvider`'
-  )
+      ),
+      '<p>x</p>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(createProcessor().processSync('x')))
-    ),
-    '<p>x</p>',
-    'should support `createProcessor`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(createProcessor({format: 'md'}).processSync('\tx'))
-      )
-    ),
-    '<pre><code>x\n</code></pre>',
-    'should support `format: md`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(createProcessor({format: 'mdx'}).processSync('\tx'))
-      )
-    ),
-    '<p>x</p>',
-    'should support `format: mdx`'
-  )
-
-  assert.throws(
-    () => {
-      // @ts-expect-error incorrect `detect`.
-      createProcessor({format: 'detect'})
-    },
-    new Error(
-      "Incorrect `format: 'detect'`: `createProcessor` can support either `md` or `mdx`; it does not support detecting the format"
-    ),
-    'should not support `format: detect`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(await compile({value: '\tx'})))
-    ),
-    '<p>x</p>',
-    'should detect as `mdx` by default'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(await compile({value: '\tx', path: 'y.md'}))
-      )
-    ),
-    '<pre><code>x\n</code></pre>',
-    'should detect `.md` as `md`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(await compile({value: '\tx', path: 'y.mdx'}))
-      )
-    ),
-    '<p>x</p>',
-    'should detect `.mdx` as `mdx`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(await compile({value: '\tx', path: 'y.md'}, {format: 'mdx'}))
-      )
-    ),
-    '<p>x</p>',
-    'should not “detect” `.md` w/ `format: mdx`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(await compile({value: '\tx', path: 'y.mdx'}, {format: 'md'}))
-      )
-    ),
-    '<pre><code>x\n</code></pre>',
-    'should not “detect” `.mdx` w/ `format: md`'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(await compile({value: '<q>r</q>', path: 's.md'}))
-      )
-    ),
-    '<p>r</p>',
-    'should not support HTML in markdown by default'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          await compile(
-            {value: '<q>r</q>', path: 's.md'},
-            {rehypePlugins: [rehypeRaw]}
+  await t.test('should not “detect” `.mdx` w/ `format: md`', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(
+            await compile({value: '\tx', path: 'y.mdx'}, {format: 'md'})
           )
         )
+      ),
+      '<pre><code>x\n</code></pre>'
+    )
+  })
+
+  await t.test(
+    'should not support HTML in markdown by default',
+
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(await compile({value: '<q>r</q>', path: 's.md'}))
+          )
+        ),
+        '<p>r</p>'
       )
-    ),
-    '<p><q>r</q></p>',
-    'should support HTML in markdown w/ `rehype-raw`'
+    }
   )
 
-  assert.match(
-    String(
-      await compile('a', {
-        format: 'md',
-        remarkPlugins: [
-          () => (/** @type {Root} */ tree) => {
-            tree.children.unshift({
-              type: 'mdxjsEsm',
-              value: '',
-              data: {
-                estree: {
-                  type: 'Program',
-                  comments: [],
-                  sourceType: 'module',
-                  body: [
-                    {
-                      type: 'VariableDeclaration',
-                      kind: 'var',
-                      declarations: [
+  await t.test('should support HTML in markdown w/ `rehype-raw`', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(
+            await compile(
+              {value: '<q>r</q>', path: 's.md'},
+              {rehypePlugins: [rehypeRaw]}
+            )
+          )
+        )
+      ),
+      '<p><q>r</q></p>'
+    )
+  })
+
+  await t.test(
+    'should support injected MDX nodes w/ `rehype-raw`',
+
+    async () => {
+      assert.match(
+        String(
+          await compile('a', {
+            format: 'md',
+            remarkPlugins: [
+              () => (/** @type {Root} */ tree) => {
+                tree.children.unshift({
+                  type: 'mdxjsEsm',
+                  value: '',
+                  data: {
+                    estree: {
+                      type: 'Program',
+                      comments: [],
+                      sourceType: 'module',
+                      body: [
                         {
-                          type: 'VariableDeclarator',
-                          id: {type: 'Identifier', name: 'a'},
-                          init: {type: 'Literal', value: 1}
+                          type: 'VariableDeclaration',
+                          kind: 'var',
+                          declarations: [
+                            {
+                              type: 'VariableDeclarator',
+                              id: {type: 'Identifier', name: 'a'},
+                              init: {type: 'Literal', value: 1}
+                            }
+                          ]
                         }
                       ]
                     }
-                  ]
+                  }
+                })
+              }
+            ],
+            rehypePlugins: [[rehypeRaw, {passThrough: nodeTypes}]]
+          })
+        ),
+        /var a = 1/
+      )
+    }
+  )
+})
+
+test('jsx', async (t) => {
+  await t.test('should serialize JSX w/ `jsx: true`', () => {
+    assert.equal(
+      String(compileSync('*a*', {jsx: true})),
+      [
+        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        'function _createMdxContent(props) {',
+        '  const _components = Object.assign({',
+        '    em: "em",',
+        '    p: "p"',
+        '  }, props.components);',
+        '  return <_components.p><_components.em>{"a"}</_components.em></_components.p>;',
+        '}',
+        'function MDXContent(props = {}) {',
+        '  const {wrapper: MDXLayout} = props.components || ({});',
+        '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
+        '}',
+        'export default MDXContent;',
+        ''
+      ].join('\n')
+    )
+  })
+
+  await t.test('should serialize props', () => {
+    assert.equal(
+      String(compileSync('<a {...b} c d="1" e={1} />', {jsx: true})),
+      [
+        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        'function _createMdxContent(props) {',
+        '  return <a {...b} c d="1" e={1} />;',
+        '}',
+        'function MDXContent(props = {}) {',
+        '  const {wrapper: MDXLayout} = props.components || ({});',
+        '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
+        '}',
+        'export default MDXContent;',
+        ''
+      ].join('\n')
+    )
+  })
+
+  await t.test('should serialize fragments, namespaces, members', () => {
+    assert.equal(
+      String(compileSync('<><a:b /><c.d/></>', {jsx: true})),
+      [
+        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        'function _createMdxContent(props) {',
+        '  const {c} = props.components || ({});',
+        '  if (!c) _missingMdxReference("c", false);',
+        '  if (!c.d) _missingMdxReference("c.d", true);',
+        '  return <><><a:b /><c.d /></></>;',
+        '}',
+        'function MDXContent(props = {}) {',
+        '  const {wrapper: MDXLayout} = props.components || ({});',
+        '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
+        '}',
+        'export default MDXContent;',
+        'function _missingMdxReference(id, component) {',
+        '  throw new Error("Expected " + (component ? "component" : "object") + " `" + id + "` to be defined: you likely forgot to import, pass, or provide it.");',
+        '}',
+        ''
+      ].join('\n')
+    )
+  })
+
+  await t.test('should serialize fragments, expressions', () => {
+    assert.equal(
+      String(compileSync('<>a {/* 1 */} b</>', {jsx: true})),
+      [
+        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        '/*1*/',
+        'function _createMdxContent(props) {',
+        '  return <><>{"a "}{}{" b"}</></>;',
+        '}',
+        'function MDXContent(props = {}) {',
+        '  const {wrapper: MDXLayout} = props.components || ({});',
+        '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
+        '}',
+        'export default MDXContent;',
+        ''
+      ].join('\n')
+    )
+  })
+
+  await t.test('should serialize custom elements inside expressions', () => {
+    assert.equal(
+      String(compileSync('{<a-b></a-b>}', {jsx: true})),
+      [
+        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        'function _createMdxContent(props) {',
+        '  const _components = Object.assign({',
+        '    "a-b": "a-b"',
+        '  }, props.components), _component0 = _components["a-b"];',
+        '  return <>{<_component0></_component0>}</>;',
+        '}',
+        'function MDXContent(props = {}) {',
+        '  const {wrapper: MDXLayout} = props.components || ({});',
+        '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
+        '}',
+        'export default MDXContent;',
+        ''
+      ].join('\n')
+    )
+  })
+
+  await t.test('should allow using props', () => {
+    assert.equal(
+      String(compileSync('Hello {props.name}', {jsx: true})),
+      [
+        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        'function _createMdxContent(props) {',
+        '  const _components = Object.assign({',
+        '    p: "p"',
+        '  }, props.components);',
+        '  return <_components.p>{"Hello "}{props.name}</_components.p>;',
+        '}',
+        'function MDXContent(props = {}) {',
+        '  const {wrapper: MDXLayout} = props.components || ({});',
+        '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
+        '}',
+        'export default MDXContent;',
+        ''
+      ].join('\n')
+    )
+  })
+
+  await t.test(
+    'should not have a conditional expression for MDXLayout when there is an internal layout',
+    () => {
+      assert.equal(
+        String(
+          compileSync(
+            'export default function Layout({components, ...props}) { return <section {...props} /> }\n\na',
+            {jsx: true}
+          )
+        ),
+        [
+          '/*@jsxRuntime automatic @jsxImportSource react*/',
+          'const MDXLayout = function Layout({components, ...props}) {',
+          '  return <section {...props} />;',
+          '};',
+          'function _createMdxContent(props) {',
+          '  const _components = Object.assign({',
+          '    p: "p"',
+          '  }, props.components);',
+          '  return <_components.p>{"a"}</_components.p>;',
+          '}',
+          'function MDXContent(props = {}) {',
+          '  return <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout>;',
+          '}',
+          'export default MDXContent;',
+          ''
+        ].join('\n')
+      )
+    }
+  )
+
+  await t.test('should serialize double quotes in attribute values', () => {
+    assert.match(
+      String(compileSync("{<w x='y \" z' />}", {jsx: true})),
+      /x="y &quot; z"/
+    )
+  })
+
+  await t.test(
+    'should serialize `<` and `{` in JSX text',
+
+    () => {
+      assert.match(
+        String(compileSync('{<>a &amp; b &#123; c &lt; d</>}', {jsx: true})),
+        /a & b &#123; c &lt; d/
+      )
+    }
+  )
+
+  await t.test('should use React props and DOM styles by default', () => {
+    assert.match(
+      String(
+        compileSync('', {
+          rehypePlugins: [
+            /** @type {import('unified').Plugin<[], import('hast').Root>} */
+            function () {
+              return function (tree) {
+                tree.children.push({
+                  type: 'element',
+                  tagName: 'a',
+                  properties: {
+                    className: 'b',
+                    style: '-webkit-box-shadow: 0 0 1px 0 red'
+                  },
+                  children: []
+                })
+              }
+            }
+          ],
+          jsx: true
+        })
+      ),
+      /className="b"/
+    )
+  })
+
+  await t.test(
+    'should support `elementAttributeNameCase` and `stylePropertyNameCase`',
+    () => {
+      assert.match(
+        String(
+          compileSync('', {
+            rehypePlugins: [
+              /** @type {import('unified').Plugin<[], import('hast').Root>} */
+              function () {
+                return function (tree) {
+                  tree.children.push({
+                    type: 'element',
+                    tagName: 'a',
+                    properties: {
+                      className: 'b',
+                      style: '-webkit-box-shadow: 0 0 1px 0 red'
+                    },
+                    children: []
+                  })
                 }
               }
-            })
-          }
-        ],
-        rehypePlugins: [[rehypeRaw, {passThrough: nodeTypes}]]
-      })
-    ),
-    /var a = 1/,
-    'should support injected MDX nodes w/ `rehype-raw`'
+            ],
+            elementAttributeNameCase: 'html',
+            stylePropertyNameCase: 'css',
+            jsx: true
+          })
+        ),
+        /class="b"/
+      )
+    }
   )
 })
 
-test('jsx', async () => {
-  assert.equal(
-    String(compileSync('*a*', {jsx: true})),
-    [
-      '/*@jsxRuntime automatic @jsxImportSource react*/',
-      'function _createMdxContent(props) {',
-      '  const _components = Object.assign({',
-      '    em: "em",',
-      '    p: "p"',
-      '  }, props.components);',
-      '  return <_components.p><_components.em>{"a"}</_components.em></_components.p>;',
-      '}',
-      'function MDXContent(props = {}) {',
-      '  const {wrapper: MDXLayout} = props.components || ({});',
-      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
-      '}',
-      'export default MDXContent;',
-      ''
-    ].join('\n'),
-    'should serialize JSX w/ `jsx: true`'
+test('markdown (CM)', async (t) => {
+  await t.test('should support links (resource) (`[]()` -> `a`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('[a](b)')))
+      ),
+      '<p><a href="b">a</a></p>'
+    )
+  })
+
+  await t.test('should support links (reference) (`[][]` -> `a`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('[a]: b\n[a]')))
+      ),
+      '<p><a href="b">a</a></p>'
+    )
+  })
+
+  await t.test(
+    'should *not* support links (autolink) (`<http://a>` -> error)',
+    async () => {
+      assert.throws(() => {
+        compileSync('<http://a>')
+      }, /note: to create a link in MDX, use `\[text]\(url\)/)
+    }
   )
 
-  assert.equal(
-    String(compileSync('<a {...b} c d="1" e={1} />', {jsx: true})),
-    [
-      '/*@jsxRuntime automatic @jsxImportSource react*/',
-      'function _createMdxContent(props) {',
-      '  return <a {...b} c d="1" e={1} />;',
-      '}',
-      'function MDXContent(props = {}) {',
-      '  const {wrapper: MDXLayout} = props.components || ({});',
-      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
-      '}',
-      'export default MDXContent;',
-      ''
-    ].join('\n'),
-    'should serialize props'
-  )
-
-  assert.equal(
-    String(compileSync('<><a:b /><c.d/></>', {jsx: true})),
-    [
-      '/*@jsxRuntime automatic @jsxImportSource react*/',
-      'function _createMdxContent(props) {',
-      '  const {c} = props.components || ({});',
-      '  if (!c) _missingMdxReference("c", false);',
-      '  if (!c.d) _missingMdxReference("c.d", true);',
-      '  return <><><a:b /><c.d /></></>;',
-      '}',
-      'function MDXContent(props = {}) {',
-      '  const {wrapper: MDXLayout} = props.components || ({});',
-      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
-      '}',
-      'export default MDXContent;',
-      'function _missingMdxReference(id, component) {',
-      '  throw new Error("Expected " + (component ? "component" : "object") + " `" + id + "` to be defined: you likely forgot to import, pass, or provide it.");',
-      '}',
-      ''
-    ].join('\n'),
-    'should serialize fragments, namespaces, members'
-  )
-
-  assert.equal(
-    String(compileSync('<>a {/* 1 */} b</>', {jsx: true})),
-    [
-      '/*@jsxRuntime automatic @jsxImportSource react*/',
-      '/*1*/',
-      'function _createMdxContent(props) {',
-      '  return <><>{"a "}{}{" b"}</></>;',
-      '}',
-      'function MDXContent(props = {}) {',
-      '  const {wrapper: MDXLayout} = props.components || ({});',
-      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
-      '}',
-      'export default MDXContent;',
-      ''
-    ].join('\n'),
-    'should serialize fragments, expressions'
-  )
-
-  assert.equal(
-    String(compileSync('{<a-b></a-b>}', {jsx: true})),
-    [
-      '/*@jsxRuntime automatic @jsxImportSource react*/',
-      'function _createMdxContent(props) {',
-      '  const _components = Object.assign({',
-      '    "a-b": "a-b"',
-      '  }, props.components), _component0 = _components["a-b"];',
-      '  return <>{<_component0></_component0>}</>;',
-      '}',
-      'function MDXContent(props = {}) {',
-      '  const {wrapper: MDXLayout} = props.components || ({});',
-      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
-      '}',
-      'export default MDXContent;',
-      ''
-    ].join('\n'),
-    'should serialize custom elements inside expressions'
-  )
-
-  assert.equal(
-    String(compileSync('Hello {props.name}', {jsx: true})),
-    [
-      '/*@jsxRuntime automatic @jsxImportSource react*/',
-      'function _createMdxContent(props) {',
-      '  const _components = Object.assign({',
-      '    p: "p"',
-      '  }, props.components);',
-      '  return <_components.p>{"Hello "}{props.name}</_components.p>;',
-      '}',
-      'function MDXContent(props = {}) {',
-      '  const {wrapper: MDXLayout} = props.components || ({});',
-      '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
-      '}',
-      'export default MDXContent;',
-      ''
-    ].join('\n'),
-    'should allow using props'
-  )
-
-  assert.equal(
-    String(
-      compileSync(
-        'export default function Layout({components, ...props}) { return <section {...props} /> }\n\na',
-        {jsx: true}
+  await t.test(
+    'should support block quotes (`>` -> `blockquote`)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('> a')))
+        ),
+        '<blockquote>\n<p>a</p>\n</blockquote>'
       )
-    ),
-    [
-      '/*@jsxRuntime automatic @jsxImportSource react*/',
-      'const MDXLayout = function Layout({components, ...props}) {',
-      '  return <section {...props} />;',
-      '};',
-      'function _createMdxContent(props) {',
-      '  const _components = Object.assign({',
-      '    p: "p"',
-      '  }, props.components);',
-      '  return <_components.p>{"a"}</_components.p>;',
-      '}',
-      'function MDXContent(props = {}) {',
-      '  return <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout>;',
-      '}',
-      'export default MDXContent;',
-      ''
-    ].join('\n'),
-    'should not have a conditional expression for MDXLayout when there is an internal layout'
+    }
   )
 
-  assert.match(
-    String(compileSync("{<w x='y \" z' />}", {jsx: true})),
-    /x="y &quot; z"/,
-    'should serialize double quotes in attribute values'
+  await t.test('should support characters (escape) (`\\` -> ``)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('\\*a*')))
+      ),
+      '<p>*a*</p>'
+    )
+  })
+
+  await t.test(
+    'should support character (reference) (`&lt;` -> `<`)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('&lt;')))
+        ),
+        '<p>&lt;</p>'
+      )
+    }
   )
 
-  assert.match(
-    String(compileSync('{<>a &amp; b &#123; c &lt; d</>}', {jsx: true})),
-    /a & b &#123; c &lt; d/,
-    'should serialize `<` and `{` in JSX text'
+  await t.test(
+    'should support code (fenced) (` ``` ` -> `pre code`)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('```\na')))
+        ),
+        '<pre><code>a\n</code></pre>'
+      )
+    }
   )
 
-  assert.match(
-    String(
-      compileSync('', {
-        rehypePlugins: [
-          /** @type {import('unified').Plugin<[], import('hast').Root>} */
-          function () {
-            return function (tree) {
-              tree.children.push({
-                type: 'element',
-                tagName: 'a',
-                properties: {
-                  className: 'b',
-                  style: '-webkit-box-shadow: 0 0 1px 0 red'
-                },
-                children: []
-              })
-            }
-          }
-        ],
-        jsx: true
-      })
-    ),
-    /className="b"/,
-    'should use React props and DOM styles by default'
+  await t.test(
+    'should *not* support code (indented) (`\\ta` -> `p`)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('    a')))
+        ),
+        '<p>a</p>'
+      )
+    }
   )
 
-  assert.match(
-    String(
-      compileSync('', {
-        rehypePlugins: [
-          /** @type {import('unified').Plugin<[], import('hast').Root>} */
-          function () {
-            return function (tree) {
-              tree.children.push({
-                type: 'element',
-                tagName: 'a',
-                properties: {
-                  className: 'b',
-                  style: '-webkit-box-shadow: 0 0 1px 0 red'
-                },
-                children: []
-              })
-            }
-          }
-        ],
-        elementAttributeNameCase: 'html',
-        stylePropertyNameCase: 'css',
-        jsx: true
-      })
-    ),
-    /class="b"/,
-    'should support `elementAttributeNameCase` and `stylePropertyNameCase`'
+  await t.test('should support code (text) (`` `a` `` -> `code`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(React.createElement(await run(compileSync('`a`')))),
+      '<p><code>a</code></p>'
+    )
+  })
+
+  await t.test('should support emphasis (`*` -> `em`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(React.createElement(await run(compileSync('*a*')))),
+      '<p><em>a</em></p>'
+    )
+  })
+
+  await t.test(
+    'should support hard break (escape) (`\\\\\\n` -> `<br>`)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('a\\\nb')))
+        ),
+        '<p>a<br/>\nb</p>'
+      )
+    }
   )
+
+  await t.test(
+    'should support hard break (whitespace) (`\\\\\\n` -> `<br>`)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('a  \nb')))
+        ),
+        '<p>a<br/>\nb</p>'
+      )
+    }
+  )
+
+  await t.test('should support headings (atx) (`#` -> `<h1>`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(React.createElement(await run(compileSync('#')))),
+      '<h1></h1>'
+    )
+  })
+
+  await t.test('should support headings (setext) (`=` -> `<h1>`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(React.createElement(await run(compileSync('a\n=')))),
+      '<h1>a</h1>'
+    )
+  })
+
+  await t.test(
+    'should support list (ordered) (`1.` -> `<ol><li>`)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(React.createElement(await run(compileSync('1.')))),
+        '<ol>\n<li></li>\n</ol>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support list (unordered) (`*` -> `<ul><li>`)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(React.createElement(await run(compileSync('*')))),
+        '<ul>\n<li></li>\n</ul>'
+      )
+    }
+  )
+
+  await t.test('should support strong (`**` -> `strong`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('**a**')))
+      ),
+      '<p><strong>a</strong></p>'
+    )
+  })
+
+  await t.test('should support thematic break (`***` -> `<hr>`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(React.createElement(await run(compileSync('***')))),
+      '<hr/>'
+    )
+  })
 })
 
-test('markdown (CM)', async () => {
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('[a](b)')))),
-    '<p><a href="b">a</a></p>',
-    'should support links (resource) (`[]()` -> `a`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('[a]: b\n[a]')))
-    ),
-    '<p><a href="b">a</a></p>',
-    'should support links (reference) (`[][]` -> `a`)'
-  )
-
-  assert.throws(
-    () => {
-      compileSync('<http://a>')
-    },
-    /note: to create a link in MDX, use `\[text]\(url\)/,
-    'should *not* support links (autolink) (`<http://a>` -> error)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('> a')))),
-    '<blockquote>\n<p>a</p>\n</blockquote>',
-    'should support block quotes (`>` -> `blockquote`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('\\*a*')))),
-    '<p>*a*</p>',
-    'should support characters (escape) (`\\` -> ``)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('&lt;')))),
-    '<p>&lt;</p>',
-    'should support character (reference) (`&lt;` -> `<`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('```\na')))),
-    '<pre><code>a\n</code></pre>',
-    'should support code (fenced) (` ``` ` -> `pre code`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('    a')))),
-    '<p>a</p>',
-    'should *not* support code (indented) (`\\ta` -> `p`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('`a`')))),
-    '<p><code>a</code></p>',
-    'should support code (text) (`` `a` `` -> `code`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('*a*')))),
-    '<p><em>a</em></p>',
-    'should support emphasis (`*` -> `em`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('a\\\nb')))),
-    '<p>a<br/>\nb</p>',
-    'should support hard break (escape) (`\\\\\\n` -> `<br>`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('a  \nb')))),
-    '<p>a<br/>\nb</p>',
-    'should support hard break (whitespace) (`\\\\\\n` -> `<br>`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('#')))),
-    '<h1></h1>',
-    'should support headings (atx) (`#` -> `<h1>`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('a\n=')))),
-    '<h1>a</h1>',
-    'should support headings (setext) (`=` -> `<h1>`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('1.')))),
-    '<ol>\n<li></li>\n</ol>',
-    'should support list (ordered) (`1.` -> `<ol><li>`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('*')))),
-    '<ul>\n<li></li>\n</ul>',
-    'should support list (unordered) (`*` -> `<ul><li>`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('**a**')))),
-    '<p><strong>a</strong></p>',
-    'should support strong (`**` -> `strong`)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('***')))),
-    '<hr/>',
-    'should support thematic break (`***` -> `<hr>`)'
-  )
-})
-
-test('markdown (GFM, with `remark-gfm`)', async () => {
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('http://a', {remarkPlugins: [remarkGfm]}))
+test('markdown (GFM, with `remark-gfm`)', async (t) => {
+  await t.test(
+    'should support links (autolink literal) (`http://a` -> `a`)',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(compileSync('http://a', {remarkPlugins: [remarkGfm]}))
+          )
+        ),
+        '<p><a href="http://a">http://a</a></p>'
       )
-    ),
-    '<p><a href="http://a">http://a</a></p>',
-    'should support links (autolink literal) (`http://a` -> `a`)'
+    }
   )
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('[^a]\n[^a]: b', {remarkPlugins: [remarkGfm]}))
-      )
-    ),
-    `<p><sup><a href="#user-content-fn-a" id="user-content-fnref-a" data-footnote-ref="true" aria-describedby="footnote-label">1</a></sup></p>
+  await t.test('should support footnotes (`[^a]` -> `<sup><a…>`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(compileSync('[^a]\n[^a]: b', {remarkPlugins: [remarkGfm]}))
+        )
+      ),
+      `<p><sup><a href="#user-content-fn-a" id="user-content-fnref-a" data-footnote-ref="true" aria-describedby="footnote-label">1</a></sup></p>
 <section data-footnotes="true" class="footnotes"><h2 class="sr-only" id="footnote-label">Footnotes</h2>
 <ol>
 <li id="user-content-fn-a">
 <p>b <a href="#user-content-fnref-a" data-footnote-backref="true" class="data-footnote-backref" aria-label="Back to content">↩</a></p>
 </li>
 </ol>
-</section>`,
-    'should support footnotes (`[^a]` -> `<sup><a…>`)'
-  )
+</section>`
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('| a |\n| - |', {remarkPlugins: [remarkGfm]}))
-      )
-    ),
-    '<table><thead><tr><th>a</th></tr></thead></table>',
-    'should support tables (`| a |` -> `<table>...`)'
-  )
+  await t.test('should support tables (`| a |` -> `<table>...`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(compileSync('| a |\n| - |', {remarkPlugins: [remarkGfm]}))
+        )
+      ),
+      '<table><thead><tr><th>a</th></tr></thead></table>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('* [x] a\n* [ ] b', {remarkPlugins: [remarkGfm]}))
-      )
-    ),
-    '<ul class="contains-task-list">\n<li class="task-list-item"><input type="checkbox" disabled="" checked=""/> a</li>\n<li class="task-list-item"><input type="checkbox" disabled=""/> b</li>\n</ul>',
-    'should support task lists (`* [x]` -> `input`)'
-  )
+  await t.test('should support task lists (`* [x]` -> `input`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(
+            compileSync('* [x] a\n* [ ] b', {remarkPlugins: [remarkGfm]})
+          )
+        )
+      ),
+      '<ul class="contains-task-list">\n<li class="task-list-item"><input type="checkbox" disabled="" checked=""/> a</li>\n<li class="task-list-item"><input type="checkbox" disabled=""/> b</li>\n</ul>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('~a~', {remarkPlugins: [remarkGfm]}))
-      )
-    ),
-    '<p><del>a</del></p>',
-    'should support strikethrough (`~` -> `del`)'
-  )
+  await t.test('should support strikethrough (`~` -> `del`)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(compileSync('~a~', {remarkPlugins: [remarkGfm]}))
+        )
+      ),
+      '<p><del>a</del></p>'
+    )
+  })
 })
 
-test('markdown (frontmatter, `remark-frontmatter`)', async () => {
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('---\na: b\n---\nc', {remarkPlugins: [remarkFrontmatter]})
+test('markdown (frontmatter, `remark-frontmatter`)', async (t) => {
+  await t.test('should support frontmatter (YAML)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(
+            compileSync('---\na: b\n---\nc', {
+              remarkPlugins: [remarkFrontmatter]
+            })
+          )
         )
-      )
-    ),
-    '<p>c</p>',
-    'should support frontmatter (YAML)'
-  )
+      ),
+      '<p>c</p>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('+++\na: b\n+++\nc', {
-            remarkPlugins: [[remarkFrontmatter, 'toml']]
-          })
+  await t.test('should support frontmatter (TOML)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(
+            compileSync('+++\na: b\n+++\nc', {
+              remarkPlugins: [[remarkFrontmatter, 'toml']]
+            })
+          )
         )
-      )
-    ),
-    '<p>c</p>',
-    'should support frontmatter (TOML)'
-  )
+      ),
+      '<p>c</p>'
+    )
+  })
 })
 
 test('markdown (math, `remark-math`, `rehype-katex`)', async () => {
@@ -1233,156 +1471,195 @@ test('should support custom elements with layouts', async () => {
   )
 })
 
-test('MDX (JSX)', async () => {
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('a <s>b</s>')))
-    ),
-    '<p>a <s>b</s></p>',
-    'should support JSX (text)'
-  )
+test('MDX (JSX)', async (t) => {
+  await t.test('should support JSX (text)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('a <s>b</s>')))
+      ),
+      '<p>a <s>b</s></p>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('<div>\n  b\n</div>')))
-    ),
-    '<div><p>b</p></div>',
-    'should support JSX (flow)'
-  )
+  await t.test('should support JSX (flow)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('<div>\n  b\n</div>')))
+      ),
+      '<div><p>b</p></div>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('<h1>b</h1>')))
-    ),
-    '<h1>b</h1>',
-    'should unravel JSX (text) as an only child'
-  )
+  await t.test('should unravel JSX (text) as an only child', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('<h1>b</h1>')))
+      ),
+      '<h1>b</h1>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('<a>b</a><b>c</b>')))
-    ),
-    '<a>b</a>\n<b>c</b>',
-    'should unravel JSX (text) as only children'
-  )
+  await t.test('should unravel JSX (text) as only children', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('<a>b</a><b>c</b>')))
+      ),
+      '<a>b</a>\n<b>c</b>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('<a>b</a>\t<b>c</b>')))
-    ),
-    '<a>b</a>\n<b>c</b>',
-    'should unravel JSX (text) and whitespace as only children'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('{1}')))),
-    '1',
-    'should unravel expression (text) as an only child'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(React.createElement(await run(compileSync('{1}{2}')))),
-    '1\n2',
-    'should unravel expression (text) as only children'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('{1}\n{2}')))
-    ),
-    '1\n2',
-    'should unravel expression (text) and whitespace as only children'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('a <>b</>')))
-    ),
-    '<p>a b</p>',
-    'should support JSX (text, fragment)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('<>\n  b\n</>')))
-    ),
-    '<p>b</p>',
-    'should support JSX (flow, fragment)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('a <x:y>b</x:y>')))
-    ),
-    '<p>a <x:y>b</x:y></p>',
-    'should support JSX (namespace)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('export const a = 1\n\na {a}')))
-    ),
-    '<p>a 1</p>',
-    'should support expressions in MDX (text)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('{\n  1 + 1\n}')))
-    ),
-    '2',
-    'should support expressions in MDX (flow)'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('{/*!*/}')))
-    ),
-    '',
-    'should support empty expressions in MDX'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('<x a="1" b:c="1" hidden />')))
-    ),
-    '<x a="1" b:c="1" hidden=""></x>',
-    'should support JSX attribute names'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('<x y="1" z=\'w\' style={{color: "red"}} />'))
+  await t.test(
+    'should unravel JSX (text) and whitespace as only children',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('<a>b</a>\t<b>c</b>')))
+        ),
+        '<a>b</a>\n<b>c</b>'
       )
-    ),
-    '<x y="1" z="w" style="color:red"></x>',
-    'should support JSX attribute values'
+    }
   )
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(await run(compileSync('<x {...{a: 1}} />')))
-    ),
-    '<x a="1"></x>',
-    'should support JSX spread attributes'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('{<i>the sum of one and one is: {1 + 1}</i>}'))
+  await t.test(
+    'should unravel expression (text) as an only child',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('{1}')))
+        ),
+        '1'
       )
-    ),
-    '<i>the sum of one and one is: 2</i>',
-    'should support JSX in expressions'
+    }
   )
 
-  // Important: there should not be whitespace in the `tr`.
-  // This is normally not present, but unraveling makes this a bit more complex.
-  // See: <https://github.com/mdx-js/mdx/issues/2000>.
-  assert.equal(
-    compileSync(`<table>
+  await t.test(
+    'should unravel expression (text) as only children',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('{1}{2}')))
+        ),
+        '1\n2'
+      )
+    }
+  )
+
+  await t.test(
+    'should unravel expression (text) and whitespace as only children',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(await run(compileSync('{1}\n{2}')))
+        ),
+        '1\n2'
+      )
+    }
+  )
+
+  await t.test('should support JSX (text, fragment)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('a <>b</>')))
+      ),
+      '<p>a b</p>'
+    )
+  })
+
+  await t.test('should support JSX (flow, fragment)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('<>\n  b\n</>')))
+      ),
+      '<p>b</p>'
+    )
+  })
+
+  await t.test('should support JSX (namespace)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('a <x:y>b</x:y>')))
+      ),
+      '<p>a <x:y>b</x:y></p>'
+    )
+  })
+
+  await t.test('should support expressions in MDX (text)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(compileSync('export const a = 1\n\na {a}'))
+        )
+      ),
+      '<p>a 1</p>'
+    )
+  })
+
+  await t.test('should support expressions in MDX (flow)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('{\n  1 + 1\n}')))
+      ),
+      '2'
+    )
+  })
+
+  await t.test('should support empty expressions in MDX', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('{/*!*/}')))
+      ),
+      ''
+    )
+  })
+
+  await t.test('should support JSX attribute names', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(compileSync('<x a="1" b:c="1" hidden />'))
+        )
+      ),
+      '<x a="1" b:c="1" hidden=""></x>'
+    )
+  })
+
+  await t.test('should support JSX attribute values', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(compileSync('<x y="1" z=\'w\' style={{color: "red"}} />'))
+        )
+      ),
+      '<x y="1" z="w" style="color:red"></x>'
+    )
+  })
+
+  await t.test('should support JSX spread attributes', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(await run(compileSync('<x {...{a: 1}} />')))
+      ),
+      '<x a="1"></x>'
+    )
+  })
+
+  await t.test('should support JSX in expressions', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(compileSync('{<i>the sum of one and one is: {1 + 1}</i>}'))
+        )
+      ),
+      '<i>the sum of one and one is: 2</i>'
+    )
+  })
+
+  await t.test('should support JSX in expressions', () => {
+    // Important: there should not be whitespace in the `tr`.
+    // This is normally not present, but unraveling makes this a bit more complex.
+    // See: <https://github.com/mdx-js/mdx/issues/2000>.
+    assert.equal(
+      compileSync(`<table>
   <thead>
     <tr>
       <th>a</th>
@@ -1390,224 +1667,273 @@ test('MDX (JSX)', async () => {
     </tr>
   </thead>
 </table>`).value,
-    [
-      '/*@jsxRuntime automatic @jsxImportSource react*/',
-      'import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";',
-      'function _createMdxContent(props) {',
-      '  return _jsx("table", {',
-      '    children: _jsx("thead", {',
-      '      children: _jsxs("tr", {',
-      '        children: [_jsx("th", {',
-      '          children: "a"',
-      '        }), _jsx("th", {',
-      '          children: "b"',
-      '        })]',
-      '      })',
-      '    })',
-      '  });',
-      '}',
-      'function MDXContent(props = {}) {',
-      '  const {wrapper: MDXLayout} = props.components || ({});',
-      '  return MDXLayout ? _jsx(MDXLayout, Object.assign({}, props, {',
-      '    children: _jsx(_createMdxContent, props)',
-      '  })) : _createMdxContent(props);',
-      '}',
-      'export default MDXContent;',
-      ''
-    ].join('\n'),
-    'should support JSX in expressions'
-  )
+      [
+        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        'import {jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";',
+        'function _createMdxContent(props) {',
+        '  return _jsx("table", {',
+        '    children: _jsx("thead", {',
+        '      children: _jsxs("tr", {',
+        '        children: [_jsx("th", {',
+        '          children: "a"',
+        '        }), _jsx("th", {',
+        '          children: "b"',
+        '        })]',
+        '      })',
+        '    })',
+        '  });',
+        '}',
+        'function MDXContent(props = {}) {',
+        '  const {wrapper: MDXLayout} = props.components || ({});',
+        '  return MDXLayout ? _jsx(MDXLayout, Object.assign({}, props, {',
+        '    children: _jsx(_createMdxContent, props)',
+        '  })) : _createMdxContent(props);',
+        '}',
+        'export default MDXContent;',
+        ''
+      ].join('\n')
+    )
+  })
 })
 
-test('MDX (ESM)', async () => {
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('import {Pill} from "./components.js"\n\n<Pill>!</Pill>')
-        )
-      )
-    ),
-    '<span style="color:red">!</span>',
-    'should support importing components w/ ESM'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('import {number} from "./data.js"\n\n{number}'))
-      )
-    ),
-    '3.14',
-    'should support importing data w/ ESM'
-  )
-
-  assert.equal(
-    (await runWhole(compileSync('export const number = Math.PI'))).number,
-    Math.PI,
-    'should support exporting w/ ESM'
-  )
-
-  assert.ok(
-    'a' in (await runWhole(compileSync('export var a'))),
-    'should support exporting an identifier w/o a value'
-  )
-
-  assert.equal(
-    (
-      await runWhole(
-        compileSync('import {object} from "./data.js"\nexport var {a} = object')
-      )
-    ).a,
-    1,
-    'should support exporting an object pattern'
-  )
-
-  assert.deepEqual(
-    (
-      await runWhole(
-        compileSync(
-          'import {object} from "./data.js"\nexport var {a, ...rest} = object'
-        )
-      )
-    ).rest,
-    {b: 2},
-    'should support exporting a rest element in an object pattern'
-  )
-
-  assert.equal(
-    (
-      await runWhole(
-        compileSync(
-          'import {object} from "./data.js"\nexport var {c = 3} = object'
-        )
-      )
-    ).c,
-    3,
-    'should support exporting an assignment pattern in an object pattern'
-  )
-
-  assert.equal(
-    (
-      await runWhole(
-        compileSync('import {array} from "./data.js"\nexport var [a] = array')
-      )
-    ).a,
-    1,
-    'should support exporting an array pattern'
-  )
-
-  assert.equal(
-    (
-      await runWhole(
-        compileSync('export const number = Math.PI\nexport {number as pi}')
-      )
-    ).pi,
-    Math.PI,
-    'should support `export as` w/ ESM'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync(
-            'export default function Layout(props) { return <div {...props} /> }\n\na'
+test('MDX (ESM)', async (t) => {
+  await t.test('should support importing components w/ ESM', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(
+            compileSync(
+              'import {Pill} from "./components.js"\n\n<Pill>!</Pill>'
+            )
           )
         )
-      )
-    ),
-    '<div><p>a</p></div>',
-    'should support default export to define a layout'
-  )
+      ),
+      '<span style="color:red">!</span>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('export {Layout as default} from "./components.js"\n\na')
+  await t.test('should support importing data w/ ESM', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(compileSync('import {number} from "./data.js"\n\n{number}'))
         )
-      )
-    ),
-    '<div style="color:red"><p>a</p></div>',
-    'should support default export from a source'
+      ),
+      '3.14'
+    )
+  })
+
+  await t.test('should support exporting w/ ESM', async () => {
+    assert.equal(
+      (await runWhole(compileSync('export const number = Math.PI'))).number,
+      Math.PI
+    )
+  })
+
+  await t.test(
+    'should support exporting an identifier w/o a value',
+    async () => {
+      assert.ok('a' in (await runWhole(compileSync('export var a'))))
+    }
   )
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('export {default} from "./components.js"\n\na'))
-      )
-    ),
-    '<div style="color:red"><p>a</p></div>',
-    'should support rexporting something as a default export from a source'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('export {default} from "./components.js"\n\na'))
-      )
-    ),
-    '<div style="color:red"><p>a</p></div>',
-    'should support rexporting the default export from a source'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(compileSync('export {default} from "./components.js"\n\na'))
-      )
-    ),
-    '<div style="color:red"><p>a</p></div>',
-    'should support rexporting the default export from a source'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        await run(
-          compileSync('export {default, Pill} from "./components.js"\n\na')
+  await t.test('should support exporting an object pattern', async () => {
+    assert.equal(
+      (
+        await runWhole(
+          compileSync(
+            'import {object} from "./data.js"\nexport var {a} = object'
+          )
         )
+      ).a,
+      1
+    )
+  })
+
+  await t.test(
+    'should support exporting a rest element in an object pattern',
+    async () => {
+      assert.deepEqual(
+        (
+          await runWhole(
+            compileSync(
+              'import {object} from "./data.js"\nexport var {a, ...rest} = object'
+            )
+          )
+        ).rest,
+        {b: 2}
       )
-    ),
-    '<div style="color:red"><p>a</p></div>',
-    'should support rexporting the default export, and other things, from a source'
+    }
   )
 
-  assert.equal(
-    compileSync({value: '<X />', path: 'path/to/file.js'}, {development: true})
-      .value,
-    [
-      '/*@jsxRuntime automatic @jsxImportSource react*/',
-      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
-      'function _createMdxContent(props) {',
-      '  const {X} = props.components || ({});',
-      '  if (!X) _missingMdxReference("X", true, "1:1-1:6");',
-      '  return _jsxDEV(X, {}, undefined, false, {',
-      '    fileName: "path/to/file.js",',
-      '    lineNumber: 1,',
-      '    columnNumber: 1',
-      '  }, this);',
-      '}',
-      'function MDXContent(props = {}) {',
-      '  const {wrapper: MDXLayout} = props.components || ({});',
-      '  return MDXLayout ? _jsxDEV(MDXLayout, Object.assign({}, props, {',
-      '    children: _jsxDEV(_createMdxContent, props, undefined, false, {',
-      '      fileName: "path/to/file.js"',
-      '    }, this)',
-      '  }), undefined, false, {',
-      '    fileName: "path/to/file.js"',
-      '  }, this) : _createMdxContent(props);',
-      '}',
-      'export default MDXContent;',
-      'function _missingMdxReference(id, component, place) {',
-      '  throw new Error("Expected " + (component ? "component" : "object") + " `" + id + "` to be defined: you likely forgot to import, pass, or provide it." + (place ? "\\nIt’s referenced in your code at `" + place + "` in `path/to/file.js`" : ""));',
-      '}',
-      ''
-    ].join('\n'),
-    'should support the jsx dev runtime'
+  await t.test(
+    'should support exporting an assignment pattern in an object pattern',
+    async () => {
+      assert.equal(
+        (
+          await runWhole(
+            compileSync(
+              'import {object} from "./data.js"\nexport var {c = 3} = object'
+            )
+          )
+        ).c,
+        3
+      )
+    }
   )
+
+  await t.test('should support exporting an array pattern', async () => {
+    assert.equal(
+      (
+        await runWhole(
+          compileSync('import {array} from "./data.js"\nexport var [a] = array')
+        )
+      ).a,
+      1
+    )
+  })
+
+  await t.test('should support `export as` w/ ESM', async () => {
+    assert.equal(
+      (
+        await runWhole(
+          compileSync('export const number = Math.PI\nexport {number as pi}')
+        )
+      ).pi,
+      Math.PI
+    )
+  })
+
+  await t.test('should support default export to define a layout', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(
+            compileSync(
+              'export default function Layout(props) { return <div {...props} /> }\n\na'
+            )
+          )
+        )
+      ),
+      '<div><p>a</p></div>'
+    )
+  })
+
+  await t.test('should support default export from a source', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          await run(
+            compileSync(
+              'export {Layout as default} from "./components.js"\n\na'
+            )
+          )
+        )
+      ),
+      '<div style="color:red"><p>a</p></div>'
+    )
+  })
+
+  await t.test(
+    'should support rexporting something as a default export from a source',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync('export {default} from "./components.js"\n\na')
+            )
+          )
+        ),
+        '<div style="color:red"><p>a</p></div>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support rexporting the default export from a source',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync('export {default} from "./components.js"\n\na')
+            )
+          )
+        ),
+        '<div style="color:red"><p>a</p></div>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support rexporting the default export from a source',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync('export {default} from "./components.js"\n\na')
+            )
+          )
+        ),
+        '<div style="color:red"><p>a</p></div>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support rexporting the default export, and other things, from a source',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            await run(
+              compileSync('export {default, Pill} from "./components.js"\n\na')
+            )
+          )
+        ),
+        '<div style="color:red"><p>a</p></div>'
+      )
+    }
+  )
+
+  await t.test('should support the jsx dev runtime', async () => {
+    assert.equal(
+      compileSync(
+        {value: '<X />', path: 'path/to/file.js'},
+        {development: true}
+      ).value,
+      [
+        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+        'function _createMdxContent(props) {',
+        '  const {X} = props.components || ({});',
+        '  if (!X) _missingMdxReference("X", true, "1:1-1:6");',
+        '  return _jsxDEV(X, {}, undefined, false, {',
+        '    fileName: "path/to/file.js",',
+        '    lineNumber: 1,',
+        '    columnNumber: 1',
+        '  }, this);',
+        '}',
+        'function MDXContent(props = {}) {',
+        '  const {wrapper: MDXLayout} = props.components || ({});',
+        '  return MDXLayout ? _jsxDEV(MDXLayout, Object.assign({}, props, {',
+        '    children: _jsxDEV(_createMdxContent, props, undefined, false, {',
+        '      fileName: "path/to/file.js"',
+        '    }, this)',
+        '  }), undefined, false, {',
+        '    fileName: "path/to/file.js"',
+        '  }, this) : _createMdxContent(props);',
+        '}',
+        'export default MDXContent;',
+        'function _missingMdxReference(id, component, place) {',
+        '  throw new Error("Expected " + (component ? "component" : "object") + " `" + id + "` to be defined: you likely forgot to import, pass, or provide it." + (place ? "\\nIt’s referenced in your code at `" + place + "` in `path/to/file.js`" : ""));',
+        '}',
+        ''
+      ].join('\n')
+    )
+  })
 })
 
 test('source maps', async () => {

--- a/packages/mdx/test/evaluate.js
+++ b/packages/mdx/test/evaluate.js
@@ -20,371 +20,409 @@ const runtime = runtime_
 /** @type {import('react')} */
 const React = React_
 
-test('evaluate', async () => {
-  assert.throws(
-    () => {
+test('evaluate', async (t) => {
+  await t.test('should throw on missing `Fragment`', async () => {
+    assert.throws(() => {
       // @ts-expect-error: missing required arguments
       evaluateSync('a')
-    },
-    /Expected `Fragment` given to `evaluate`/,
-    'should throw on missing `Fragment`'
-  )
+    }, /Expected `Fragment` given to `evaluate`/)
+  })
 
-  assert.throws(
-    () => {
+  await t.test('should throw on missing `jsx`', async () => {
+    assert.throws(() => {
       evaluateSync('a', {Fragment: runtime.Fragment})
-    },
-    /Expected `jsx` given to `evaluate`/,
-    'should throw on missing `jsx`'
-  )
+    }, /Expected `jsx` given to `evaluate`/)
+  })
 
-  assert.throws(
-    () => {
+  await t.test('should throw on missing `jsxs`', async () => {
+    assert.throws(() => {
       evaluateSync('a', {Fragment: runtime.Fragment, jsx: runtime.jsx})
-    },
-    /Expected `jsxs` given to `evaluate`/,
-    'should throw on missing `jsxs`'
-  )
+    }, /Expected `jsxs` given to `evaluate`/)
+  })
 
-  assert.throws(
-    () => {
+  await t.test('should throw on missing `jsxDEV` in dev mode', async () => {
+    assert.throws(() => {
       evaluateSync('a', {Fragment: runtime.Fragment, development: true})
-    },
-    /Expected `jsxDEV` given to `evaluate`/,
-    'should throw on missing `jsxDEV` in dev mode'
-  )
+    }, /Expected `jsxDEV` given to `evaluate`/)
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement((await evaluate('# hi!', runtime)).default)
-    ),
-    '<h1>hi!</h1>',
-    'should evaluate'
-  )
+  await t.test('should evaluate', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement((await evaluate('# hi!', runtime)).default)
+      ),
+      '<h1>hi!</h1>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(evaluateSync('# hi!', runtime).default)
-    ),
-    '<h1>hi!</h1>',
-    'should evaluate (sync)'
-  )
+  await t.test('should evaluate (sync)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(evaluateSync('# hi!', runtime).default)
+      ),
+      '<h1>hi!</h1>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        (await evaluate('# hi dev!', {development: true, ...devRuntime}))
-          .default
-      )
-    ),
-    '<h1>hi dev!</h1>',
-    'should evaluate (sync)'
-  )
+  await t.test('should evaluate (sync)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          (await evaluate('# hi dev!', {development: true, ...devRuntime}))
+            .default
+        )
+      ),
+      '<h1>hi dev!</h1>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        evaluateSync('# hi dev!', {development: true, ...devRuntime}).default
-      )
-    ),
-    '<h1>hi dev!</h1>',
-    'should evaluate (sync)'
-  )
+  await t.test('should evaluate (sync)', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          evaluateSync('# hi dev!', {development: true, ...devRuntime}).default
+        )
+      ),
+      '<h1>hi dev!</h1>'
+    )
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        (
-          await evaluate(
-            'import {number} from "./context/data.js"\n\n{number}',
-            {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+  await t.test(
+    'should support an `import` of a relative url w/ `useDynamicImport`',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            (
+              await evaluate(
+                'import {number} from "./context/data.js"\n\n{number}',
+                {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+              )
+            ).default
           )
-        ).default
+        ),
+        '3.14'
       )
-    ),
-    '3.14',
-    'should support an `import` of a relative url w/ `useDynamicImport`'
+    }
   )
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        (
-          await evaluate(
-            'import {number} from "' +
-              new URL('context/data.js', import.meta.url) +
-              '"\n\n{number}',
-            {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+  await t.test(
+    'should support an `import` of a full url w/ `useDynamicImport`',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            (
+              await evaluate(
+                'import {number} from "' +
+                  new URL('context/data.js', import.meta.url) +
+                  '"\n\n{number}',
+                {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+              )
+            ).default
           )
-        ).default
+        ),
+        '3.14'
       )
-    ),
-    '3.14',
-    'should support an `import` of a full url w/ `useDynamicImport`'
+    }
   )
 
-  assert.match(
-    String(
-      await compile('import "a"', {
-        outputFormat: 'function-body',
-        useDynamicImport: true
-      })
-    ),
-    /\nawait import\("a"\);?\n/,
-    'should support an `import` w/o specifiers w/ `useDynamicImport`'
+  await t.test(
+    'should support an `import` w/o specifiers w/ `useDynamicImport`',
+    async () => {
+      assert.match(
+        String(
+          await compile('import "a"', {
+            outputFormat: 'function-body',
+            useDynamicImport: true
+          })
+        ),
+        /\nawait import\("a"\);?\n/
+      )
+    }
   )
 
-  assert.match(
-    String(
-      await compile('import {} from "a"', {
-        outputFormat: 'function-body',
-        useDynamicImport: true
-      })
-    ),
-    /\nawait import\("a"\);?\n/,
-    'should support an `import` w/ 0 specifiers w/ `useDynamicImport`'
+  await t.test(
+    'should support an `import` w/ 0 specifiers w/ `useDynamicImport`',
+    async () => {
+      assert.match(
+        String(
+          await compile('import {} from "a"', {
+            outputFormat: 'function-body',
+            useDynamicImport: true
+          })
+        ),
+        /\nawait import\("a"\);?\n/
+      )
+    }
   )
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        (
-          await evaluate(
-            'import * as x from "./context/components.js"\n\n<x.Pill>Hi!</x.Pill>',
-            {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+  await t.test(
+    'should support a namespace import w/ `useDynamicImport`',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            (
+              await evaluate(
+                'import * as x from "./context/components.js"\n\n<x.Pill>Hi!</x.Pill>',
+                {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+              )
+            ).default
           )
-        ).default
+        ),
+        '<span style="color:red">Hi!</span>'
       )
-    ),
-    '<span style="color:red">Hi!</span>',
-    'should support a namespace import w/ `useDynamicImport`'
+    }
   )
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        (
-          await evaluate(
-            'import Div, * as x from "./context/components.js"\n\n<x.Pill>a</x.Pill> and <Div>b</Div>',
-            {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+  await t.test(
+    'should support a namespace import and a bare specifier w/ `useDynamicImport`',
+    async () => {
+      assert.equal(
+        renderToStaticMarkup(
+          React.createElement(
+            (
+              await evaluate(
+                'import Div, * as x from "./context/components.js"\n\n<x.Pill>a</x.Pill> and <Div>b</Div>',
+                {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+              )
+            ).default
           )
-        ).default
+        ),
+        '<p><span style="color:red">a</span> and <div style="color:red">b</div></p>'
       )
-    ),
-    '<p><span style="color:red">a</span> and <div style="color:red">b</div></p>',
-    'should support a namespace import and a bare specifier w/ `useDynamicImport`'
+    }
   )
 
-  let mod = await evaluate('export const a = 1\n\n{a}', runtime)
+  await t.test('should support an `export`', async () => {
+    const mod = await evaluate('export const a = 1\n\n{a}', runtime)
 
-  assert.equal(
-    renderToStaticMarkup(React.createElement(mod.default)),
-    '1',
-    'should support an `export` (1)'
-  )
+    assert.equal(renderToStaticMarkup(React.createElement(mod.default)), '1')
 
-  assert.equal(mod.a, 1, 'should support an `export` (2)')
+    assert.equal(mod.a, 1)
+  })
 
-  mod = await evaluate('export function a() { return 1 }\n\n{a()}', runtime)
+  await t.test('should support an `export function`', async () => {
+    const mod = await evaluate(
+      'export function a() { return 1 }\n\n{a()}',
+      runtime
+    )
 
-  assert.equal(
-    renderToStaticMarkup(React.createElement(mod.default)),
-    '1',
-    'should support an `export function` (1)'
-  )
+    assert.equal(renderToStaticMarkup(React.createElement(mod.default)), '1')
 
-  if (typeof mod.a !== 'function') throw new TypeError('missing function')
+    assert.ok(typeof mod.a === 'function')
 
-  assert.equal(mod.a(), 1, 'should support an `export function` (2)')
+    assert.equal(mod.a(), 1)
+  })
 
-  mod = await evaluate(
-    'export class A { constructor() { this.b = 1 } }\n\n{new A().b}',
-    runtime
-  )
+  await t.test('should support an `export class`', async () => {
+    const mod = await evaluate(
+      'export class A { constructor() { this.b = 1 } }\n\n{new A().b}',
+      runtime
+    )
 
-  assert.equal(
-    renderToStaticMarkup(React.createElement(mod.default)),
-    '1',
-    'should support an `export class` (1)'
-  )
+    assert.equal(renderToStaticMarkup(React.createElement(mod.default)), '1')
 
-  const A = /** @type {new () => {b: number}} */ (mod.A)
-  const a = new A()
-  assert.equal(a.b, 1, 'should support an `export class` (2)')
+    const A = /** @type {new () => {b: number}} */ (mod.A)
+    const a = new A()
+    assert.equal(a.b, 1)
+  })
 
-  mod = await evaluate('export const a = 1\nexport {a as b}\n\n{a}', runtime)
+  await t.test('should support an `export as`', async () => {
+    const mod = await evaluate(
+      'export const a = 1\nexport {a as b}\n\n{a}',
+      runtime
+    )
 
-  assert.equal(
-    renderToStaticMarkup(React.createElement(mod.default)),
-    '1',
-    'should support an `export as` (1)'
-  )
+    assert.equal(renderToStaticMarkup(React.createElement(mod.default)), '1')
 
-  assert.equal(mod.a, 1, 'should support an `export as` (2)')
-  assert.equal(mod.b, 1, 'should support an `export as` (3)')
+    assert.equal(mod.a, 1, 'should support an `export as` (2)')
+    assert.equal(mod.b, 1, 'should support an `export as` (3)')
+  })
 
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        (
-          await evaluate(
-            'export default function Layout({components, ...props}) { return <section {...props} /> }\n\na',
-            runtime
-          )
-        ).default
-      )
-    ),
-    '<section><p>a</p></section>',
-    'should support an `export default`'
-  )
+  await t.test('should support an `export default`', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement(
+          (
+            await evaluate(
+              'export default function Layout({components, ...props}) { return <section {...props} /> }\n\na',
+              runtime
+            )
+          ).default
+        )
+      ),
+      '<section><p>a</p></section>'
+    )
+  })
 
-  assert.throws(
-    () => {
+  await t.test('should throw on an export from', () => {
+    assert.throws(() => {
       evaluateSync('export {a} from "b"', runtime)
-    },
-    /Cannot use `import` or `export … from` in `evaluate` \(outputting a function body\) by default/,
-    'should throw on an export from'
-  )
+    }, /Cannot use `import` or `export … from` in `evaluate` \(outputting a function body\) by default/)
+  })
 
-  assert.equal(
-    (
-      await evaluate('export {number} from "./context/data.js"', {
-        baseUrl: import.meta.url,
-        useDynamicImport: true,
-        ...runtime
-      })
-    ).number,
-    3.14,
-    'should support an `export from` w/ `useDynamicImport`'
-  )
-
-  assert.equal(
-    (
-      await evaluate(
-        'import {number} from "./context/data.js"\nexport {number}',
-        {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+  await t.test(
+    'should support an `export from` w/ `useDynamicImport`',
+    async () => {
+      assert.equal(
+        (
+          await evaluate('export {number} from "./context/data.js"', {
+            baseUrl: import.meta.url,
+            useDynamicImport: true,
+            ...runtime
+          })
+        ).number,
+        3.14
       )
-    ).number,
-    3.14,
-    'should support an `export` w/ `useDynamicImport`'
+    }
   )
 
-  assert.equal(
-    (
-      await evaluate('export {number as data} from "./context/data.js"', {
-        baseUrl: import.meta.url,
-        useDynamicImport: true,
-        ...runtime
-      })
-    ).data,
-    3.14,
-    'should support an `export as from` w/ `useDynamicImport`'
-  )
+  await t.test('should support an `export` w/ `useDynamicImport`', async () => {
+    assert.equal(
+      (
+        await evaluate(
+          'import {number} from "./context/data.js"\nexport {number}',
+          {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+        )
+      ).number,
+      3.14
+    )
+  })
 
-  assert.equal(
-    (
-      await evaluate('export {default as data} from "./context/data.js"', {
-        baseUrl: import.meta.url,
-        useDynamicImport: true,
-        ...runtime
-      })
-    ).data,
-    6.28,
-    'should support an `export default as from` w/ `useDynamicImport`'
-  )
-
-  assert.deepEqual(
-    {
-      ...(await evaluate('export * from "./context/data.js"', {
-        baseUrl: import.meta.url,
-        useDynamicImport: true,
-        ...runtime
-      })),
-      default: undefined
-    },
-    {array: [1, 2], default: undefined, number: 3.14, object: {a: 1, b: 2}},
-    'should support an `export all from` w/ `useDynamicImport`'
-  )
-
-  // I’m not sure if this makes sense, but it is how Node works.
-  assert.deepEqual(
-    {
-      ...(await evaluate(
-        'export {default as number} from "./context/data.js"\nexport * from "./context/data.js"',
-        {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
-      )),
-      default: undefined
-    },
-    {array: [1, 2], default: undefined, number: 6.28, object: {a: 1, b: 2}},
-    'should support an `export all from`, but prefer explicit exports, w/ `useDynamicImport`'
-  )
-
-  assert.equal(
-    (
-      await evaluate(
-        'export const x = new URL("example.png", import.meta.url).href',
-        {baseUrl: 'https://example.com', ...runtime}
+  await t.test(
+    'should support an `export as from` w/ `useDynamicImport`',
+    async () => {
+      assert.equal(
+        (
+          await evaluate('export {number as data} from "./context/data.js"', {
+            baseUrl: import.meta.url,
+            useDynamicImport: true,
+            ...runtime
+          })
+        ).data,
+        3.14
       )
-    ).x,
-    'https://example.com/example.png',
-    'should support rewriting `import.meta.url` w/ `baseUrl`'
+    }
   )
 
-  assert.throws(
-    () => {
-      evaluateSync('export * from "a"', runtime)
-    },
-    /Cannot use `import` or `export … from` in `evaluate` \(outputting a function body\) by default/,
-    'should throw on an export all from'
+  await t.test(
+    'should support an `export default as from` w/ `useDynamicImport`',
+    async () => {
+      assert.equal(
+        (
+          await evaluate('export {default as data} from "./context/data.js"', {
+            baseUrl: import.meta.url,
+            useDynamicImport: true,
+            ...runtime
+          })
+        ).data,
+        6.28
+      )
+    }
   )
 
-  assert.throws(
-    () => {
-      evaluateSync('import {a} from "b"', runtime)
-    },
-    /Cannot use `import` or `export … from` in `evaluate` \(outputting a function body\) by default/,
-    'should throw on an import'
-  )
-
-  assert.throws(
-    () => {
-      evaluateSync('import a from "b"', runtime)
-    },
-    /Cannot use `import` or `export … from` in `evaluate` \(outputting a function body\) by default/,
-    'should throw on an import default'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement((await evaluate('<X/>', runtime)).default, {
-        components: {
-          X() {
-            return React.createElement('span', {}, '!')
-          }
-        }
-      })
-    ),
-    '<span>!</span>',
-    'should support a given components'
-  )
-
-  assert.equal(
-    renderToStaticMarkup(
-      React.createElement(
-        provider.MDXProvider,
+  await t.test(
+    'should support an `export all from` w/ `useDynamicImport`',
+    async () => {
+      assert.deepEqual(
         {
+          ...(await evaluate('export * from "./context/data.js"', {
+            baseUrl: import.meta.url,
+            useDynamicImport: true,
+            ...runtime
+          })),
+          default: undefined
+        },
+        {array: [1, 2], default: undefined, number: 3.14, object: {a: 1, b: 2}}
+      )
+    }
+  )
+
+  await t.test(
+    'should support an `export all from`, but prefer explicit exports, w/ `useDynamicImport`',
+    async () => {
+      // I’m not sure if this makes sense, but it is how Node works.
+      assert.deepEqual(
+        {
+          ...(await evaluate(
+            'export {default as number} from "./context/data.js"\nexport * from "./context/data.js"',
+            {baseUrl: import.meta.url, useDynamicImport: true, ...runtime}
+          )),
+          default: undefined
+        },
+        {array: [1, 2], default: undefined, number: 6.28, object: {a: 1, b: 2}}
+      )
+    }
+  )
+
+  await t.test(
+    'should support rewriting `import.meta.url` w/ `baseUrl`',
+    async () => {
+      assert.equal(
+        (
+          await evaluate(
+            'export const x = new URL("example.png", import.meta.url).href',
+            {baseUrl: 'https://example.com', ...runtime}
+          )
+        ).x,
+        'https://example.com/example.png'
+      )
+    }
+  )
+
+  await t.test('should throw on an export all from', () => {
+    assert.throws(() => {
+      evaluateSync('export * from "a"', runtime)
+    }, /Cannot use `import` or `export … from` in `evaluate` \(outputting a function body\) by default/)
+  })
+
+  await t.test('should throw on an import', () => {
+    assert.throws(() => {
+      evaluateSync('import {a} from "b"', runtime)
+    }, /Cannot use `import` or `export … from` in `evaluate` \(outputting a function body\) by default/)
+  })
+
+  await t.test('should throw on an import default', () => {
+    assert.throws(() => {
+      evaluateSync('import a from "b"', runtime)
+    }, /Cannot use `import` or `export … from` in `evaluate` \(outputting a function body\) by default/)
+  })
+
+  await t.test('should support a given components', async () => {
+    assert.equal(
+      renderToStaticMarkup(
+        React.createElement((await evaluate('<X/>', runtime)).default, {
           components: {
             X() {
               return React.createElement('span', {}, '!')
             }
           }
-        },
+        })
+      ),
+      '<span>!</span>'
+    )
+  })
+
+  await t.test('should support a provider w/ `useMDXComponents`', async () => {
+    assert.equal(
+      renderToStaticMarkup(
         React.createElement(
-          (await evaluate('<X/>', {...runtime, ...provider})).default
+          provider.MDXProvider,
+          {
+            components: {
+              X() {
+                return React.createElement('span', {}, '!')
+              }
+            }
+          },
+          React.createElement(
+            (await evaluate('<X/>', {...runtime, ...provider})).default
+          )
         )
-      )
-    ),
-    '<span>!</span>',
-    'should support a provider w/ `useMDXComponents`'
-  )
+      ),
+      '<span>!</span>'
+    )
+  })
 })

--- a/packages/remark-mdx/test/index.js
+++ b/packages/remark-mdx/test/index.js
@@ -18,89 +18,10 @@ import remarkMdx from '../index.js'
 
 const basic = unified().use(remarkParse).use(remarkMdx)
 
-test('parse: basics', () => {
-  assert.deepEqual(
-    clean(basic.parse('Alpha <b/> charlie.')),
-    u('root', [
-      u('paragraph', [
-        u('text', 'Alpha '),
-        u('mdxJsxTextElement', {name: 'b', attributes: []}, []),
-        u('text', ' charlie.')
-      ])
-    ]),
-    'should parse a self-closing tag'
-  )
-
-  assert.deepEqual(
-    clean(basic.parse('Alpha <b></b> charlie.')),
-    u('root', [
-      u('paragraph', [
-        u('text', 'Alpha '),
-        u('mdxJsxTextElement', {name: 'b', attributes: []}, []),
-        u('text', ' charlie.')
-      ])
-    ]),
-    'should parse an opening and a closing tag'
-  )
-
-  assert.deepEqual(
-    clean(basic.parse('Alpha <></> charlie.')),
-    u('root', [
-      u('paragraph', [
-        u('text', 'Alpha '),
-        u('mdxJsxTextElement', {name: null, attributes: []}, []),
-        u('text', ' charlie.')
-      ])
-    ]),
-    'should parse fragments'
-  )
-
-  assert.deepEqual(
-    clean(basic.parse('Alpha <b>*bravo*</b> charlie.')),
-    u('root', [
-      u('paragraph', [
-        u('text', 'Alpha '),
-        u('mdxJsxTextElement', {name: 'b', attributes: []}, [
-          u('emphasis', [u('text', 'bravo')])
-        ]),
-        u('text', ' charlie.')
-      ])
-    ]),
-    'should parse markdown inside tags'
-  )
-
-  assert.deepEqual(
-    clean(basic.parse('Alpha {1 + 1} charlie.')),
-    u('root', [
-      u('paragraph', [
-        u('text', 'Alpha '),
-        u('mdxTextExpression', {data: {estree: null}}, '1 + 1'),
-        u('text', ' charlie.')
-      ])
-    ]),
-    'should parse expressions'
-  )
-})
-
-test('stringify', () => {
-  const basic = unified().use(remarkStringify).use(remarkMdx)
-
-  assert.equal(
-    basic.stringify(
-      u('root', [
-        u('paragraph', [
-          u('text', 'Alpha '),
-          u('mdxJsxTextElement', {name: null, attributes: []}, []),
-          u('text', ' charlie.')
-        ])
-      ])
-    ),
-    'Alpha <></> charlie.\n',
-    'should serialize an empty nameless fragment'
-  )
-
-  assert.equal(
-    basic.stringify(
+test('parse: basics', async (t) => {
+  await t.test('should parse a self-closing tag', () => {
+    assert.deepEqual(
+      clean(basic.parse('Alpha <b/> charlie.')),
       u('root', [
         u('paragraph', [
           u('text', 'Alpha '),
@@ -108,195 +29,291 @@ test('stringify', () => {
           u('text', ' charlie.')
         ])
       ])
-    ),
-    'Alpha <b /> charlie.\n',
-    'should serialize a tag with a name'
-  )
+    )
+  })
 
-  assert.equal(
-    basic.stringify(
+  await t.test('should parse an opening and a closing tag', () => {
+    assert.deepEqual(
+      clean(basic.parse('Alpha <b></b> charlie.')),
       u('root', [
         u('paragraph', [
           u('text', 'Alpha '),
-          u(
-            'mdxJsxTextElement',
-            {name: 'b', attributes: [u('mdxJsxAttribute', {name: 'bravo'})]},
-            []
-          ),
+          u('mdxJsxTextElement', {name: 'b', attributes: []}, []),
           u('text', ' charlie.')
         ])
       ])
-    ),
-    'Alpha <b bravo /> charlie.\n',
-    'should serialize a boolean attribute (element)'
-  )
+    )
+  })
 
-  assert.equal(
-    basic.stringify(
+  await t.test('should parse fragments', () => {
+    assert.deepEqual(
+      clean(basic.parse('Alpha <></> charlie.')),
       u('root', [
         u('paragraph', [
           u('text', 'Alpha '),
-          u(
-            'mdxJsxTextElement',
-            {
-              name: 'b',
-              attributes: [u('mdxJsxAttribute', {name: 'bravo'}, 'bravo')]
-            },
-            []
-          ),
+          u('mdxJsxTextElement', {name: null, attributes: []}, []),
           u('text', ' charlie.')
         ])
       ])
-    ),
-    'Alpha <b bravo="bravo" /> charlie.\n',
-    'should serialize an attribute (element)'
-  )
+    )
+  })
 
-  assert.equal(
-    basic.stringify(
+  await t.test('should parse markdown inside tags', () => {
+    assert.deepEqual(
+      clean(basic.parse('Alpha <b>*bravo*</b> charlie.')),
       u('root', [
         u('paragraph', [
           u('text', 'Alpha '),
-          u(
-            'mdxJsxTextElement',
-            {
-              name: 'b',
-              attributes: [u('mdxJsxAttribute', {name: 'br:avo'}, 'bravo')]
-            },
-            []
-          ),
+          u('mdxJsxTextElement', {name: 'b', attributes: []}, [
+            u('emphasis', [u('text', 'bravo')])
+          ]),
           u('text', ' charlie.')
         ])
       ])
-    ),
-    'Alpha <b br:avo="bravo" /> charlie.\n',
-    'should serialize a prefixed attribute (element)'
-  )
+    )
+  })
 
-  assert.equal(
-    basic.stringify(
+  await t.test('should parse expressions', () => {
+    assert.deepEqual(
+      clean(basic.parse('Alpha {1 + 1} charlie.')),
       u('root', [
         u('paragraph', [
           u('text', 'Alpha '),
-          u(
-            'mdxJsxTextElement',
-            {
-              name: 'b',
-              attributes: [u('mdxJsxExpressionAttribute', '...props')]
-            },
-            []
-          ),
+          u('mdxTextExpression', {data: {estree: null}}, '1 + 1'),
           u('text', ' charlie.')
         ])
       ])
-    ),
-    'Alpha <b {...props} /> charlie.\n',
-    'should serialize a attribute expression (element)'
-  )
+    )
+  })
+})
 
-  assert.equal(
-    basic.stringify(
-      u('root', [
-        u('paragraph', [
-          u('text', 'Alpha '),
-          u(
-            'mdxJsxTextElement',
-            {
-              name: 'b',
-              attributes: [
-                u('mdxJsxAttribute', {
-                  name: 'b',
-                  value: u(
-                    'mdxJsxAttributeValueExpression',
-                    {data: {estree: undefined}},
-                    '1 + 1'
-                  )
-                })
-              ]
-            },
-            []
-          ),
-          u('text', ' charlie.')
-        ])
-      ])
-    ),
-    'Alpha <b b={1 + 1} /> charlie.\n',
-    'should serialize an expression attribute (element)'
-  )
+test('stringify', async (t) => {
+  const basic = unified().use(remarkStringify).use(remarkMdx)
 
-  assert.equal(
-    basic.stringify(
-      u('root', [
-        u('paragraph', [
-          u('link', {url: 'https://mdxjs.com'}, [
-            u('text', 'https://mdxjs.com')
+  await t.test('should serialize an empty nameless fragment', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u('mdxJsxTextElement', {name: null, attributes: []}, []),
+            u('text', ' charlie.')
           ])
         ])
-      ])
-    ),
-    '[https://mdxjs.com](https://mdxjs.com)\n',
-    'should write out a url as the raw value'
-  )
+      ),
+      'Alpha <></> charlie.\n'
+    )
+  })
 
-  assert.equal(
-    basic.stringify(
-      u('root', [
-        u('paragraph', [
-          u('text', 'Alpha '),
-          u('mdxJsxTextElement', {name: null, attributes: []}, [
-            u('text', '1 < 3')
-          ]),
-          u('text', ' bravo.')
+  await t.test('should serialize a tag with a name', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u('mdxJsxTextElement', {name: 'b', attributes: []}, []),
+            u('text', ' charlie.')
+          ])
         ])
-      ])
-    ),
-    'Alpha <>1 \\< 3</> bravo.\n',
-    'should encode `<` in text'
-  )
+      ),
+      'Alpha <b /> charlie.\n'
+    )
+  })
 
-  assert.equal(
-    basic.stringify(
-      u('root', [
-        u('paragraph', [
-          u('text', 'Alpha '),
-          u('mdxJsxTextElement', {name: null, attributes: []}, [
-            u('text', '1 { 3')
-          ]),
-          u('text', ' bravo.')
+  await t.test('should serialize a boolean attribute (element)', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u(
+              'mdxJsxTextElement',
+              {name: 'b', attributes: [u('mdxJsxAttribute', {name: 'bravo'})]},
+              []
+            ),
+            u('text', ' charlie.')
+          ])
         ])
-      ])
-    ),
-    'Alpha <>1 \\{ 3</> bravo.\n',
-    'should encode `{` in text'
-  )
+      ),
+      'Alpha <b bravo /> charlie.\n'
+    )
+  })
 
-  assert.equal(
-    basic.stringify(
-      u('root', [
-        u('paragraph', [
-          u('text', 'Alpha '),
-          u('mdxTextExpression', ''),
-          u('text', ' bravo.')
+  await t.test('should serialize an attribute (element)', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u(
+              'mdxJsxTextElement',
+              {
+                name: 'b',
+                attributes: [u('mdxJsxAttribute', {name: 'bravo'}, 'bravo')]
+              },
+              []
+            ),
+            u('text', ' charlie.')
+          ])
         ])
-      ])
-    ),
-    'Alpha {} bravo.\n',
-    'should serialize empty expressions'
-  )
+      ),
+      'Alpha <b bravo="bravo" /> charlie.\n'
+    )
+  })
 
-  assert.equal(
-    basic.stringify(
-      u('root', [
-        u('paragraph', [
-          u('text', 'Alpha '),
-          u('mdxTextExpression', '1 + 1'),
-          u('text', ' bravo.')
+  await t.test('should serialize a prefixed attribute (element)', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u(
+              'mdxJsxTextElement',
+              {
+                name: 'b',
+                attributes: [u('mdxJsxAttribute', {name: 'br:avo'}, 'bravo')]
+              },
+              []
+            ),
+            u('text', ' charlie.')
+          ])
         ])
-      ])
-    ),
-    'Alpha {1 + 1} bravo.\n',
-    'should serialize expressions'
-  )
+      ),
+      'Alpha <b br:avo="bravo" /> charlie.\n'
+    )
+  })
+
+  await t.test('should serialize a attribute expression (element)', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u(
+              'mdxJsxTextElement',
+              {
+                name: 'b',
+                attributes: [u('mdxJsxExpressionAttribute', '...props')]
+              },
+              []
+            ),
+            u('text', ' charlie.')
+          ])
+        ])
+      ),
+      'Alpha <b {...props} /> charlie.\n'
+    )
+  })
+
+  await t.test('should serialize an expression attribute (element)', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u(
+              'mdxJsxTextElement',
+              {
+                name: 'b',
+                attributes: [
+                  u('mdxJsxAttribute', {
+                    name: 'b',
+                    value: u(
+                      'mdxJsxAttributeValueExpression',
+                      {data: {estree: undefined}},
+                      '1 + 1'
+                    )
+                  })
+                ]
+              },
+              []
+            ),
+            u('text', ' charlie.')
+          ])
+        ])
+      ),
+      'Alpha <b b={1 + 1} /> charlie.\n'
+    )
+  })
+
+  await t.test('should write out a url as the raw value', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('link', {url: 'https://mdxjs.com'}, [
+              u('text', 'https://mdxjs.com')
+            ])
+          ])
+        ])
+      ),
+      '[https://mdxjs.com](https://mdxjs.com)\n'
+    )
+  })
+
+  await t.test('should encode `<` in text', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u('mdxJsxTextElement', {name: null, attributes: []}, [
+              u('text', '1 < 3')
+            ]),
+            u('text', ' bravo.')
+          ])
+        ])
+      ),
+      'Alpha <>1 \\< 3</> bravo.\n'
+    )
+  })
+
+  await t.test('should encode `{` in text', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u('mdxJsxTextElement', {name: null, attributes: []}, [
+              u('text', '1 { 3')
+            ]),
+            u('text', ' bravo.')
+          ])
+        ])
+      ),
+      'Alpha <>1 \\{ 3</> bravo.\n'
+    )
+  })
+
+  await t.test('should serialize empty expressions', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u('mdxTextExpression', ''),
+            u('text', ' bravo.')
+          ])
+        ])
+      ),
+      'Alpha {} bravo.\n'
+    )
+  })
+
+  await t.test('should serialize expressions', () => {
+    assert.equal(
+      basic.stringify(
+        u('root', [
+          u('paragraph', [
+            u('text', 'Alpha '),
+            u('mdxTextExpression', '1 + 1'),
+            u('text', ' bravo.')
+          ])
+        ])
+      ),
+      'Alpha {1 + 1} bravo.\n'
+    )
+  })
 })
 
 /**


### PR DESCRIPTION
These packages have significantly sized test cases. Using subtests helps when troubleshooting these tests.
