### PR TITLE
Fix typo in announcement blog post

### DIFF
--- a/docs/blog/v3.mdx
+++ b/docs/blog/v3.mdx
@@ -99,7 +99,7 @@ Updating every use example where needed.
 I also wrote a guide on how to inject components from anywhere:
 [§ Injecting components][injecting-components].
 
-The site a bunch faster.
+The site is a lot faster.
 There’s a nice improved playground too: [try it out! »][playground].
 We also have proper syntax highlighting here, thanks to
 [`wooorm/markdown-tm-language`][markdown-tm-language]


### PR DESCRIPTION
Fixes a teeny tiny typo. Congrats on the launch! Hope you're doing well 👋🏻 