### PR TITLE
Add recma-module-to-function to list of plugins

### DIFF
--- a/docs/docs/extending-mdx.mdx
+++ b/docs/docs/extending-mdx.mdx
@@ -87,6 +87,8 @@ See also the [list of remark plugins][remark-plugins],
 * [`remcohaszing/recma-nextjs-static-props`](https://github.com/remcohaszing/recma-nextjs-static-props)
   — generate [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching/get-static-props)
   exposing top level identifiers in Next.js
+* [`remcohaszing/recma-module-to-function`](https://github.com/remcohaszing/recma-module-to-function)
+  — convert a module into a function body
 * [`remcohaszing/rehype-mdx-code-props`](https://github.com/remcohaszing/rehype-mdx-code-props)
   — interpret the code `meta` field as JSX props
 * [`remcohaszing/rehype-mdx-import-media`](https://github.com/remcohaszing/rehype-mdx-import-media)


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This adds [`recma-module-to-function`](https://github.com/remcohaszing/recma-module-to-function) to the list of plugins. This can be used as an alternative approach to MDX on demand.

<!--do not edit: pr-->
