### PR TITLE
Use Vite plugin type and return minimal version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2070,6 +2070,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
       "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -2092,6 +2093,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2101,6 +2103,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2114,6 +2117,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2127,6 +2131,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,6 +2145,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2153,6 +2159,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2166,6 +2173,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2179,6 +2187,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2192,6 +2201,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2205,6 +2215,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2218,6 +2229,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2231,6 +2243,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2244,6 +2257,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2257,6 +2271,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2270,6 +2285,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2283,6 +2299,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2296,6 +2313,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2309,6 +2327,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,6 +2341,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2335,6 +2355,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2348,6 +2369,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2361,6 +2383,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2374,6 +2397,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7673,6 +7697,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12827,6 +12852,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -17202,6 +17228,7 @@
       "version": "4.53.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.2.tgz",
       "integrity": "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -20674,17 +20701,15 @@
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
-        "@rollup/pluginutils": "^5.0.0",
         "source-map": "^0.7.0",
         "vfile": "^6.0.0"
       },
-      "devDependencies": {},
+      "devDependencies": {
+        "rollup": "^4.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "rollup": ">=2"
       }
     },
     "packages/vue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17202,6 +17202,7 @@
       "version": "4.53.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.2.tgz",
       "integrity": "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -20678,13 +20679,9 @@
         "source-map": "^0.7.0",
         "vfile": "^6.0.0"
       },
