### PR TITLE
Fix types, lints in example

### DIFF
--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -816,7 +816,7 @@ MDX files can be imported in [Bun][] by using
 
   ```js twoslash path="bun-mdx.ts"
   import mdx from '@mdx-js/esbuild'
-  import { BunPlugin, plugin } from 'bun'
+  import {type BunPlugin, plugin} from 'bun'
 
   await plugin(mdx() as unknown as BunPlugin)
   ```

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -815,10 +815,10 @@ MDX files can be imported in [Bun][] by using
   ```
 
   ```js twoslash path="bun-mdx.ts"
-  import {plugin} from 'bun'
-  import mdx from '@mdx-js/esbuild'
+  import mdx from '@mdx-js/esbuild';
+  import { BunPlugin, plugin } from 'bun';
 
-  plugin(mdx())
+  await plugin(mdx() as unknown as BunPlugin);
   ```
 </details>
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -815,10 +815,10 @@ MDX files can be imported in [Bun][] by using
   ```
 
   ```js twoslash path="bun-mdx.ts"
-  import mdx from '@mdx-js/esbuild';
-  import { BunPlugin, plugin } from 'bun';
+  import mdx from '@mdx-js/esbuild'
+  import { BunPlugin, plugin } from 'bun'
 
-  await plugin(mdx() as unknown as BunPlugin);
+  await plugin(mdx() as unknown as BunPlugin)
   ```
 </details>
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Small follow-up to #2517 to address the type checking and linting problems with the original code from the Bun docs

```
Argument of type 'Plugin' is not assignable to parameter of type 'BunPlugin'.
  Types of property 'setup' are incompatible.
    Type '(build: PluginBuild) => void | Promise<void>' is not assignable to type '(build: PluginBuilder) => void | Promise<void>'.
      Types of parameters 'build' and 'build' are incompatible.
        Type 'PluginBuilder' is missing the following properties from type 'PluginBuild': initialOptions, resolve, onStart, onEnd, and 2 more. ts (2345)
```

```
Promises must be awaited, end with a call to .catch, or end with a call to .then with a rejection handler. eslint (@typescript-eslint/no-floating-promises)
```

<!--do not edit: pr-->
