### PR TITLE
Replace Object.assign with spread syntax in docs

### DIFF
--- a/docs/docs/using-mdx.mdx
+++ b/docs/docs/using-mdx.mdx
@@ -82,7 +82,10 @@ function _createMdxContent(props) {
 export default function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = props.components || {}
   return MDXLayout
-    ? _jsx(MDXLayout, Object.assign({}, props, {children: _jsx(_createMdxContent, props)}))
+    ? _jsx(MDXLayout, {
+        ...props,
+        children: _jsx(_createMdxContent, props)}
+      )
     : _createMdxContent(props)
 }
 ```

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -108,7 +108,10 @@ function _createMdxContent(props) {
 export default function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = props.components || {}
   return MDXLayout
-    ? _jsx(MDXLayout, Object.assign({}, props, {children: _jsx(_createMdxContent, props)}))
+    ? _jsx(MDXLayout, {
+        ...props,
+        children: _jsx(_createMdxContent, props)
+      })
     : _createMdxContent(props)
 }
 ```
@@ -558,7 +561,10 @@ compile(file, {providerImportSource: '@mdx-js/react'})
 +  }
 
    return MDXLayout
-     ? _jsx(MDXLayout, Object.assign({}, props, {children: _jsx(_createMdxContent, {})}))
+     ? _jsx(MDXLayout, {
+         ...props,
+         children: _jsx(_createMdxContent, {})
+       })
      : _createMdxContent()
 ```
 
@@ -602,7 +608,10 @@ compile(file, {jsx: true})
  export default function MDXContent(props = {}) {
    const {wrapper: MDXLayout} = props.components || {}
    return MDXLayout
--    ? _jsx(MDXLayout, Object.assign({}, props, {children: _jsx(_createMdxContent, props)}))
+-    ? _jsx(MDXLayout, {
+-        ...props,
+-        children: _jsx(_createMdxContent, props)
+-      })
 +    ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout>
      : _createMdxContent(props)
  }


### PR DESCRIPTION
`estree-util-build-jsx` was updated to version 3, which uses spread syntax. However, some documentation was still using `Object.assign` in output examples.
