### PR TITLE
Add recmaJsxPlugins hook point, and update docs accordingly

### DIFF
--- a/docs/docs/extending-mdx.mdx
+++ b/docs/docs/extending-mdx.mdx
@@ -120,7 +120,7 @@ See also the [list of remark plugins][remark-plugins],
 Where to pass plugins is encoded in their name:
 remark plugins go in `remarkPlugins`,
 rehype plugins go in `rehypePlugins`,
-and recma plugins go in `recmaPlugins` (or `recmaJsxPlugins`) of
+and recma plugins go in `recmaPlugins` of
 [`ProcessorOptions`][processor-options].
 Those fields expect lists of plugins and/or of `[plugin, options]`:
 

--- a/docs/docs/extending-mdx.mdx
+++ b/docs/docs/extending-mdx.mdx
@@ -120,7 +120,7 @@ See also the [list of remark plugins][remark-plugins],
 Where to pass plugins is encoded in their name:
 remark plugins go in `remarkPlugins`,
 rehype plugins go in `rehypePlugins`,
-and recma plugins go in `recmaPlugins` of
+and recma plugins go in `recmaPlugins` (or `recmaJsxPlugins`) of
 [`ProcessorOptions`][processor-options].
 Those fields expect lists of plugins and/or of `[plugin, options]`:
 

