### PR TITLE
Change webpack peer dependency to optional in loader

### DIFF
--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -47,7 +47,16 @@
     "source-map": "^0.7.0"
   },
   "peerDependencies": {
+    "@rspack/core": "0.x || 1.x",
     "webpack": ">=5"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
   },
   "devDependencies": {},
   "scripts": {

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -47,13 +47,9 @@
     "source-map": "^0.7.0"
   },
   "peerDependencies": {
-    "@rspack/core": "0.x || 1.x",
     "webpack": ">=5"
   },
   "peerDependenciesMeta": {
-    "@rspack/core": {
-      "optional": true
-    },
     "webpack": {
       "optional": true
     }

--- a/packages/loader/readme.md
+++ b/packages/loader/readme.md
@@ -7,7 +7,7 @@
 [![Backers][backers-badge]][collective]
 [![Chat][chat-badge]][chat]
 
-webpack / Rspack loader for MDX.
+webpack loader for MDX.
 
 <!-- more -->
 
@@ -34,7 +34,8 @@ This package is a webpack loader to support MDX.
 
 ## When should I use this?
 
-This integration is useful if you’re using webpack or Rspack (or another tool that uses webpack, such as Next.js).
+This integration is useful if you’re using webpack (or another tool that uses
+webpack, such as Next.js or Rspack).
 
 This integration can be combined with the Babel loader to compile modern
 JavaScript features to ones your users support.

--- a/packages/loader/readme.md
+++ b/packages/loader/readme.md
@@ -7,7 +7,7 @@
 [![Backers][backers-badge]][collective]
 [![Chat][chat-badge]][chat]
 
-webpack loader for MDX.
+webpack / Rspack loader for MDX.
 
 <!-- more -->
 
@@ -34,8 +34,7 @@ This package is a webpack loader to support MDX.
 
 ## When should I use this?
 
-This integration is useful if you’re using webpack (or another tool that uses
-webpack, such as Next.js).
+This integration is useful if you’re using webpack or Rspack (or another tool that uses webpack, such as Next.js).
 
 This integration can be combined with the Babel loader to compile modern
 JavaScript features to ones your users support.


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

[Rspack](https://github.com/web-infra-dev/rspack) is a fast Rust-based web bundler and it is compatible with the architecture and ecosystem of webpack.

The `@mdx-js/loader` can be used with Rspack, but users will get a peer dependency warning, adding peerDependenciesMeta can resolve it. 

The same as: https://github.com/jantimon/html-webpack-plugin/pull/1829 

<!--do not edit: pr-->
