### PR TITLE
esbuild plugin: use esbuild "jsx" loader if output is JSX

### DIFF
--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -142,7 +142,7 @@ export function esbuild(options) {
       return {
         contents: value || '',
         errors,
-        loader: options.jsx ? 'jsx' : 'js',
+        loader: options?.jsx ? 'jsx' : 'js',
         resolveDir: path.resolve(file.cwd, file.dirname),
         warnings
       }

--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -142,6 +142,7 @@ export function esbuild(options) {
       return {
         contents: value || '',
         errors,
+        loader: options.jsx ? 'jsx' : 'js',
         resolveDir: path.resolve(file.cwd, file.dirname),
         warnings
       }

--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -66,10 +66,8 @@ const name = '@mdx-js/esbuild'
  *   Plugin.
  */
 export function esbuild(options) {
-  const {extnames, process} = createFormatAwareProcessors({
-    ...options,
-    SourceMapGenerator
-  })
+  const settings = {...options, SourceMapGenerator};
+  const {extnames, process} = createFormatAwareProcessors(settings)
 
   return {name, setup}
 
@@ -142,7 +140,7 @@ export function esbuild(options) {
       return {
         contents: value || '',
         errors,
-        loader: options?.jsx ? 'jsx' : 'js',
+        loader: settings.jsx ? 'jsx' : 'js',
         resolveDir: path.resolve(file.cwd, file.dirname),
         warnings
       }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

In the esbuild plugin, if the MDX pipeline is configured to output unprocessed JSX (via `jsx: true` in its options), have esbuild expect JSX (via `loader: "jsx"` instead of the default `"js"`). This allows users to freely choose whether the JSX-to-JS processing happens in the MDX pipeline or in esbuild (both are capable of doing it).

<!--do not edit: pr-->
