### PR TITLE
Add `remark-directive-mdx` to list of plugins

### DIFF
--- a/docs/docs/extending-mdx.mdx
+++ b/docs/docs/extending-mdx.mdx
@@ -97,6 +97,8 @@ See also the [list of remark plugins][remark-plugins],
   — expose the page title as a string
 * [`boning-w/rehype-mdx-toc`](https://github.com/boning-w/rehype-mdx-toc)
   — export the table of contents data into MDX module
+* [`re-xyr/remark-directive-mdx`](https://github.com/re-xyr/remark-directive-mdx)
+  — transform Markdown directives (`:directive[]`) to JSX elements
 * [`pangelani/remark-mdx-chartjs`](https://github.com/pangelani/remark-mdx-chartjs)
   — replace fenced code blocks with charts using [`react-chartjs-2`](https://react-chartjs-2.js.org/).
 * [`remcohaszing/remark-mdx-frontmatter`](https://github.com/remcohaszing/remark-mdx-frontmatter)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

[`remark-directive-mdx`](https://github.com/re-xyr/remark-directive-mdx) is a remark plugin that transforms Markdown directives (`:directive[]{}`) parsed by [`remark-directive`](https://github.com/remarkjs/remark-directive) into MDX JSX elements. This change adds this plugin to the plugins list in the docs.

<!--do not edit: pr-->