-      "devDependencies": {},
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "rollup": ">=2"
       }
     },
     "packages/vue": {

--- a/packages/rollup/lib/index.js
+++ b/packages/rollup/lib/index.js
@@ -44,7 +44,7 @@ export function rollup(options) {
   /** @type {FormatAwareProcessors} */
   let formatAwareProcessors
 
-  /** @type {vite.Plugin} */
+  /** @type {vite.Plugin<never>} */
   const plugin = {
     name: '@mdx-js/rollup',
     config(config, env) {

--- a/packages/rollup/lib/index.js
+++ b/packages/rollup/lib/index.js
@@ -1,13 +1,15 @@
 /**
  * @import {FormatAwareProcessors} from '@mdx-js/mdx/internal-create-format-aware-processors'
  * @import {CompileOptions} from '@mdx-js/mdx'
- * @import {FilterPattern} from '@rollup/pluginutils'
- * @import {SourceDescription} from 'rollup'
+ * @import * as vite from 'vite'
  */
 
 /**
  * @typedef {Omit<CompileOptions, 'SourceMapGenerator'>} ApplicableOptions
  *   Applicable compile configuration.
+ *
+ * @typedef {string | RegExp | Array<string | RegExp>} FilterPattern
+ *   A Rollup filter pattern.
  *
  * @typedef ExtraOptions
  *   Extra configuration.
@@ -23,37 +25,9 @@
  *   Plugin that is compatible with both Rollup and Vite.
  * @property {string} name
  *   The name of the plugin
- * @property {ViteConfig} config
- *   Function used by Vite to set additional configuration options.
- * @property {Transform} transform
- *   Function to transform the source content.
- *
- * @callback Transform
- *   Callback called by Rollup and Vite to transform.
- * @param {string} value
- *   File contents.
- * @param {string} id
- *   Module ID.
- * @returns {Promise<SourceDescription | undefined>}
- *   Result.
- *
- * @callback ViteConfig
- *   Callback called by Vite to set additional configuration options.
- * @param {unknown} config
- *   Configuration object (unused).
- * @param {ViteEnv} env
- *   Environment variables.
- * @returns {undefined}
- *   Nothing.
- *
- * @typedef ViteEnv
- *   Environment variables used by Vite.
- * @property {string} mode
- *   Mode.
  */
 
 import {createFormatAwareProcessors} from '@mdx-js/mdx/internal-create-format-aware-processors'
-import {createFilter} from '@rollup/pluginutils'
 import {SourceMapGenerator} from 'source-map'
 import {VFile} from 'vfile'
 
@@ -69,9 +43,9 @@ export function rollup(options) {
   const {exclude, include, ...rest} = options || {}
   /** @type {FormatAwareProcessors} */
   let formatAwareProcessors
-  const filter = createFilter(include, exclude)
 
-  return {
+  /** @type {vite.Plugin} */
+  const plugin = {
     name: '@mdx-js/rollup',
     config(config, env) {
       formatAwareProcessors = createFormatAwareProcessors({
@@ -80,28 +54,35 @@ export function rollup(options) {
         ...rest
       })
     },
-    async transform(value, id) {
-      if (!formatAwareProcessors) {
-        formatAwareProcessors = createFormatAwareProcessors({
-          SourceMapGenerator,
-          ...rest
-        })
-      }
+    transform: {
+      filter: {
+        id: {
+          include: /** @type {FilterPattern} */ (include),
+          exclude: /** @type {FilterPattern} */ (exclude)
+        }
+      },
+      async handler(value, id) {
+        if (!formatAwareProcessors) {
+          formatAwareProcessors = createFormatAwareProcessors({
+            SourceMapGenerator,
+            ...rest
+          })
+        }
 
-      const [path] = id.split('?')
-      const file = new VFile({path, value})
+        const [path] = id.split('?')
+        const file = new VFile({path, value})
 
-      if (
-        file.extname &&
-        filter(file.path) &&
-        formatAwareProcessors.extnames.includes(file.extname)
-      ) {
-        const compiled = await formatAwareProcessors.process(file)
-        const code = String(compiled.value)
-        /** @type {SourceDescription} */
-        const result = {code, map: compiled.map}
-        return result
+        if (
+          file.extname &&
+          formatAwareProcessors.extnames.includes(file.extname)
+        ) {
+          const compiled = await formatAwareProcessors.process(file)
+          const code = String(compiled.value)
+          return {code, map: compiled.map}
+        }
       }
     }
   }
+
+  return plugin
 }

--- a/packages/rollup/lib/index.js
+++ b/packages/rollup/lib/index.js
@@ -2,7 +2,7 @@
  * @import {FormatAwareProcessors} from '@mdx-js/mdx/internal-create-format-aware-processors'
  * @import {CompileOptions} from '@mdx-js/mdx'
  * @import {FilterPattern} from '@rollup/pluginutils'
- * @import {SourceDescription} from 'rollup'
+ * @import * as vite from 'vite'
  */
 
 /**
@@ -23,33 +23,6 @@
  *   Plugin that is compatible with both Rollup and Vite.
  * @property {string} name
  *   The name of the plugin
- * @property {ViteConfig} config
- *   Function used by Vite to set additional configuration options.
- * @property {Transform} transform
- *   Function to transform the source content.
- *
- * @callback Transform
- *   Callback called by Rollup and Vite to transform.
- * @param {string} value
- *   File contents.
- * @param {string} id
- *   Module ID.
- * @returns {Promise<SourceDescription | undefined>}
- *   Result.
- *
- * @callback ViteConfig
- *   Callback called by Vite to set additional configuration options.
- * @param {unknown} config
- *   Configuration object (unused).
- * @param {ViteEnv} env
- *   Environment variables.
- * @returns {undefined}
- *   Nothing.
- *
- * @typedef ViteEnv
- *   Environment variables used by Vite.
- * @property {string} mode
- *   Mode.
  */
 
 import {createFormatAwareProcessors} from '@mdx-js/mdx/internal-create-format-aware-processors'
@@ -71,7 +44,8 @@ export function rollup(options) {
   let formatAwareProcessors
   const filter = createFilter(include, exclude)
 
-  return {
+  /** @type {vite.Plugin} */
+  const plugin = {
     name: '@mdx-js/rollup',
     config(config, env) {
       formatAwareProcessors = createFormatAwareProcessors({
@@ -102,4 +76,6 @@ export function rollup(options) {
       }
     }
   }
+
+  return plugin
 }

--- a/packages/rollup/lib/index.js
+++ b/packages/rollup/lib/index.js
@@ -44,7 +44,7 @@ export function rollup(options) {
   let formatAwareProcessors
   const filter = createFilter(include, exclude)
 
-  /** @type {vite.Plugin} */
+  /** @type {vite.Plugin<unknown>} */
   const plugin = {
     name: '@mdx-js/rollup',
     config(config, env) {

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -39,14 +39,12 @@
   ],
   "dependencies": {
     "@mdx-js/mdx": "^3.0.0",
-    "@rollup/pluginutils": "^5.0.0",
     "source-map": "^0.7.0",
     "vfile": "^6.0.0"
   },
-  "peerDependencies": {
-    "rollup": ">=2"
+  "devDependencies": {
+    "rollup": "^4.0.0"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "npm run test-coverage",
     "test-api": "node --conditions development test/index.js",

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -63,10 +63,6 @@
     "source-map": "^0.7.0",
     "vfile": "^6.0.0"
   },
-  "peerDependencies": {
-    "rollup": ">=2"
-  },
-  "devDependencies": {},
   "scripts": {
     "test": "npm run test-coverage",
     "test-api": "node --conditions development test/index.js",


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This change uses the Vite plugin type to annotate the Rollup plugin internally. This means that we get full type checking support for the implementation. However, the return type is annotated as our very minimal plugin type. This way it’s compatible with Rollup, Vite, and Rolldown, but we don’t need a dependency on Rollup.

`@rollup/pluginutils` has an optional peer dependency on `rollup`, but it’s not actually used. So it can be removed now.

Closes #2671

<!--do not edit: pr-->
