### PR TITLE
Remove the type casting of JSX runtimes

### DIFF
--- a/docs/migrating/v3.mdx
+++ b/docs/migrating/v3.mdx
@@ -52,10 +52,6 @@ You will get a runtime error if these features are used in MDX without
 If you passed the `useDynamicImport` option before, remove it, the behavior
 is now the default.
 
-If you use `react/jsx-runtime`, you might get a TypeScript error (such as
-`Property 'Fragment' is missing in type`), because it is typed incorrectly.
-To remediate this, do:
-
 ```tsx
 import * as runtime from 'react/jsx-runtime'
 

--- a/packages/preact/test/index.jsx
+++ b/packages/preact/test/index.jsx
@@ -2,7 +2,6 @@
 /* @jsxImportSource preact */
 
 /**
- * @import {Fragment, Jsx} from '@mdx-js/mdx'
  * @import {ComponentProps} from 'preact'
  */
 
@@ -10,12 +9,8 @@ import assert from 'node:assert/strict'
 import {test} from 'node:test'
 import {evaluate} from '@mdx-js/mdx'
 import {MDXProvider, useMDXComponents} from '@mdx-js/preact'
-import * as runtime_ from 'preact/jsx-runtime'
+import * as runtime from 'preact/jsx-runtime'
 import {render} from 'preact-render-to-string'
-
-const runtime = /** @type {{Fragment: Fragment, jsx: Jsx, jsxs: Jsx}} */ (
-  runtime_
-)
 
 test('@mdx-js/preact', async function (t) {
   await t.test('should expose the public api', async function () {

--- a/packages/react/test/index.jsx
+++ b/packages/react/test/index.jsx
@@ -1,5 +1,4 @@
 /**
- * @import {Fragment, Jsx} from '@mdx-js/mdx'
  * @import {ComponentProps} from 'react'
  */
 
@@ -8,12 +7,8 @@ import {test} from 'node:test'
 import {evaluate} from '@mdx-js/mdx'
 import {MDXProvider, useMDXComponents} from '@mdx-js/react'
 import React from 'react'
-import * as runtime_ from 'react/jsx-runtime'
+import * as runtime from 'react/jsx-runtime'
 import {renderToString} from 'react-dom/server'
-
-const runtime = /** @type {{Fragment: Fragment, jsx: Jsx, jsxs: Jsx}} */ (
-  /** @type {unknown} */ (runtime_)
-)
 
 test('@mdx-js/react', async function (t) {
   await t.test('should expose the public api', async function () {

--- a/packages/vue/test/index.js
+++ b/packages/vue/test/index.js
@@ -1,5 +1,4 @@
 /**
- * @import {Fragment, Jsx} from '@mdx-js/mdx'
  * @import {MDXModule} from 'mdx/types.js'
  * @import {Component} from 'vue'
  */
@@ -8,17 +7,9 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {compile, run} from '@mdx-js/mdx'
 import {MDXProvider, useMDXComponents} from '@mdx-js/vue'
-import * as runtime_ from 'vue/jsx-runtime'
+import serverRenderer from '@vue/server-renderer'
+import * as runtime from 'vue/jsx-runtime'
 import * as vue from 'vue'
-
-const runtime = /** @type {{Fragment: Fragment, jsx: Jsx, jsxs: Jsx}} */ (
-  /** @type {unknown} */ (runtime_)
-)
-
-// Note: a regular import would be nice but that completely messes up the JSX types.
-const name = '@vue/server-renderer'
-/** @type {{default: {renderToString(node: unknown): string}}} */
-const {default: serverRenderer} = await import(name)
 
 test('@mdx-js/vue', async function (t) {
   await t.test('should expose the public api', async function () {
@@ -133,7 +124,10 @@ async function evaluate(value) {
     outputFormat: 'function-body',
     providerImportSource: '#'
   })
-  return run(file, {...runtime, useMDXComponents})
+  return run(file, {
+    ...runtime,
+    useMDXComponents
+  })
 }
 
 /**


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

There used to be type incompatibilities for JSX runtimes. This isn’t the case anymore. This removes the now redundant type casting from tests and a warning from the docs.

<!--do not edit: pr-->
