### PR TITLE
Add `remark-mdx-remove-expressions` to list of plugins

### DIFF
--- a/docs/docs/extending-mdx.mdx
+++ b/docs/docs/extending-mdx.mdx
@@ -107,6 +107,8 @@ See also the [list of remark plugins][remark-plugins],
   — enhance math with JavaScript inside it
 * [`ipikuka/remark-mdx-remove-esm`](https://github.com/ipikuka/remark-mdx-remove-esm)
   — remove import and/or export statements (mdxjsEsm)
+* [`ipikuka/remark-mdx-remove-expressions`](https://github.com/ipikuka/remark-mdx-remove-expressions)
+  — remove MDX expressions within curlybraces {} in MDX content
 
 {/*
   * Please use alpha sorting on **project** name!


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

If MDX content is not fully trusted, then **Remote Code Execution (RCE)** is inherently possible. This is clearly documented in MDX and related integration package documentation. 

Lately, it is reported that the critical vulnerability [CVE-2026-0969](https://www.cve.org/CVERecord?id=CVE-2026-0969) may cause RCEs.

[**remark-mdx-remove-expressions**](https://github.com/ipikuka/remark-mdx-remove-expressions) is a remark plugin that removes MDX expressions.

It is a remark plugin to sanitize MDX content by removing JS expressions for enhanced security, allowing you to explicitly control JS expression handling in MDX.

It can remove all JS expressions from MDX content, but it is more suitable to use **safer balanced mode** (recommended) removes only dangerous MDX expressions:
```ts
import remarkMdxRemoveExpressions from "remark-mdx-remove-expressions";

{
  mdxOptions: {
    remarkPlugins: [
      [remarkMdxRemoveExpressions, { onlyDangerousExpressions: true }]
    ]
  }
}
```

This change adds `remark-mdx-remove-expressions` to the plugin list in the docs.

<!--do not edit: pr-->
