### PR TITLE
Update link to KaTeX CSS in docs

### DIFF
--- a/docs/guides/math.mdx
+++ b/docs/guides/math.mdx
@@ -5,7 +5,7 @@ export const info = {
     {name: 'Titus Wormer', github: 'wooorm', twitter: 'wooorm'}
   ],
   published: new Date('2021-10-06'),
-  modified: new Date('2022-12-14')
+  modified: new Date('2023-10-09')
 }
 
 # Math
@@ -68,6 +68,11 @@ console.log(
 <Note type="important">
   **Important**: if you chose `rehype-katex`, you should also use `katex.css`
   somewhere on the page to style math properly.
+  At the time of writing, the last version is:
+  ```html
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
+  ```
+
   To get the latest link to the stylesheet, go to [`katex docs`][katex docs].
 </Note>
 

--- a/docs/guides/math.mdx
+++ b/docs/guides/math.mdx
@@ -69,6 +69,7 @@ console.log(
   **Important**: if you chose `rehype-katex`, you should also use `katex.css`
   somewhere on the page to style math properly.
   At the time of writing, the last version is:
+
   ```html
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
   ```

--- a/docs/guides/math.mdx
+++ b/docs/guides/math.mdx
@@ -68,11 +68,7 @@ console.log(
 <Note type="important">
   **Important**: if you chose `rehype-katex`, you should also use `katex.css`
   somewhere on the page to style math properly.
-  At the time of writing, the last version is:
-
-  ```html
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css" integrity="sha384-RZU/ijkSsFbcmivfdRBQDtwuwVqK7GMOw6IMvKyeWL2K5UAlyp6WonmB8m7Jd0Hn" crossorigin="anonymous">
-  ```
+  To get the latest link to the stylesheet, go to [`katex docs`][katex docs].
 </Note>
 
 <Note type="info">
@@ -95,3 +91,5 @@ console.log(
 [options-rehype-plugins]: /packages/mdx/#optionsrehypeplugins
 
 [extend]: /docs/extending-mdx/
+
+[katex docs]: https://katex.org/docs/browser#loading-as-global


### PR DESCRIPTION
`Closes GH-#2341`

Remove old link to katex.css and refer to the katex docs to get the latest version.