### PR TITLE
Object spread

### DIFF
--- a/docs/docs/using-mdx.server.mdx
+++ b/docs/docs/using-mdx.server.mdx
@@ -65,7 +65,10 @@ import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from 'react/jsx-runti
 export const Thing = () => _jsx(_Fragment, {children: 'World'})
 
 function _createMdxContent(props) {
-  const _components = Object.assign({h1: 'h1'}, props.components)
+  const _components = {
+    h1: 'h1',
+    ...props.components
+  }
   return _jsxs(_components.h1, {
     children: ['Hello ', _jsx(Thing, {})]
   })

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -92,7 +92,10 @@ import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from 'react/jsx-runti
 export const Thing = () => _jsx(_Fragment, {children: 'World'})
 
 function _createMdxContent(props) {
-  const _components = Object.assign({h1: 'h1'}, props.components)
+  const _components = {
+    h1: 'h1',
+    ...props.components
+  }
   return _jsxs(_components.h1, {
     children: ['Hello ', _jsx(Thing, {})]
   })
@@ -533,14 +536,20 @@ compile(file, {providerImportSource: '@mdx-js/react'})
  export const Thing = () => _jsx(_Fragment, {children: 'World!'})
 
  function _createMdxContent(props) {
--  const _components = Object.assign({h1: 'h1'}, props.components)
-+  const _components = Object.assign({h1: 'h1'}, _provideComponents(), props.components)
+   const _components = {
+     h1: 'h1',
++    ..._provideComponents(),
+     ...props.components
+   }
    return _jsxs(_components.h1, {children: ['Hello ', _jsx(Thing, {})]})
  }
 
  export default function MDXContent(props = {}) {
 -  const {wrapper: MDXLayout} = props.components || {}
-+  const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components)
++  const {wrapper: MDXLayout} = {
++    ..._provideComponents(),
++    ...props.components
++  }
 
    return MDXLayout
      ? _jsx(MDXLayout, Object.assign({}, props, {children: _jsx(_createMdxContent, {})}))
@@ -574,7 +583,10 @@ compile(file, {jsx: true})
 +export const Thing = () => <>World!</>
 
  function _createMdxContent(props) {
-   const _components = Object.assign({h1: 'h1'}, props.components)
+   const _components = {
+     h1: 'h1',
+     ...props.components
+   }
 -  return _jsxs(_components.h1, {children: ['Hello ', _jsx(Thing, {})]})
 +  return <_components.h1>{"Hello "}<Thing /></_components.h1>
  }

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -895,10 +895,11 @@ test('jsx', async (t) => {
       [
         '/*@jsxRuntime automatic @jsxImportSource react*/',
         'function _createMdxContent(props) {',
-        '  const _components = Object.assign({',
+        '  const _components = {',
         '    em: "em",',
-        '    p: "p"',
-        '  }, props.components);',
+        '    p: "p",',
+        '    ...props.components',
+        '  };',
         '  return <_components.p><_components.em>{"a"}</_components.em></_components.p>;',
         '}',
         'function MDXContent(props = {}) {',
@@ -978,9 +979,10 @@ test('jsx', async (t) => {
       [
         '/*@jsxRuntime automatic @jsxImportSource react*/',
         'function _createMdxContent(props) {',
-        '  const _components = Object.assign({',
-        '    "a-b": "a-b"',
-        '  }, props.components), _component0 = _components["a-b"];',
+        '  const _components = {',
+        '    "a-b": "a-b",',
+        '    ...props.components',
+        '  }, _component0 = _components["a-b"];',
         '  return <>{<_component0></_component0>}</>;',
         '}',
         'function MDXContent(props = {}) {',
@@ -999,9 +1001,10 @@ test('jsx', async (t) => {
       [
         '/*@jsxRuntime automatic @jsxImportSource react*/',
         'function _createMdxContent(props) {',
-        '  const _components = Object.assign({',
-        '    p: "p"',
-        '  }, props.components);',
+        '  const _components = {',
+        '    p: "p",',
+        '    ...props.components',
+        '  };',
         '  return <_components.p>{"Hello "}{props.name}</_components.p>;',
         '}',
         'function MDXContent(props = {}) {',
@@ -1030,13 +1033,50 @@ test('jsx', async (t) => {
           '  return <section {...props} />;',
           '};',
           'function _createMdxContent(props) {',
-          '  const _components = Object.assign({',
-          '    p: "p"',
-          '  }, props.components);',
+          '  const _components = {',
+          '    p: "p",',
+          '    ...props.components',
+          '  };',
           '  return <_components.p>{"a"}</_components.p>;',
           '}',
           'function MDXContent(props = {}) {',
           '  return <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout>;',
+          '}',
+          'export default MDXContent;',
+          ''
+        ].join('\n')
+      )
+    }
+  )
+
+  await t.test(
+    'should combine passing `components` w/ props and a provider',
+    () => {
+      assert.equal(
+        String(
+          compileSync('a', {
+            jsx: true,
+            providerImportSource: '@mdx-js/react'
+          })
+        ),
+        [
+          '/*@jsxRuntime automatic @jsxImportSource react*/',
+          'import {useMDXComponents as _provideComponents} from "@mdx-js/react";',
+          'function _createMdxContent(props) {',
+          '  const _components = {',
+          '    p: "p",',
+          '    ..._provideComponents(),',
+          '    ...props.components',
+          '  };',
+          '  return <_components.p>{"a"}</_components.p>;',
+          '}',
+          'function MDXContent(props = {}) {',
+          '  const {wrapper: MDXLayout} = {',
+          '    ..._provideComponents(),',
+          '    ...props.components',
+          '  };',
+          '  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);',
+
           '}',
           'export default MDXContent;',
           ''

--- a/packages/rollup/test/index.js
+++ b/packages/rollup/test/index.js
@@ -34,7 +34,7 @@ test('@mdx-js/rollup', async () => {
 
   assert.equal(
     output[0].map ? output[0].map.mappings : undefined,
-    ';;;MAAaA,OAAU,GAAA,MAAAC,GAAA,CAAAC,QAAA,EAAA;AAAQ,EAAA,QAAA,EAAA,QAAA;;;;;;;AAE7B,IAAA,QAAA,EAAA,CAAA,SAAA,EAAAD,GAAA,CAAA,OAAA,EAAA,EAAA,CAAA,CAAA;;;;;;;;;;;;',
+    ';;;MAAaA,OAAU,GAAA,MAAAC,GAAA,CAAAC,QAAA,EAAA;AAAQ,EAAA,QAAA,EAAA,QAAA;;;;;;;;AAE7B,IAAA,QAAA,EAAA,CAAA,SAAA,EAAAD,GAAA,CAAA,OAAA,EAAA,EAAA,CAAA,CAAA;;;;;;;;;;;;',
     'should add a source map'
   )
 


### PR DESCRIPTION
This affects the assignment of `_components`. For JSX see https://github.com/syntax-tree/estree-util-build-jsx/pull/8.

Refs #2310