### PR TITLE
Fix generated JSX pragmas for new babel

### DIFF
--- a/docs/_asset/editor.jsx
+++ b/docs/_asset/editor.jsx
@@ -1,4 +1,4 @@
-/**
+/*
  * @jsxRuntime automatic
  * @jsxImportSource react
  */

--- a/docs/_asset/editor.jsx
+++ b/docs/_asset/editor.jsx
@@ -1,5 +1,7 @@
-/* @jsxRuntime automatic
-@jsxImportSource react */
+/**
+ * @jsxRuntime automatic
+ * @jsxImportSource react
+ */
 
 /**
  * @typedef {import('@wooorm/starry-night').Grammar} Grammar

--- a/docs/_asset/editor.jsx
+++ b/docs/_asset/editor.jsx
@@ -1,4 +1,5 @@
-/* @jsxRuntime automatic @jsxImportSource react */
+/* @jsxRuntime automatic
+@jsxImportSource react */
 
 /**
  * @typedef {import('@wooorm/starry-night').Grammar} Grammar

--- a/docs/docs/using-mdx.mdx
+++ b/docs/docs/using-mdx.mdx
@@ -41,7 +41,8 @@ That’s *roughly* turned into the following JavaScript.
 The below might help to form a mental model:
 
 ```tsx path="output-outline.jsx"
-/* @jsxRuntime automatic @jsxImportSource react */
+/* @jsxRuntime automatic
+@jsxImportSource react */
 
 export function Thing() {
   return <>World</>

--- a/docs/docs/using-mdx.mdx
+++ b/docs/docs/using-mdx.mdx
@@ -41,8 +41,10 @@ That’s *roughly* turned into the following JavaScript.
 The below might help to form a mental model:
 
 ```tsx path="output-outline.jsx"
-/* @jsxRuntime automatic
-@jsxImportSource react */
+/*
+@jsxRuntime automatic
+@jsxImportSource react
+*/
 
 export function Thing() {
   return <>World</>

--- a/docs/docs/using-mdx.mdx
+++ b/docs/docs/using-mdx.mdx
@@ -41,8 +41,8 @@ That’s *roughly* turned into the following JavaScript.
 The below might help to form a mental model:
 
 ```tsx path="output-outline.jsx"
-/*@jsxRuntime automatic*/
-/*@jsxImportSource react*/
+/* @jsxRuntime automatic */
+/* @jsxImportSource react */
 
 export function Thing() {
   return <>World</>

--- a/docs/docs/using-mdx.mdx
+++ b/docs/docs/using-mdx.mdx
@@ -41,10 +41,8 @@ That’s *roughly* turned into the following JavaScript.
 The below might help to form a mental model:
 
 ```tsx path="output-outline.jsx"
-/*
-@jsxRuntime automatic
-@jsxImportSource react
-*/
+/*@jsxRuntime automatic*/
+/*@jsxImportSource react*/
 
 export function Thing() {
   return <>World</>

--- a/packages/mdx/lib/plugin/recma-document.js
+++ b/packages/mdx/lib/plugin/recma-document.js
@@ -105,7 +105,7 @@ export function recmaDocument(options) {
     if (pragmas.length > 0) {
       tree.comments.unshift({
         type: 'Block',
-        value: pragmas.join('\n'),
+        value: '\n' + pragmas.join('\n') + '\n',
         data: {_mdxIsPragmaComment: true}
       })
     }

--- a/packages/mdx/lib/plugin/recma-document.js
+++ b/packages/mdx/lib/plugin/recma-document.js
@@ -73,8 +73,6 @@ export function recmaDocument(options) {
     const exportedIdentifiers = []
     /** @type {Array<Directive | ModuleDeclaration | Statement>} */
     const replacement = []
-    /** @type {Array<string>} */
-    const pragmas = []
     let exportAllCount = 0
     /** @type {ExportDefaultDeclaration | ExportSpecifier | undefined} */
     let layout
@@ -83,31 +81,20 @@ export function recmaDocument(options) {
     /** @type {Node} */
     let child
 
-    if (jsxRuntime) {
-      pragmas.push('@jsxRuntime ' + jsxRuntime)
-    }
-
-    if (jsxRuntime === 'automatic' && jsxImportSource) {
-      pragmas.push('@jsxImportSource ' + jsxImportSource)
+    if (jsxRuntime === 'classic' && pragmaFrag) {
+      injectPragma(tree, '@jsxFrag', pragmaFrag)
     }
 
     if (jsxRuntime === 'classic' && pragma) {
-      pragmas.push('@jsx ' + pragma)
+      injectPragma(tree, '@jsx', pragma)
     }
 
-    if (jsxRuntime === 'classic' && pragmaFrag) {
-      pragmas.push('@jsxFrag ' + pragmaFrag)
+    if (jsxRuntime === 'automatic' && jsxImportSource) {
+      injectPragma(tree, '@jsxImportSource', jsxImportSource)
     }
 
-    /* c8 ignore next -- comments can be missing in the types, we always have it. */
-    if (!tree.comments) tree.comments = []
-
-    for (let index = pragmas.length; index--; index >= 0) {
-      tree.comments.unshift({
-        type: 'Block',
-        value: pragmas[index],
-        data: {_mdxIsPragmaComment: true}
-      })
+    if (jsxRuntime) {
+      injectPragma(tree, '@jsxRuntime', jsxRuntime)
     }
 
     if (jsxRuntime === 'classic' && pragmaImportSource) {
@@ -704,6 +691,20 @@ export function recmaDocument(options) {
         : declaration
     ]
   }
+}
+
+/**
+ * @param {Program} tree
+ * @param {string} name
+ * @param {string} value
+ * @returns {undefined}
+ */
+function injectPragma(tree, name, value) {
+  tree.comments?.unshift({
+    type: 'Block',
+    value: name + ' ' + value,
+    data: {_mdxIsPragmaComment: true}
+  })
 }
 
 /**

--- a/packages/mdx/lib/plugin/recma-document.js
+++ b/packages/mdx/lib/plugin/recma-document.js
@@ -102,10 +102,10 @@ export function recmaDocument(options) {
     /* c8 ignore next -- comments can be missing in the types, we always have it. */
     if (!tree.comments) tree.comments = []
 
-    if (pragmas.length > 0) {
+    for (let index = pragmas.length; index--; index >= 0) {
       tree.comments.unshift({
         type: 'Block',
-        value: '\n' + pragmas.join('\n') + '\n',
+        value: pragmas[index],
         data: {_mdxIsPragmaComment: true}
       })
     }

--- a/packages/mdx/lib/plugin/recma-document.js
+++ b/packages/mdx/lib/plugin/recma-document.js
@@ -105,7 +105,7 @@ export function recmaDocument(options) {
     if (pragmas.length > 0) {
       tree.comments.unshift({
         type: 'Block',
-        value: pragmas.join(' '),
+        value: pragmas.join('\n'),
         data: {_mdxIsPragmaComment: true}
       })
     }

--- a/packages/mdx/lib/plugin/recma-jsx-build.js
+++ b/packages/mdx/lib/plugin/recma-jsx-build.js
@@ -46,14 +46,9 @@ export function recmaJsxBuild(options) {
     // Remove the pragma comment that we injected ourselves as it is no longer
     // needed.
     if (tree.comments) {
-      let index = 0
-      while (index < tree.comments.length) {
-        if (tree.comments[index].data?._mdxIsPragmaComment) {
-          tree.comments.splice(index, 1)
-        } else {
-          index++
-        }
-      }
+      tree.comments = tree.comments.filter(function (d) {
+        return !d.data?._mdxIsPragmaComment
+      })
     }
 
     // When compiling to a function body, replace the import that was just

--- a/packages/mdx/lib/plugin/recma-jsx-build.js
+++ b/packages/mdx/lib/plugin/recma-jsx-build.js
@@ -45,13 +45,15 @@ export function recmaJsxBuild(options) {
 
     // Remove the pragma comment that we injected ourselves as it is no longer
     // needed.
-    if (
-      tree.comments &&
-      tree.comments[0].type === 'Block' &&
-      tree.comments[0].data &&
-      tree.comments[0].data._mdxIsPragmaComment
-    ) {
-      tree.comments.shift()
+    if (tree.comments) {
+      let index = 0
+      while (index < tree.comments.length) {
+        if (tree.comments[index].data?._mdxIsPragmaComment) {
+          tree.comments.splice(index, 1)
+        } else {
+          index++
+        }
+      }
     }
 
     // When compiling to a function body, replace the import that was just

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -653,7 +653,8 @@ Configuration for `createProcessor` (TypeScript type).
 
   ```diff
   -import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from 'react/jsx-runtime'
-  +/* @jsxRuntime automatic @jsxImportSource react */
+  +/* @jsxRuntime automatic
+  +@jsxImportSource react */
 
   export function Thing() {
   -  return _jsx(_Fragment, {children: 'World'})

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -653,10 +653,8 @@ Configuration for `createProcessor` (TypeScript type).
 
   ```diff
   -import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from 'react/jsx-runtime'
-  +/*
-  +@jsxRuntime automatic
-  +@jsxImportSource react
-  +*/
+  +/*@jsxRuntime automatic*/
+  +/*@jsxImportSource react*/
 
   export function Thing() {
   -  return _jsx(_Fragment, {children: 'World'})

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -653,8 +653,10 @@ Configuration for `createProcessor` (TypeScript type).
 
   ```diff
   -import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from 'react/jsx-runtime'
-  +/* @jsxRuntime automatic
-  +@jsxImportSource react */
+  +/*
+  +@jsxRuntime automatic
+  +@jsxImportSource react
+  +*/
 
   export function Thing() {
   -  return _jsx(_Fragment, {children: 'World'})

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -1154,10 +1154,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('*a*', {jsx: true})),
       [
-        '/*',
-        '@jsxRuntime automatic',
-        '@jsxImportSource react',
-        '*/',
+        '/*@jsxRuntime automatic*/',
+        '/*@jsxImportSource react*/',
         'function _createMdxContent(props) {',
         '  const _components = {',
         '    em: "em",',
@@ -1179,10 +1177,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('<a {...b} c d="1" e={1} />', {jsx: true})),
       [
-        '/*',
-        '@jsxRuntime automatic',
-        '@jsxImportSource react',
-        '*/',
+        '/*@jsxRuntime automatic*/',
+        '/*@jsxImportSource react*/',
         'function _createMdxContent(props) {',
         '  return <a {...b} c d="1" e={1} />;',
         '}',
@@ -1201,10 +1197,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
       assert.equal(
         String(await compile('<><a:b /><c.d/></>', {jsx: true})),
         [
-          '/*',
-          '@jsxRuntime automatic',
-          '@jsxImportSource react',
-          '*/',
+          '/*@jsxRuntime automatic*/',
+          '/*@jsxImportSource react*/',
           'function _createMdxContent(props) {',
           '  const {c} = props.components || ({});',
           '  if (!c) _missingMdxReference("c", false);',
@@ -1228,10 +1222,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('<>a {/* 1 */} b</>', {jsx: true})),
       [
-        '/*',
-        '@jsxRuntime automatic',
-        '@jsxImportSource react',
-        '*/',
+        '/*@jsxRuntime automatic*/',
+        '/*@jsxImportSource react*/',
         '/*1*/',
         'function _createMdxContent(props) {',
         '  return <><>{"a "}{}{" b"}</></>;',
@@ -1251,10 +1243,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
       assert.equal(
         String(await compile('{<a-b></a-b>}', {jsx: true})),
         [
-          '/*',
-          '@jsxRuntime automatic',
-          '@jsxImportSource react',
-          '*/',
+          '/*@jsxRuntime automatic*/',
+          '/*@jsxImportSource react*/',
           'function _createMdxContent(props) {',
           '  const _components = {',
           '    "a-b": "a-b",',
@@ -1276,10 +1266,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('Hello {props.name}', {jsx: true})),
       [
-        '/*',
-        '@jsxRuntime automatic',
-        '@jsxImportSource react',
-        '*/',
+        '/*@jsxRuntime automatic*/',
+        '/*@jsxImportSource react*/',
         'function _createMdxContent(props) {',
         '  const _components = {',
         '    p: "p",',
@@ -1307,10 +1295,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
           )
         ),
         [
-          '/*',
-          '@jsxRuntime automatic',
-          '@jsxImportSource react',
-          '*/',
+          '/*@jsxRuntime automatic*/',
+          '/*@jsxImportSource react*/',
           'const MDXLayout = function Layout({components, ...props}) {',
           '  return <section {...props} />;',
           '};',
@@ -1341,10 +1327,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
           })
         ),
         [
-          '/*',
-          '@jsxRuntime automatic',
-          '@jsxImportSource react',
-          '*/',
+          '/*@jsxRuntime automatic*/',
+          '/*@jsxImportSource react*/',
           'import {useMDXComponents as _provideComponents} from "@mdx-js/react";',
           'function _createMdxContent(props) {',
           '  const _components = {',

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -1154,8 +1154,10 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('*a*', {jsx: true})),
       [
-        '/*@jsxRuntime automatic',
-        '@jsxImportSource react*/',
+        '/*',
+        '@jsxRuntime automatic',
+        '@jsxImportSource react',
+        '*/',
         'function _createMdxContent(props) {',
         '  const _components = {',
         '    em: "em",',
@@ -1177,8 +1179,10 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('<a {...b} c d="1" e={1} />', {jsx: true})),
       [
-        '/*@jsxRuntime automatic',
-        '@jsxImportSource react*/',
+        '/*',
+        '@jsxRuntime automatic',
+        '@jsxImportSource react',
+        '*/',
         'function _createMdxContent(props) {',
         '  return <a {...b} c d="1" e={1} />;',
         '}',
@@ -1197,8 +1201,10 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
       assert.equal(
         String(await compile('<><a:b /><c.d/></>', {jsx: true})),
         [
-          '/*@jsxRuntime automatic',
-          '@jsxImportSource react*/',
+          '/*',
+          '@jsxRuntime automatic',
+          '@jsxImportSource react',
+          '*/',
           'function _createMdxContent(props) {',
           '  const {c} = props.components || ({});',
           '  if (!c) _missingMdxReference("c", false);',
@@ -1222,8 +1228,10 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('<>a {/* 1 */} b</>', {jsx: true})),
       [
-        '/*@jsxRuntime automatic',
-        '@jsxImportSource react*/',
+        '/*',
+        '@jsxRuntime automatic',
+        '@jsxImportSource react',
+        '*/',
         '/*1*/',
         'function _createMdxContent(props) {',
         '  return <><>{"a "}{}{" b"}</></>;',
@@ -1243,8 +1251,10 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
       assert.equal(
         String(await compile('{<a-b></a-b>}', {jsx: true})),
         [
-          '/*@jsxRuntime automatic',
-          '@jsxImportSource react*/',
+          '/*',
+          '@jsxRuntime automatic',
+          '@jsxImportSource react',
+          '*/',
           'function _createMdxContent(props) {',
           '  const _components = {',
           '    "a-b": "a-b",',
@@ -1266,8 +1276,10 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('Hello {props.name}', {jsx: true})),
       [
-        '/*@jsxRuntime automatic',
-        '@jsxImportSource react*/',
+        '/*',
+        '@jsxRuntime automatic',
+        '@jsxImportSource react',
+        '*/',
         'function _createMdxContent(props) {',
         '  const _components = {',
         '    p: "p",',
@@ -1295,8 +1307,10 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
           )
         ),
         [
-          '/*@jsxRuntime automatic',
-          '@jsxImportSource react*/',
+          '/*',
+          '@jsxRuntime automatic',
+          '@jsxImportSource react',
+          '*/',
           'const MDXLayout = function Layout({components, ...props}) {',
           '  return <section {...props} />;',
           '};',
@@ -1327,8 +1341,10 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
           })
         ),
         [
-          '/*@jsxRuntime automatic',
-          '@jsxImportSource react*/',
+          '/*',
+          '@jsxRuntime automatic',
+          '@jsxImportSource react',
+          '*/',
           'import {useMDXComponents as _provideComponents} from "@mdx-js/react";',
           'function _createMdxContent(props) {',
           '  const _components = {',

--- a/packages/mdx/test/compile.js
+++ b/packages/mdx/test/compile.js
@@ -1154,7 +1154,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('*a*', {jsx: true})),
       [
-        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        '/*@jsxRuntime automatic',
+        '@jsxImportSource react*/',
         'function _createMdxContent(props) {',
         '  const _components = {',
         '    em: "em",',
@@ -1176,7 +1177,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('<a {...b} c d="1" e={1} />', {jsx: true})),
       [
-        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        '/*@jsxRuntime automatic',
+        '@jsxImportSource react*/',
         'function _createMdxContent(props) {',
         '  return <a {...b} c d="1" e={1} />;',
         '}',
@@ -1195,7 +1197,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
       assert.equal(
         String(await compile('<><a:b /><c.d/></>', {jsx: true})),
         [
-          '/*@jsxRuntime automatic @jsxImportSource react*/',
+          '/*@jsxRuntime automatic',
+          '@jsxImportSource react*/',
           'function _createMdxContent(props) {',
           '  const {c} = props.components || ({});',
           '  if (!c) _missingMdxReference("c", false);',
@@ -1219,7 +1222,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('<>a {/* 1 */} b</>', {jsx: true})),
       [
-        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        '/*@jsxRuntime automatic',
+        '@jsxImportSource react*/',
         '/*1*/',
         'function _createMdxContent(props) {',
         '  return <><>{"a "}{}{" b"}</></>;',
@@ -1239,7 +1243,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
       assert.equal(
         String(await compile('{<a-b></a-b>}', {jsx: true})),
         [
-          '/*@jsxRuntime automatic @jsxImportSource react*/',
+          '/*@jsxRuntime automatic',
+          '@jsxImportSource react*/',
           'function _createMdxContent(props) {',
           '  const _components = {',
           '    "a-b": "a-b",',
@@ -1261,7 +1266,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
     assert.equal(
       String(await compile('Hello {props.name}', {jsx: true})),
       [
-        '/*@jsxRuntime automatic @jsxImportSource react*/',
+        '/*@jsxRuntime automatic',
+        '@jsxImportSource react*/',
         'function _createMdxContent(props) {',
         '  const _components = {',
         '    p: "p",',
@@ -1289,7 +1295,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
           )
         ),
         [
-          '/*@jsxRuntime automatic @jsxImportSource react*/',
+          '/*@jsxRuntime automatic',
+          '@jsxImportSource react*/',
           'const MDXLayout = function Layout({components, ...props}) {',
           '  return <section {...props} />;',
           '};',
@@ -1320,7 +1327,8 @@ test('@mdx-js/mdx: compile (JSX)', async function (t) {
           })
         ),
         [
-          '/*@jsxRuntime automatic @jsxImportSource react*/',
+          '/*@jsxRuntime automatic',
+          '@jsxImportSource react*/',
           'import {useMDXComponents as _provideComponents} from "@mdx-js/react";',
           'function _createMdxContent(props) {',
           '  const _components = {',


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Each JSX pragma needs to be on its own line for tools like Babel or TypeScript to understand them.

There is a broken pragma in the @mdx-js/preact tests, which was left untouched. Due to a misconfiguration, to fix it, would break type checking.

<!--do not edit: pr-->
