### PR TITLE
Add rehype-mdx-toc to export toc to list of plugins

### DIFF
--- a/docs/docs/extending-mdx.mdx
+++ b/docs/docs/extending-mdx.mdx
@@ -95,6 +95,8 @@ See also the [list of remark plugins][remark-plugins],
   — change media sources to JavaScript imports
 * [`remcohaszing/rehype-mdx-title`](https://github.com/remcohaszing/rehype-mdx-title)
   — expose the page title as a string
+* [`boning-w/rehype-mdx-toc`](https://github.com/boning-w/rehype-mdx-toc)
+  — export the table of contents data into MDX module
 * [`pangelani/remark-mdx-chartjs`](https://github.com/pangelani/remark-mdx-chartjs)
   — replace fenced code blocks with charts using [`react-chartjs-2`](https://react-chartjs-2.js.org/).
 * [`remcohaszing/remark-mdx-frontmatter`](https://github.com/remcohaszing/remark-mdx-frontmatter)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add a rehype plugin [rehype-mdx-toc](https://github.com/boning-w/rehype-mdx-toc) that allows users to export the table of contents (TOC) data as a named export from an MDX module.

#### Why another table of contents plugin?

Since MDX supports exporting data from MDX modules, it's much more convinent to export the TOC — so that users can use it whatever they like, just like with [remark-mdx-frontmatter](https://github.com/remcohaszing/remark-mdx-frontmatter/tree/main).

Simple usage:

```js
import { compile, run } from "@mdx-js/mdx";
import rehypeMdxToc from "rehype-mdx-toc";
import * as runtime from "react/jsx-runtime";

const mdxContent = `
# Heading 1
## Heading 2
### Heading 3
`;

const compiled = await compile(mdxContent, {
  outputFormat: "function-body",
  rehypePlugins: [rehypeMdxToc],
});
const result = await run(compiled, { ...runtime });
const toc = result.toc;
console.log(toc);
```

With some bundlers — like [@mdx-js/esbuild](https://mdxjs.com/packages/esbuild/), [@mdx-js/rollup](https://mdxjs.com/packages/rollup/), and [@mdx-js/loader](https://mdxjs.com/packages/loader/), we can easily import the TOC data at build time:

```js
import MDXContent, { toc } from "./you-mdx-file.mdx";
```

<!--do not edit: pr-->
