### PR TITLE
Fix size of hero heading in some cases

### DIFF
--- a/docs/_asset/index.css
+++ b/docs/_asset/index.css
@@ -1213,7 +1213,7 @@ details[open] {
 
 @media (min-width: 76em) {
   #markdown-for-thecomponent-era {
-    font-size: 6rem;
+    font-size: 5.9rem;
     line-height: calc(1em + (1 / 6 * 1ex));
     margin-block: calc(1 / 6 * (1em + 1ex));
   }


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description

I noticed that the heading of the hero section is spanning in 3 lines, leaving quite some blank in the 2nd line. I thought that condensing it to 2 lines would result in a much better and cleaner layout, hence this PR.

Before:
![Screenshot from 2024-05-08 14-54-03](https://github.com/mdx-js/mdx/assets/65856786/45fbc9df-7265-422b-9818-badb5d2458b9)

After:
![Screenshot from 2024-05-08 14-54-17](https://github.com/mdx-js/mdx/assets/65856786/6ba8d113-80e2-4011-be2b-e283af97f163)

I'd love to hear your thoughts about this.

#### Changes
I decreased the font size of the heading from `6rem` (or 108px) to `5.9rem` (or 106.2px).

<!--do not edit: pr-->
