### PR TITLE
Add `remark-mdx-remove-esm` to list of plugins

### DIFF
--- a/docs/docs/extending-mdx.mdx
+++ b/docs/docs/extending-mdx.mdx
@@ -105,6 +105,8 @@ See also the [list of remark plugins][remark-plugins],
   — change frontmatter (YAML) metadata to exports
 * [`goodproblems/remark-mdx-math-enhanced`](https://github.com/goodproblems/remark-mdx-math-enhanced)
   — enhance math with JavaScript inside it
+* [`ipikuka/remark-mdx-remove-esm`](https://github.com/ipikuka/remark-mdx-remove-esm)
+  — remove import and/or export statements (mdxjsEsm)
 
 {/*
   * Please use alpha sorting on **project** name!


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

[**remark-mdx-remove-esm**](https://github.com/ipikuka/remark-mdx-remove-esm) is a remark plugin that removes import and/or export statements (mdxjsEsm) from MDX content. It provides an essential security layer for applications handling user-generated content.

It is a remark plugin to sanitize MDX content by removing ESM (`import`/`export`) statements for enhanced security.

This change adds `remark-mdx-remove-esm` to the plugin list in the docs.

<!--do not edit: pr-->
