### PR TITLE
Add Bun section to Getting started

### DIFF
--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -817,9 +817,23 @@ See its readme on how to configure it.
 
 #### Bun
 
-MDX files can be imported in Bun by using
+MDX files can be imported in [Bun][] by using
 [`@mdx-js/esbuild`][mdx-esbuild].
-See [the section above][bundler-esbuild] on how to configure it.
+
+<details>
+  <summary>Expand example</summary>
+
+  ```toml path="bunfig.toml"
+  preload = ["./bunMdxEsbuild.ts"]
+  ```
+
+  ```js twoslash path="bunMdxEsbuild.ts"
+  import {plugin} from 'bun'
+  import mdx from '@mdx-js/esbuild'
+
+  plugin(mdx())
+  ```
+</details>
 
 ## Further reading
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -234,22 +234,9 @@ etc.) you use.
 To use more modern JavaScript features than what your users support,
 [configure esbuild’s `target`][esbuild-target].
 
-`@mdx-js/esbuild` can also be used with [Bun][]:
-
-<details>
-  <summary>Expand example</summary>
-
-  ```toml path="bunfig.toml"
-  preload = ["./bunMdxEsbuild.ts"]
-  ```
-
-  ```js twoslash path="bunMdxEsbuild.ts"
-  import {plugin} from 'bun'
-  import mdx from '@mdx-js/esbuild'
-
-  plugin(mdx())
-  ```
-</details>
+See also [¶ Bun][javascript-engines-bun],
+which you might be using,
+for more info.
 
 #### Rollup
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -935,7 +935,9 @@ MDX files can be imported in [Bun][] by using
 
 [build-system-vite]: #vite
 
-[bun]: https://bun.sh/
+[bun]: https://bun.sh
+
+[javascript-engines-bun]: #bun
 
 [bundler-esbuild]: #esbuild
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -811,10 +811,10 @@ MDX files can be imported in [Bun][] by using
   <summary>Expand example</summary>
 
   ```toml path="bunfig.toml"
-  preload = ["./bunMdxEsbuild.ts"]
+  preload = ["./bun-mdx.ts"]
   ```
 
-  ```js twoslash path="bunMdxEsbuild.ts"
+  ```js twoslash path="bun-mdx.ts"
   import {plugin} from 'bun'
   import mdx from '@mdx-js/esbuild'
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -234,6 +234,23 @@ etc.) you use.
 To use more modern JavaScript features than what your users support,
 [configure esbuild’s `target`][esbuild-target].
 
+`@mdx-js/esbuild` can also be used with [Bun][]:
+
+<details>
+  <summary>Expand example</summary>
+
+  ```toml path="bunfig.toml"
+  preload = ["./bunMdxEsbuild.ts"]
+  ```
+
+  ```js twoslash path="bunMdxEsbuild.ts"
+  import {plugin} from 'bun'
+  import mdx from '@mdx-js/esbuild'
+
+  plugin(mdx())
+  ```
+</details>
+
 #### Rollup
 
 <details>
@@ -910,6 +927,8 @@ See its readme on how to configure it.
 [api-processor-options]: /packages/mdx/#processoroptions
 
 [build-system-vite]: #vite
+
+[bun]: https://bun.sh/
 
 [bundler-esbuild]: #esbuild
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -62,7 +62,7 @@ MDX is a language that’s compiled to JavaScript.
 The easiest way to get started is to use an integration for your bundler if you
 have one:
 
-* if you use **esbuild**,
+* if you use **esbuild** (or Bun),
   install and configure [`@mdx-js/esbuild`][mdx-esbuild]
 * if you use **Rollup** (or Vite),
   install and configure [`@mdx-js/rollup`][mdx-rollup]
@@ -814,6 +814,12 @@ for more info.
 MDX files can be imported in Node by using
 [`@mdx-js/node-loader`][mdx-node-loader].
 See its readme on how to configure it.
+
+#### Bun
+
+MDX files can be imported in Bun by using
+[`@mdx-js/esbuild`][mdx-esbuild].
+See [the section above][bundler-esbuild] on how to configure it.
 
 ## Further reading
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add footnote to `@mdx-js/esbuild` section that Bun is supported via the esbuild-compatible plugin API (I confirmed support and [Bun docs confirm it too](https://bun.sh/docs/runtime/plugins#third-party-plugins))

This actually also enables MDX eval support in scripts, which is not a straightforward thing to set up with `esbuild` (because [the Transform API, used by programs like `tsx`, does not support plugins](https://github.com/privatenumber/tsx/issues/491#issuecomment-1987041573))

### Alternatives considered

1. Don't include a code block, but rather link to https://bun.sh/docs/runtime/plugins#third-party-plugins. downsides:
   1. these docs are not dedicated to `@mdx-js/esbuild`, so it could disappear at any time
   2. it's not a full example to be used on its own
2. Add this instead to https://mdxjs.com/packages/esbuild/ . downsides:
   1. less discoverable (no ability to `cmd-f` -> search for "Bun" on "Getting Started" page)

<!--do not edit: pr-->
