### PR TITLE
Use mdxlint to run remark-lint rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "hastscript": "^9.0.0",
         "ink": "^6.0.0",
         "lz-string": "^1.0.0",
+        "mdxlint": "^1.0.0",
         "p-all": "^5.0.0",
         "postcss": "^8.0.0",
         "postcss-cli": "^11.0.0",
@@ -2996,7 +2997,6 @@
       "integrity": "sha512-g7XrNf25iL4TJOiPqatNuaChyqt49a/onq5YsJ9+hXeugK+41LVg7AxikMfM02PC6jbNtZLCJj6AUcQXJS/jGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.47.0",
@@ -10899,6 +10899,27 @@
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdxlint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdxlint/-/mdxlint-1.0.0.tgz",
+      "integrity": "sha512-EEOFUOYM1VPPqW/l1WyTxEiL8N1+LBNSBpzPk/Aq4z8UkfA19Abo75pK3qRZAi3MEW9NHK49+Fz0BdRrwLVzaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0",
+        "unified-args": "^11.0.0"
+      },
+      "bin": {
+        "mdxlint": "lib/bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
     },
     "node_modules/meow": {
       "version": "13.2.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "hastscript": "^9.0.0",
     "ink": "^6.0.0",
     "lz-string": "^1.0.0",
+    "mdxlint": "^1.0.0",
     "p-all": "^5.0.0",
     "postcss": "^8.0.0",
     "postcss-cli": "^11.0.0",
@@ -144,7 +145,7 @@
     "docs-js-editor": "esbuild --bundle --conditions=browser,production --define:process.env.NODE_ENV=\\\"production\\\" --log-level=warning --minify --outfile=public/editor.js --target=es2020 docs/_asset/editor.jsx",
     "docs-post": "node website/post.js",
     "docs-prep": "node website/prep.js && npm run docs-js && npm run docs-css",
-    "format": "remark --frail --output --quiet -- . && remark --ext mdx --frail --output --quiet --use remark-mdx -- . && prettier . --log-level warn --write && xo --fix",
+    "format": "remark --frail --output --quiet -- . && mdxlint --frail --output --quiet -- . && prettier . --log-level warn --write && xo --fix",
     "test": "npm run build && npm run format && npm run test-coverage",
     "test-api": "npm run test-api --workspaces --if-present",
     "test-coverage": "npm run test-coverage --workspaces --if-present"
@@ -168,6 +169,11 @@
     "tabWidth": 2,
     "trailingComma": "none",
     "useTabs": false
+  },
+  "mdxlint": {
+    "plugins": [
+      "./docs/.remarkrc.js"
+    ]
   },
   "remarkConfig": {
     "plugins": [


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This change replaces `remark --ext mdx --plugin remark-mdx` with `mdxlint`. This provides an editor integration and doesn’t rely on the use of CLI flags.

<!--do not edit: pr-->
