### PR TITLE
Updated the site banner

### DIFF
--- a/docs/_component/nav-site.jsx
+++ b/docs/_component/nav-site.jsx
@@ -43,7 +43,7 @@ export function NavigationSite(properties) {
 
   return (
     <nav className="navigation" aria-label="Site navigation">
-      <div id="banner">Ceasefire now! 🕊️</div>
+      <div id="banner">Release the Israeli hostages now! 🕊️</div>
       <a
         href="#start-of-content"
         id="start-of-navigation"


### PR DESCRIPTION
This PR changes the top banner from `Ceasefire now` to `Release the Israeli hostages now`.

For those with a short memory, here's a reminder that there was a ceasefire on Oct. 6, just before the Palestinians decided to launch a terror attack against Israel - butchering, raping, and burning alive more than 1,200 Israeli citizens.

As of writing these lines, there are still **120 hostages**, including young children, being held by the Palestinians terrorist groups in Gaza. They refuse to release them because **they don't want a ceasefire**. They want to terrorize Israel out of existence.

So when you call for a "Ceasefire now", what you're essentially saying is - let the terror win, let the hostages die, and don't let Israel defend itself against blood thirsty maniacs. 

That's a shameful message. Open your eyes and change it by approving this PR.