### PR TITLE
Refactor to handle uncaught webpack errors

### DIFF
--- a/packages/loader/index.cjs
+++ b/packages/loader/index.cjs
@@ -28,5 +28,5 @@ function loader(code) {
   // Note that `import()` caches, so this should be fast enough.
   import('./lib/index.js').then((module) => {
     return module.loader.call(this, code, callback)
-  })
+  }, callback)
 }


### PR DESCRIPTION
A dynamic import may fail for various reasons. This was unhandled. This means the loader could wait indefinitely. Now it defers the error to Webpack.

I didn’t encounter this, but it the code just caught my eye. I don’t know how to test it. It doesn’t affect test coverage.