--- a/packages/mdx/lib/core.js
+++ b/packages/mdx/lib/core.js
@@ -99,25 +99,22 @@
  *   `mdx/types.js`).
  * @property {PluggableList | null | undefined} [recmaPlugins]
  *   List of [recma plugins](https://github.com/mdx-js/recma#readme) (optional)
- *   to apply to the final Javascript syntax tree about to be output. Unless
- *   `jsx: true` is set, these plugins see vanilla JS with JSX rewritten.
- * @property {PluggableList | null | undefined} [recmaJsxPlugins]
- *   List of [recma plugins](https://github.com/mdx-js/recma#readme) (optional)
- *   to apply to the Javascript-with-JSX tree before JSX tags are rewritten.
+ *   to apply to the final Javascript syntax tree about to be output
+ *   (with JSX exceptions if `jsx: true` is set).
  * @property {PluggableList | null | undefined} [remarkPlugins]
  *   List of [remark plugins](https://github.com/remarkjs/remark#readme)
- *   (optional) to apply to the parsed markdown-with-JSX (aka MDX) tree just
- *   before conversion to HTML-with-JSX.
+ *   (optional) to apply to the parsed markdown tree (with MDX extensions)
+ *   just before conversion to HTML.
  * @property {PluggableList | null | undefined} [rehypePlugins]
  *   List of [rehype plugins](https://github.com/rehypejs/rehype#readme)
- *   (optional) to apply to the HTML-with-JSX tree just before conversion to
- *   Javascript-with-JSX.
+ *   (optional) to apply to the HTML tree (with MDX extensions) just before
+ *   conversion to Javascript.
  * @property {Readonly<RemarkRehypeOptions> | null | undefined} [remarkRehypeOptions]
- *   Options to pass to `remark-rehype`, which converts
- *   markdown-with-JSX to HTML-with-JSX (optional); the option
- *   `allowDangerousHtml` will always be set to `true` and MDX nodes
- *   (see `nodeTypes`) are passed through; in particular, you might want to
- *   pass configuration for footnotes if your content is not in English.
+ *   Options to pass to `remark-rehype` (optional) to control conversion of
+ *   markdown to HTML; the option `allowDangerousHtml` will always be
+ *   overridden to `true`, and MDX extension nodes (see `nodeTypes`) are always
+ *   passed through. In particular, you might want to adjust footnote
+ *   configuration here if your content is not in English.
  * @property {RehypeRecmaOptions['stylePropertyNameCase']} [stylePropertyNameCase='dom']
  *   Casing to use for property names in `style` objects (default: `'dom'`);
  *   CSS casing is for example `background-color` and `-webkit-line-clamp`;
@@ -222,7 +219,6 @@ export function createProcessor(options) {
     .use(settings.rehypePlugins || [])
 
   if (settings.format === 'md') {
-    // Should this come before rehypePlugins?
     pipeline.use(rehypeRemoveRaw)
   }
 
@@ -238,9 +234,8 @@ export function createProcessor(options) {
   }
 
   pipeline
-    .use(settings.recmaJsxPlugins || [])
     .use(recmaJsx)
-    .use(recmaStringify, settings) // Move recmaStringify after recmaPlugins?
+    .use(recmaStringify, settings)
     .use(settings.recmaPlugins || [])
 
   // @ts-expect-error: TS doesn’t get the plugins we added with if-statements.

--- a/packages/mdx/lib/core.js
+++ b/packages/mdx/lib/core.js
@@ -98,19 +98,26 @@
  *   without arguments to get an object of components (`MDXComponents` from
  *   `mdx/types.js`).
  * @property {PluggableList | null | undefined} [recmaPlugins]
- *   List of recma plugins (optional);
- *   this is a new ecosystem, currently in beta, to transform esast trees
- *   (JavaScript)
+ *   List of [recma plugins](https://github.com/mdx-js/recma#readme) (optional)
+ *   to apply to the final Javascript syntax tree about to be output. Unless
+ *   `jsx: true` is set, these plugins see vanilla JS with JSX rewritten.
+ * @property {PluggableList | null | undefined} [recmaJsxPlugins]
+ *   List of [recma plugins](https://github.com/mdx-js/recma#readme) (optional)
+ *   to apply to the Javascript-with-JSX tree before JSX tags are rewritten.
  * @property {PluggableList | null | undefined} [remarkPlugins]
- *   List of remark plugins (optional).
+ *   List of [remark plugins](https://github.com/remarkjs/remark#readme)
+ *   (optional) to apply to the parsed markdown-with-JSX (aka MDX) tree just
+ *   before conversion to HTML-with-JSX.
  * @property {PluggableList | null | undefined} [rehypePlugins]
- *   List of rehype plugins (optional).
+ *   List of [rehype plugins](https://github.com/rehypejs/rehype#readme)
+ *   (optional) to apply to the HTML-with-JSX tree just before conversion to
+ *   Javascript-with-JSX.
  * @property {Readonly<RemarkRehypeOptions> | null | undefined} [remarkRehypeOptions]
- *   Options to pass through to `remark-rehype` (optional);
- *   the option `allowDangerousHtml` will always be set to `true` and the MDX
- *   nodes (see `nodeTypes`) are passed through;
- *   In particular, you might want to pass configuration for footnotes if your
- *   content is not in English.
+ *   Options to pass to `remark-rehype`, which converts
+ *   markdown-with-JSX to HTML-with-JSX (optional); the option
+ *   `allowDangerousHtml` will always be set to `true` and MDX nodes
+ *   (see `nodeTypes`) are passed through; in particular, you might want to
+ *   pass configuration for footnotes if your content is not in English.
  * @property {RehypeRecmaOptions['stylePropertyNameCase']} [stylePropertyNameCase='dom']
  *   Casing to use for property names in `style` objects (default: `'dom'`);
  *   CSS casing is for example `background-color` and `-webkit-line-clamp`;
@@ -215,6 +222,7 @@ export function createProcessor(options) {
     .use(settings.rehypePlugins || [])
 
   if (settings.format === 'md') {
+    // Should this come before rehypePlugins?
     pipeline.use(rehypeRemoveRaw)
   }
 
@@ -230,8 +238,9 @@ export function createProcessor(options) {
   }
 
   pipeline
+    .use(settings.recmaJsxPlugins || [])
     .use(recmaJsx)
-    .use(recmaStringify, settings)
+    .use(recmaStringify, settings) // Move recmaStringify after recmaPlugins?
     .use(settings.recmaPlugins || [])
 
   // @ts-expect-error: TS doesn’t get the plugins we added with if-statements.

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -918,15 +918,10 @@ Configuration for `createProcessor` (TypeScript type).
 
   </details>
 
-* `recmaJsxPlugins` ([`PluggableList` from `unified`][unified-pluggable-list],
-  optional)
-  — list of [recma plugins][recma] to apply to the Javascript-with-JSX syntax
-  tree before JSX tags are rewritten to vanilla JS.
-
 * `rehypePlugins` ([`PluggableList` from `unified`][unified-pluggable-list],
   optional)
-  — list of [rehype plugins][rehype-plugins] to apply to the HTML-with-JSX
-  syntax tree just before conversion to Javascript-with-JSX.
+  — list of [rehype plugins][rehype-plugins] to apply to the HTML syntax tree
+  (with MDX extensions) just before conversion to Javascript.
 
   <details><summary>Expand example</summary>
 
@@ -948,8 +943,7 @@ Configuration for `createProcessor` (TypeScript type).
 * `remarkPlugins` ([`PluggableList` from `unified`][unified-pluggable-list],
   optional)
   — list of [remark plugins][remark-plugins] to apply to the
-  markdown-with-JSX (aka MDX) syntax tree just before conversion to
-  HTML-with-JSX.
+  markdown syntax tree (with MDX extensions) just before conversion to HTML.
 
   <details><summary>Expand example</summary>
 
@@ -967,11 +961,11 @@ Configuration for `createProcessor` (TypeScript type).
 
 * `remarkRehypeOptions` ([`Options` from
   `remark-rehype`][remark-rehype-options], optional)
-  — options to pass to `remark-rehype`, which converts markdown-with-JSX to
-  HTML-with-JSX; the option `allowDangerousHtml` will always be set to `true`
-  and MDX nodes (see [`nodeTypes`][api-node-types]) are passed through;
-  in particular, you might want to pass configuration for footnotes if your
-  content is not in English
+  — options to pass to `remark-rehype` to control conversion of markdown
+  to HTML; the option `allowDangerousHtml` will always be overriden to `true`,
+  and MDX extension nodes (see [`nodeTypes`][api-node-types]) are always
+  passed through. in particular, you might want to adjust footnote
+  configuration if your content is not in English
 
   <details><summary>Expand example</summary>
 
@@ -1142,10 +1136,10 @@ Then we go to JavaScript: [esast][] (JS; an
 AST which is compatible with estree but looks a bit more like other unist ASTs).
 This transformation is done by
 [`rehype-recma`][rehype-recma].
-This is a new ecosystem that does not have many utilities or plugins yet.
+This is a new ecosystem that does not have utilities or plugins yet.
 But it’s where `@mdx-js/mdx` does its thing: where it adds imports/exports,
-where it compiles JSX away into `_jsx()` calls, and where it does the other
-cool things that it provides.
+where it compiles JSX away into `_jsx()` calls, and where it does the other cool
+things that it provides.
 
 Finally, The output is serialized JavaScript.
 That final step is done by [astring][], a

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -905,9 +905,8 @@ Configuration for `createProcessor` (TypeScript type).
 
 * `recmaPlugins` ([`PluggableList` from `unified`][unified-pluggable-list],
   optional)
-  — list of recma plugins;
-  this is a new ecosystem, currently in beta, to transform [esast][] trees
-  (JavaScript)
+  — list of [recma plugins](https://github.com/mdx-js/recma#readme)
+  to apply to the final Javascript syntax tree about to be output.
 
   <details><summary>Expand example</summary>
 
@@ -919,9 +918,16 @@ Configuration for `createProcessor` (TypeScript type).
 
   </details>
 
+* `recmaJsxPlugins` ([`PluggableList` from `unified`][unified-pluggable-list],
+  optional)
+  — list of [recma plugins](https://github.com/mdx-js/recma#readme)
+  to apply to the Javascript-with-JSX syntax tree before JSX tags are
+  rewritten to vanilla JS.
+
 * `rehypePlugins` ([`PluggableList` from `unified`][unified-pluggable-list],
   optional)
-  — list of [rehype plugins][rehype-plugins]
+  — list of [rehype plugins][rehype-plugins] to apply to the HTML-with-JSX
+  syntax tree just before conversion to Javascript-with-JSX.
 
   <details><summary>Expand example</summary>
 
@@ -942,7 +948,9 @@ Configuration for `createProcessor` (TypeScript type).
 
 * `remarkPlugins` ([`PluggableList` from `unified`][unified-pluggable-list],
   optional)
-  — list of [remark plugins][remark-plugins]
+  — list of [remark plugins][remark-plugins] to apply to the
+  markdown-with-JSX (aka MDX) syntax tree just before conversion to
+  HTML-with-JSX.
 
   <details><summary>Expand example</summary>
 
@@ -960,10 +968,10 @@ Configuration for `createProcessor` (TypeScript type).
 
 * `remarkRehypeOptions` ([`Options` from
   `remark-rehype`][remark-rehype-options], optional)
-  — options to pass through to `remark-rehype`;
-  the option `allowDangerousHtml` will always be set to `true` and the MDX
-  nodes (see [`nodeTypes`][api-node-types]) are passed through;
-  In particular, you might want to pass configuration for footnotes if your
+  — options to pass to `remark-rehype`, which converts markdown-with-JSX to
+  HTML-with-JSX; the option `allowDangerousHtml` will always be set to `true`
+  and MDX nodes (see [`nodeTypes`][api-node-types]) are passed through;
+  in particular, you might want to pass configuration for footnotes if your
   content is not in English
 
   <details><summary>Expand example</summary>
@@ -1135,10 +1143,10 @@ Then we go to JavaScript: [esast][] (JS; an
 AST which is compatible with estree but looks a bit more like other unist ASTs).
 This transformation is done by
 [`rehype-recma`][rehype-recma].
-This is a new ecosystem that does not have utilities or plugins yet.
+This is a new ecosystem that does not have many utilities or plugins yet.
 But it’s where `@mdx-js/mdx` does its thing: where it adds imports/exports,
-where it compiles JSX away into `_jsx()` calls, and where it does the other cool
-things that it provides.
+where it compiles JSX away into `_jsx()` calls, and where it does the other
+cool things that it provides.
 
 Finally, The output is serialized JavaScript.
 That final step is done by [astring][], a

--- a/packages/mdx/readme.md
+++ b/packages/mdx/readme.md
@@ -905,8 +905,8 @@ Configuration for `createProcessor` (TypeScript type).
 
 * `recmaPlugins` ([`PluggableList` from `unified`][unified-pluggable-list],
   optional)
-  — list of [recma plugins](https://github.com/mdx-js/recma#readme)
-  to apply to the final Javascript syntax tree about to be output.
+  — list of [recma plugins][recma] to apply to the final Javascript syntax
+  tree about to be output.
 
   <details><summary>Expand example</summary>
 
@@ -920,9 +920,8 @@ Configuration for `createProcessor` (TypeScript type).
 
 * `recmaJsxPlugins` ([`PluggableList` from `unified`][unified-pluggable-list],
   optional)
-  — list of [recma plugins](https://github.com/mdx-js/recma#readme)
-  to apply to the Javascript-with-JSX syntax tree before JSX tags are
-  rewritten to vanilla JS.
+  — list of [recma plugins][recma] to apply to the Javascript-with-JSX syntax
+  tree before JSX tags are rewritten to vanilla JS.
 
 * `rehypePlugins` ([`PluggableList` from `unified`][unified-pluggable-list],
   optional)
@@ -1270,6 +1269,8 @@ abide by its terms.
 [mit]: https://github.com/mdx-js/mdx/blob/main/packages/mdx/license
 
 [npm]: https://docs.npmjs.com/cli/install
+
+[recma]: https://github.com/mdx-js/recma#readme
 
 [rehype-highlight]: https://github.com/rehypejs/rehype-highlight
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Per discussion at https://github.com/orgs/mdx-js/discussions/2581 I think it might make sense to add another
point for recma plugins which want to process Javascript with JSX tags still in, before the JSX is rewritten.
My use case is to implement pseudotags like `<$if>` and `<$for>` but I could imagine a number of other use cases.
This is the point at which tag content is maximally consistent -- Markdown, HTML-in-markdown and
components-in-markdown have all been rewritten into standard JSX nodes at this point.

I also expanded the documentation a bit to clarify exactly where in the stack the user plugins are added,
since that would have been helpful for me to know.

<!--do not edit: pr-->
