### PR TITLE
add use client directive to react package

### DIFF
--- a/packages/react/lib/index.js
+++ b/packages/react/lib/index.js
@@ -1,3 +1,4 @@
+'use client'
 /**
  * @typedef {import('mdx/types.js').MDXComponents} MDXComponents
  * @typedef {import('react').Component<{}, {}, unknown>} Component


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests

### Description of changes

Frameworks like the Next.js MDX plugin default to `@mdx-js/react` if no `mdx-components` file is present. When this happens, an error is thrown due to `useContext` in `useMDXComponents` and it's not apparent what's going on. This fixes this default use case in Next.js when overriding MDX components is not needed.

<!--do not edit: pr-->
