### PR TITLE
Handle query parameters in Vite

### DIFF
--- a/packages/rollup/test/index.js
+++ b/packages/rollup/test/index.js
@@ -101,4 +101,27 @@ test('@mdx-js/rollup', async function (t) {
     assert.doesNotMatch(code, /jsxs?\(/)
     assert.match(code, /jsxDEV\(/)
   })
+
+  await t.test('should handle query parameters in vite', async () => {
+    const result = /** @type {Array<RollupOutput>} */ (
+      await build({
+        build: {
+          lib: {
+            entry:
+              fileURLToPath(new URL('vite-entry.mdx', import.meta.url)) +
+              '?query=param',
+            name: 'query'
+          },
+          write: false
+        },
+        logLevel: 'silent',
+        plugins: [rollupMdx()]
+      })
+    )
+
+    const code = result[0].output[0].code
+
+    assert.match(code, /Hello Vite/)
+    assert.match(code, /jsxs?\(/)
+  })
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This fixes an issue where MDX imports with query parameters aren't picked up by the Rollup plugin in Vite. To fix this, this PR uses the `extnamesToRegex` util to create a regular expression for matching MDX extensions, and this util already handles the existence of query parameters correctly.

I ran into this in the context of React Router where I'm working on RSC support for Framework Mode which uses Vite. We're using query parameters to transform client and server versions of route files, but this approach means that MDX routes are no longer working since the query parameters cause the MDX plugin to skip over them.

<!--do not edit: pr-->
