### PR TITLE
Fix `mdx-embed` link in docs

### DIFF
--- a/docs/guides/embed.mdx
+++ b/docs/guides/embed.mdx
@@ -133,6 +133,6 @@ import Example from './example.mdx' // Assumes an integration is used to compile
 
 [remark-embedder]: https://github.com/remark-embedder/core
 
-[mdx-embed]: https://www.mdx-embed.com/
+[mdx-embed]: https://mdx-embed.netlify.app/
 
 [mdx-react]: /packages/react/


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
The old URL is broken so I updated a new URL, see https://github.com/PaulieScanlon/mdx-embed/pull/253.