### PR TITLE
Support source maps in the node loader

### DIFF
--- a/packages/node-loader/lib/index.js
+++ b/packages/node-loader/lib/index.js
@@ -61,8 +61,17 @@ export function createLoader(options) {
     if (url.protocol === 'file:' && regex.test(url.pathname)) {
       const value = await fs.readFile(url)
       const file = await process(new VFile({value, path: url}))
+      let source = String(file)
+      /* c8 ignore start -- not sure how to test this. */
+      if (file.map) {
+        source +=
+          '\n//# sourceMappingURL=data:application/json;base64,' +
+          Buffer.from(JSON.stringify(file.map)).toString('base64') +
+          '\n'
+      }
+      /* c8 ignore stop */
 
-      return {format: 'module', shortCircuit: true, source: String(file)}
+      return {format: 'module', shortCircuit: true, source}
     }
 
     return nextLoad(href, context)


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This allows people to debug MDX files when using the Node.js loader. I confirmed this works using the VSCode debugger. I’m not sure how to test this properly.

<!--do not edit: pr-->
