### PR TITLE
Fix reset of playground render errors

### DIFF
--- a/docs/_asset/editor.jsx
+++ b/docs/_asset/editor.jsx
@@ -210,7 +210,7 @@ function Playground() {
           })
 
           return (
-            <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <ErrorBoundary FallbackComponent={ErrorFallback} resetKeys={[value]}>
               <div className="playground-result">{mod.default({})}</div>
             </ErrorBoundary>
           )


### PR DESCRIPTION
The error boundary does not automatically reset on changing the text value, To fix it the [`value`](https://github.com/mdx-js/mdx/blob/efff74e48aec9286c62185bf04f7b8aa72e07bd6/docs/_asset/editor.jsx#L149C45-L149C45) state was added to the `resetKeys` in `ErrorBoundary`

You can see the difference on the [official site](https://mdxjs.com/playground/) vs localhost:

https://github.com/mdx-js/mdx/assets/73928607/ce24eb47-b9f9-41be-8882-a5d1c54ad9be

