### PR TITLE
Remove docz from projects

### DIFF
--- a/docs/community/projects.mdx
+++ b/docs/community/projects.mdx
@@ -27,7 +27,6 @@ This page lists community projects using MDX.
 ## Libraries
 
 * [ok-mdx][]: Browser-based MDX editor
-* [docz][]: Documentation framework
 * [mdx-deck][]: MDX-based presentation decks
 * [mdx-docs][]: Next-based documentation framework
 * [mdx-paper][]: MDX-based research articles
@@ -53,8 +52,6 @@ This page lists community projects using MDX.
 [charge]: https://charge.js.org
 
 [demoboard]: https://frontarm.com/demoboard
-
-[docz]: https://www.docz.site/
 
 [mdnext]: https://github.com/domitriusclark/mdnext
 


### PR DESCRIPTION
I was looking at examples and apparently docz is now archived. The website for `docz.site` is now an OnlyFans page, so I'm assuming you would rather that not be a canonical resource for people adopting MDX.

Note: you probably also want to change `docs/blog/v1.mdx`

<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Removed references to `docz.site`.

<!--do not edit: pr-->
