### PR TITLE
Add metadata for the Vite plugin registry

### DIFF
--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -10,7 +10,12 @@
     "preact",
     "react",
     "remark",
+    "rolldown",
+    "rolldown-plugin",
     "rollup",
+    "rollup-plugin",
+    "vite",
+    "vite-plugin",
     "vue"
   ],
   "homepage": "https://mdxjs.com",
@@ -37,6 +42,21 @@
     "index.d.ts",
     "index.js"
   ],
+  "compatiblePackages": {
+    "schemaVersion": 1,
+    "rolldown": {
+      "type": "compatible",
+      "versions": "*"
+    },
+    "rollup": {
+      "type": "compatible",
+      "versions": ">=2.0.0"
+    },
+    "vite": {
+      "type": "compatible",
+      "versions": ">=2.0.0"
+    }
+  },
   "dependencies": {
     "@mdx-js/mdx": "^3.0.0",
     "@rollup/pluginutils": "^5.0.0",


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Vite now has a plugin registry where users can browse for compatible plugins at https://registry.vite.dev/. These new keywords register `@mdx-js/rollup` with this registry. The `compatiblePackages` field declares compatibility ranges. This is an alternative to using `peerDependencies`, which I prefer to avoid.

The version ranges were based on an answer in the Vite Discord server. I verified them myself as well.

<!--do not edit: pr-->
