### PR TITLE
Add source maps to esbuild plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28397,6 +28397,7 @@
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/unist": "^3.0.0",
+        "source-map": "^0.7.0",
         "vfile": "^6.0.0",
         "vfile-message": "^4.0.0"
       },
@@ -28478,6 +28479,7 @@
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
+        "source-map": "^0.7.0",
         "vfile": "^6.0.0"
       },
       "devDependencies": {},

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^3.0.0",
     "@types/unist": "^3.0.0",
+    "source-map": "^0.7.0",
     "vfile": "^6.0.0",
     "vfile-message": "^4.0.0"
   },
@@ -48,7 +49,7 @@
   },
   "scripts": {
     "test": "npm run test-coverage",
-    "test-api": "node --conditions development test/index.js",
+    "test-api": "node --conditions development --enable-source-maps test/index.js",
     "test-coverage": "c8 --100 --reporter lcov npm run test-api"
   },
   "xo": {


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This enables source maps in the MDX esbuild plugin. Previously source maps were unsupported, now they are always enabled.

<!--do not edit: pr-->
