### PR TITLE
Error handling improvements to esbuild plugin

### DIFF
--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -117,12 +117,11 @@ export function esbuild(options) {
           '\n'
         messages = file.messages
       } catch (error_) {
-        const cause = /** @type (VFileMessage | Error) */ (error_)
         const message =
           new VFileMessage(
-            `Cannot process MDX file with esbuild:\n  ${error_}`, {
-            cause,
-            place: 'reason' in cause ? cause.place : undefined,
+            `Cannot process MDX file with esbuild`, {
+            cause: /** @type (VFileMessage | Error) */ (error_),
+            place: error_ instanceof VFileMessage ? error_.place : undefined,
             ruleId: 'process-error',
             source: '@mdx-js/esbuild'
           })
@@ -198,12 +197,20 @@ function vfileMessageToEsbuild(state, message) {
     location.length = Math.min(location.length, maxLength)
   }
 
+  /** @type {Error} */
+  var exc = message
+  var text = message.reason
+  while (exc.cause instanceof Error) {
+    exc = exc.cause
+    text = `${text}:\n  ${exc}`
+  }
+
   return {
     detail: message,
     id: '',
     location,
     notes: [],
     pluginName: state.name,
-    text: message.reason
+    text,
   }
 }

--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -118,14 +118,15 @@ export function esbuild(options) {
         messages = file.messages
       } catch (error_) {
         const cause = /** @type {VFileMessage | Error} */ (error_)
-        const message =
-          new VFileMessage(
-            'Cannot process MDX file with esbuild', {
+        const message = new VFileMessage(
+          'Cannot process MDX file with esbuild',
+          {
             cause,
             place: 'reason' in cause ? cause.place : undefined,
             ruleId: 'process-error',
             source: '@mdx-js/esbuild'
-          })
+          }
+        )
         message.fatal = true
         messages.push(message)
       }
@@ -159,14 +160,14 @@ export function esbuild(options) {
  */
 function vfileMessageToEsbuild(state, message) {
   /** @type {Location} */
-  let location = {
+  const location = {
     column: 0,
     file: state.path,
     length: 0,
     line: 0,
     lineText: '',
     namespace: 'file',
-    suggestion: '',
+    suggestion: ''
   }
 
   const place = message.place
@@ -179,9 +180,9 @@ function vfileMessageToEsbuild(state, message) {
     const end = place && 'end' in place ? place.end : undefined
     if (end) {
       if (start.offset !== undefined && end.offset !== undefined) {
-        location.length = end.offset - start.offset;
+        location.length = end.offset - start.offset
       } else if (end.line === start.line) {
-        location.length = end.column - start.column;
+        location.length = end.column - start.column
       }
     }
 
@@ -199,8 +200,8 @@ function vfileMessageToEsbuild(state, message) {
   }
 
   /** @type {Error} */
-  var exc = message
-  var text = message.reason
+  let exc = message
+  let text = message.reason
   while (exc.cause instanceof Error) {
     exc = exc.cause
     text = `${text}:\n  ${exc}`
@@ -212,6 +213,6 @@ function vfileMessageToEsbuild(state, message) {
     location,
     notes: [],
     pluginName: state.name,
-    text,
+    text
   }
 }

--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -122,7 +122,7 @@ export function esbuild(options) {
           new VFileMessage(
             `Cannot process MDX file with esbuild:\n  ${error_}`, {
             cause,
-            place: ('reason' in cause && cause.place) || undefined,
+            place: 'reason' in cause ? cause.place : undefined,
             ruleId: 'process-error',
             source: '@mdx-js/esbuild'
           })

--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -117,10 +117,10 @@ export function esbuild(options) {
           '\n'
         messages = file.messages
       } catch (error_) {
-        const cause = /** @type (VFileMessage | Error) */ error_
+        const cause = /** @type {VFileMessage | Error} */ (error_)
         const message =
           new VFileMessage(
-            `Cannot process MDX file with esbuild`, {
+            'Cannot process MDX file with esbuild', {
             cause,
             place: 'reason' in cause ? cause.place : undefined,
             ruleId: 'process-error',

--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -117,11 +117,12 @@ export function esbuild(options) {
           '\n'
         messages = file.messages
       } catch (error_) {
+        const cause = /** @type (VFileMessage | Error) */ error_
         const message =
           new VFileMessage(
             `Cannot process MDX file with esbuild`, {
-            cause: /** @type (VFileMessage | Error) */ (error_),
-            place: error_ instanceof VFileMessage ? error_.place : undefined,
+            cause,
+            place: 'reason' in cause ? cause.place : undefined,
             ruleId: 'process-error',
             source: '@mdx-js/esbuild'
           })

--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -199,12 +199,9 @@ function vfileMessageToEsbuild(state, message) {
     location.length = Math.min(location.length, maxLength)
   }
 
-  /** @type {Error} */
-  let exc = message
   let text = message.reason
-  while (exc.cause instanceof Error) {
-    exc = exc.cause
-    text = `${text}:\n  ${exc}`
+  if (message.cause) {
+    text = `${text}:\n  ${message.cause}`
   }
 
   return {

--- a/packages/esbuild/lib/index.js
+++ b/packages/esbuild/lib/index.js
@@ -1,6 +1,7 @@
 /**
  * @import {CompileOptions} from '@mdx-js/mdx'
  * @import {
+      Location,
       Message,
       OnLoadArgs,
       OnLoadResult,
@@ -116,15 +117,15 @@ export function esbuild(options) {
           '\n'
         messages = file.messages
       } catch (error_) {
-        const cause = /** @type {VFileMessage | Error} */ (error_)
+        const place = typeof error_.reason === 'string' && error_.place
         const message =
-          'reason' in cause
-            ? cause
-            : new VFileMessage('Cannot process MDX file with esbuild', {
-                cause,
-                ruleId: 'process-error',
-                source: '@mdx-js/esbuild'
-              })
+          new VFileMessage(
+            `Cannot process MDX file with esbuild:\n  ${error_}`, {
+            cause: error_,
+            place,
+            ruleId: 'process-error',
+            source: '@mdx-js/esbuild'
+          })
         message.fatal = true
         messages.push(message)
       }
@@ -157,42 +158,51 @@ export function esbuild(options) {
  *   ESBuild message.
  */
 function vfileMessageToEsbuild(state, message) {
-  const place = message.place
-  const start = place ? ('start' in place ? place.start : place) : undefined
-  const end = place && 'end' in place ? place.end : undefined
-  let length = 0
-  let lineStart = 0
-  let line = 0
-  let column = 0
-
-  if (start && start.offset !== undefined) {
-    line = start.line
-    column = start.column - 1
-    lineStart = start.offset - column
-    length = 1
-
-    if (end && end.offset !== undefined) {
-      length = end.offset - start.offset
-    }
+  /** @type {Location} */
+  let location = {
+    column: 0,
+    file: state.path,
+    length: 0,
+    line: 0,
+    lineText: '',
+    namespace: 'file',
+    suggestion: '',
   }
 
-  eol.lastIndex = lineStart
+  const place = message.place
+  const start = place ? ('start' in place ? place.start : place) : undefined
+  if (start) {
+    location.column = start.column - 1
+    location.line = start.line
+    location.length = 1
 
-  const match = eol.exec(state.doc)
-  const lineEnd = match ? match.index : state.doc.length
+    const end = place && 'end' in place ? place.end : undefined
+    if (end) {
+      if (end.offset >= start.offset) {
+        location.length = end.offset - start.offset;
+      } else if (end.line == start.line) {
+        location.length = end.column - start.column;
+      }
+
+      const maxLength = state.doc.length - (start.offset || 0)
+      location.length = Math.min(location.length, maxLength)
+    }
+
+    if (start.offset !== undefined) {
+      eol.lastIndex = start.offset
+      const match = eol.exec(state.doc)
+      const lineStart = start.offset - (start.column - 1)
+      const lineEnd = match ? match.index : state.doc.length
+      location.lineText = state.doc.slice(lineStart, lineEnd)
+
+      location.length = Math.min(location.length, lineEnd - (start.offset || 0))
+    }
+  }
 
   return {
     detail: message,
     id: '',
-    location: {
-      column,
-      file: state.path,
-      length: Math.min(length, lineEnd),
-      line,
-      lineText: state.doc.slice(lineStart, lineEnd),
-      namespace: 'file',
-      suggestion: ''
-    },
+    location,
     notes: [],
     pluginName: state.name,
     text: message.reason

--- a/packages/esbuild/test/index.js
+++ b/packages/esbuild/test/index.js
@@ -366,7 +366,7 @@ test('@mdx-js/esbuild', async function (t) {
               file: 'test/esbuild.mdx',
               length: 11,
               line: 3,
-              lineText: '',  // Not available when place.offset is deleted
+              lineText: '',
               namespace: 'file',
               suggestion: ''
             },

--- a/packages/esbuild/test/index.js
+++ b/packages/esbuild/test/index.js
@@ -231,8 +231,7 @@ test('@mdx-js/esbuild', async function (t) {
         },
         notes: [],
         pluginName: '@mdx-js/esbuild',
-        text:
-          'Cannot process MDX file with esbuild:\n  1:12: Unexpected character `/` (U+002F) before local name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a link in MDX, use `[text](url)`)'
+        text: 'Cannot process MDX file with esbuild:\n  1:12: Unexpected character `/` (U+002F) before local name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a link in MDX, use `[text](url)`)'
       })
     }
 

--- a/packages/esbuild/test/index.js
+++ b/packages/esbuild/test/index.js
@@ -415,7 +415,8 @@ test('@mdx-js/esbuild', async function (t) {
         file.message('3', tree)
         file.message('4', esm)
         file.message('5', text)
-        delete file.message('6', jsx).place.start.offset
+        const m6 = file.message('6', jsx)
+        if (m6.place && 'start' in m6.place) delete m6.place.start.offset
         file.message('7', head.position.end).fatal = true // End of heading
       }
     }

--- a/packages/esbuild/test/index.js
+++ b/packages/esbuild/test/index.js
@@ -416,7 +416,9 @@ test('@mdx-js/esbuild', async function (t) {
         file.message('4', esm)
         file.message('5', text)
         const m6 = file.message('6', jsx)
-        if (m6.place && 'start' in m6.place) delete m6.place.start.offset
+        assert(m6.place)
+        assert('start' in m6.place)
+        delete m6.place.start.offset
         file.message('7', head.position.end).fatal = true // End of heading
       }
     }

--- a/packages/esbuild/test/index.js
+++ b/packages/esbuild/test/index.js
@@ -231,7 +231,8 @@ test('@mdx-js/esbuild', async function (t) {
         },
         notes: [],
         pluginName: '@mdx-js/esbuild',
-        text: 'Cannot process MDX file with esbuild:\n  1:12: Unexpected character `/` (U+002F) before local name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a link in MDX, use `[text](url)`)'
+        text:
+          'Cannot process MDX file with esbuild:\n  1:12: Unexpected character `/` (U+002F) before local name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a link in MDX, use `[text](url)`)'
       })
     }
 
@@ -365,7 +366,7 @@ test('@mdx-js/esbuild', async function (t) {
               file: 'test/esbuild.mdx',
               length: 11,
               line: 3,
-              lineText: '# Hello, <Message />',
+              lineText: '',  // Not available when place.offset is deleted
               namespace: 'file',
               suggestion: ''
             },
@@ -414,7 +415,7 @@ test('@mdx-js/esbuild', async function (t) {
         file.message('3', tree)
         file.message('4', esm)
         file.message('5', text)
-        file.message('6', jsx)
+        delete file.message('6', jsx).place.start.offset
         file.message('7', head.position.end).fatal = true // End of heading
       }
     }

--- a/packages/esbuild/test/index.js
+++ b/packages/esbuild/test/index.js
@@ -231,7 +231,7 @@ test('@mdx-js/esbuild', async function (t) {
         },
         notes: [],
         pluginName: '@mdx-js/esbuild',
-        text: 'Unexpected character `/` (U+002F) before local name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a link in MDX, use `[text](url)`)'
+        text: 'Cannot process MDX file with esbuild:\n  1:12: Unexpected character `/` (U+002F) before local name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a link in MDX, use `[text](url)`)'
       })
     }
 
@@ -271,7 +271,7 @@ test('@mdx-js/esbuild', async function (t) {
             location: {
               column: 20,
               file: 'test/esbuild.mdx',
-              length: 1,
+              length: 0,
               line: 3,
               lineText: '# Hello, <Message />',
               namespace: 'file',
@@ -290,7 +290,7 @@ test('@mdx-js/esbuild', async function (t) {
               file: 'test/esbuild.mdx',
               length: 0,
               line: 0,
-              lineText: 'export function Message() { return <>World!</> }',
+              lineText: '',
               namespace: 'file',
               suggestion: ''
             },
@@ -305,7 +305,7 @@ test('@mdx-js/esbuild', async function (t) {
               file: 'test/esbuild.mdx',
               length: 0,
               line: 0,
-              lineText: 'export function Message() { return <>World!</> }',
+              lineText: '',
               namespace: 'file',
               suggestion: ''
             },
@@ -439,19 +439,15 @@ test('@mdx-js/esbuild', async function (t) {
       /** @type {BuildFailure} */
       const result = JSON.parse(JSON.stringify(error))
 
-      for (const message of [...result.errors, ...result.warnings]) {
-        message.text = message.text.split('\n')[0]
-      }
-
       assert.deepEqual(result, {
         errors: [
           {
             detail: {
               cause: {},
               fatal: true,
-              message: 'Cannot process MDX file with esbuild',
+              message: 'Cannot process MDX file with esbuild:\n  Error: Something went wrong',
               name: '1:1',
-              reason: 'Cannot process MDX file with esbuild',
+              reason: 'Cannot process MDX file with esbuild:\n  Error: Something went wrong',
               ruleId: 'process-error',
               source: '@mdx-js/esbuild'
             },
@@ -461,13 +457,13 @@ test('@mdx-js/esbuild', async function (t) {
               file: 'test/esbuild.mdx',
               length: 0,
               line: 0,
-              lineText: '# hi',
+              lineText: '',
               namespace: 'file',
               suggestion: ''
             },
             notes: [],
             pluginName: '@mdx-js/esbuild',
-            text: 'Cannot process MDX file with esbuild'
+            text: 'Cannot process MDX file with esbuild:\n  Error: Something went wrong'
           }
         ],
         warnings: []

--- a/packages/esbuild/test/index.js
+++ b/packages/esbuild/test/index.js
@@ -449,9 +449,9 @@ test('@mdx-js/esbuild', async function (t) {
             detail: {
               cause: {},
               fatal: true,
-              message: 'Cannot process MDX file with esbuild:\n  Error: Something went wrong',
+              message: 'Cannot process MDX file with esbuild',
               name: '1:1',
-              reason: 'Cannot process MDX file with esbuild:\n  Error: Something went wrong',
+              reason: 'Cannot process MDX file with esbuild',
               ruleId: 'process-error',
               source: '@mdx-js/esbuild'
             },


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This change improves(?) error conversion in the esbuild plugin, with no change to non-error function.

Previously, if a non-`VFileMessage` error was thrown by the MDX conversion process (eg. a simple nodejs runtime Error thrown by a plugin or the core), it would be wrapped as the `cause` in a `VFileMessage` with generic "Cannot process MDX file..." text, and re-thrown by the `onload` handler. This makes sense! However, when that message is converted in `vfileMessageToEsbuild`, the `cause` was completely ignored, so all information about that underlying error was lost, which makes debugging harder (especially debugging plugins).

Also previously, even when the original error thrown was a `VFileMessage`, if the optional `place.start.offset` (or `place.offset`) isn't defined, all place information was lost. This `.offset` field is optional (though set in most common paths).

This change revises things:

- In the `onload` handler, _always_ throw a new `VFileMessage` with the original exception attached. Hoist location information to the outer exception, if the inner exception appears to be a `VFileMessage` itself. Include the inner exception's text rendering in the outer's text (after a colon).

- In `vfileMessageToEsbuild`, handle the case where offset information isn't present, working with whatever information is present.

The changes to the unit test are a decent way to see the effect of all this.

<!--do not edit: pr-->
