### PR TITLE
Add note on broken react runtime types

### DIFF
--- a/docs/migrating/v3.mdx
+++ b/docs/migrating/v3.mdx
@@ -52,8 +52,12 @@ You will get a runtime error if these features are used in MDX without
 If you passed the `useDynamicImport` option before, remove it, the behavior
 is now the default.
 
-Note that you may get a TypeScript error saying `Property 'Fragment' is missing in type`. This is [because `react/jsx-runtime` does not export its types](https://github.com/orgs/mdx-js/discussions/1862#discussioncomment-1824570). To remediate this, do: 
+Note that you may get a TypeScript error saying `Property 'Fragment' is missing in type`.
+This is [because `react/jsx-runtime` does not export its types](https://github.com/orgs/mdx-js/discussions/1862#discussioncomment-1824570).
+To remediate this, do:
+
 ```typescript
+
 // @ts-expect-error: the automatic react runtime is untyped.
 const result = await run(compiled, { ...runtime, baseUrl: import.meta.url });
 ```

--- a/docs/migrating/v3.mdx
+++ b/docs/migrating/v3.mdx
@@ -52,6 +52,12 @@ You will get a runtime error if these features are used in MDX without
 If you passed the `useDynamicImport` option before, remove it, the behavior
 is now the default.
 
+Note that you may get a TypeScript error saying `Property 'Fragment' is missing in type`. This is [because `react/jsx-runtime` does not export its types](https://github.com/orgs/mdx-js/discussions/1862#discussioncomment-1824570). To remediate this, do: 
+```typescript
+// @ts-expect-error: the automatic react runtime is untyped.
+const result = await run(compiled, { ...runtime, baseUrl: import.meta.url });
+```
+
 ## Use the automatic JSX runtime
 
 If you use the classic runtime, switch to the automatic runtime.

--- a/docs/migrating/v3.mdx
+++ b/docs/migrating/v3.mdx
@@ -52,14 +52,18 @@ You will get a runtime error if these features are used in MDX without
 If you passed the `useDynamicImport` option before, remove it, the behavior
 is now the default.
 
-Note that you may get a TypeScript error saying `Property 'Fragment' is missing in type`.
-This is [because `react/jsx-runtime` does not export its types](https://github.com/orgs/mdx-js/discussions/1862#discussioncomment-1824570).
+If you use `react/jsx-runtime`, you might get a TypeScript error (such as
+`Property 'Fragment' is missing in type`), because it is typed incorrectly.
 To remediate this, do:
 
-```typescript
+```tsx
+import {type Fragment, type Jsx, run} from '@mdx-js/mdx'
+import * as runtime_ from 'react/jsx-runtime'
 
 // @ts-expect-error: the automatic react runtime is untyped.
-const result = await run(compiled, { ...runtime, baseUrl: import.meta.url });
+const runtime: {Fragment: Fragment; jsx: Jsx; jsxs: Jsx} = runtime_
+
+const result = await run('# hi', {...runtime, baseUrl: import.meta.url})
 ```
 
 ## Use the automatic JSX runtime


### PR DESCRIPTION
_Thanks for the 3.0.0 release!_

In updating, I had to do a bit of googling and doc prowling to find how to manage an error related to types on the JSX runtime that I hadn't got prior to 3.0.0. 

I thought I'd update the docs to help others with this. 

Please feel free to change the wording.