### PR TITLE
Add `rehype-mdx-import-media` to list of plugins

### DIFF
--- a/docs/docs/extending-mdx.mdx
+++ b/docs/docs/extending-mdx.mdx
@@ -86,14 +86,14 @@ See also the [list of remark plugins][remark-plugins] and
   exposing top level identifiers in Next.js
 * [`remcohaszing/rehype-mdx-code-props`](https://github.com/remcohaszing/rehype-mdx-code-props)
   — interpret the code `meta` field as JSX props
+* [`remcohaszing/rehype-mdx-import-media`](https://github.com/remcohaszing/rehype-mdx-import-media)
+  — change media sources to JavaScript imports
 * [`remcohaszing/rehype-mdx-title`](https://github.com/remcohaszing/rehype-mdx-title)
   — expose the page title as a string
 * [`pangelani/remark-mdx-chartjs`](https://github.com/pangelani/remark-mdx-chartjs)
   — replace fenced code blocks with charts using [`react-chartjs-2`](https://react-chartjs-2.js.org/).
 * [`remcohaszing/remark-mdx-frontmatter`](https://github.com/remcohaszing/remark-mdx-frontmatter)
   — change frontmatter (YAML) metadata to exports
-* [`remcohaszing/remark-mdx-images`](https://github.com/remcohaszing/remark-mdx-images)
-  — change image sources to JavaScript imports
 * [`goodproblems/remark-mdx-math-enhanced`](https://github.com/goodproblems/remark-mdx-math-enhanced)
   — enhance math with JavaScript inside it
 


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`rehype-mdx-import-media` replaces `remark-mdx-images`. It supports more use cases, and works with other rehype plugins.

<!--do not edit: pr-->
