### PR TITLE
Fix ESM type import in Webpack loader

### DIFF
--- a/packages/loader/index.cjs
+++ b/packages/loader/index.cjs
@@ -1,9 +1,7 @@
 /**
  * @typedef {import('webpack').LoaderContext<unknown>} LoaderContext
+ * @typedef {import('./lib/index.js', {with: {'resolution-mode': 'import'}}).Options} Options
  */
-
-// @ts-expect-error: TS complains about CJS importing ESM but it works.
-/** @typedef {import('./lib/index.js').Options} Options */
 
 'use strict'
 


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

TypeScript 5.3 introduced support for import attributes and `resolution-mode`. This can be used to import types from ESM files into CJS files without a `@ts-ignore` comment.

The `@ts-ignore` comment is stripped from generated type definitions, which leads to a type error for consumers. The module resolution mode is not, which fixes it for users using TypeScript 5.3 or greater.

<!--do not edit: pr-->
