### PR TITLE
Document augmentation to make JSX available

### DIFF
--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -172,7 +172,16 @@ Our packages are typed with [TypeScript][].
 For types to work,
 the `JSX` namespace must be typed.
 This is done by installing and using the types of your framework,
-such as [`@types/react`][definitely-typed-react].
+such as [`@types/react`][definitely-typed-react],
+then augmenting the `mdx/types.js` module.
+
+```ts twoslash path="example.ts"
+import * as React from 'react'
+
+declare module 'mdx/types.js' {
+  export import JSX = React.JSX
+}
+```
 
 To enable types for imported `.mdx`, `.md`, etc.,
 install and use [`@types/mdx`][definitely-typed-mdx].


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Previously frameworks used to define a global `JSX` namespace. This is no longer the case. Now users need to define it themselves using module augmentation.

<!--do not edit: pr-->
