### PR TITLE
Support Vite raw and url query parameters

### DIFF
--- a/packages/rollup/lib/index.js
+++ b/packages/rollup/lib/index.js
@@ -90,6 +90,8 @@ export function rollup(options) {
 
       const [path, query] = id.split('?')
 
+      // Special case for Vite
+      // https://github.com/vitejs/vite/issues/22417
       if (query === 'raw' || query === 'url') {
         return
       }

--- a/packages/rollup/lib/index.js
+++ b/packages/rollup/lib/index.js
@@ -88,7 +88,12 @@ export function rollup(options) {
         })
       }
 
-      const [path] = id.split('?')
+      const [path, query] = id.split('?')
+
+      if (query === 'raw' || query === 'url') {
+        return
+      }
+
       const file = new VFile({path, value})
 
       if (

--- a/packages/rollup/lib/index.js
+++ b/packages/rollup/lib/index.js
@@ -90,8 +90,8 @@ export function rollup(options) {
 
       const [path, query] = id.split('?')
 
-      // Special case for Vite
-      // https://github.com/vitejs/vite/issues/22417
+      // Special case for Vite.
+      // <https://github.com/vitejs/vite/issues/22417>
       if (query === 'raw' || query === 'url') {
         return
       }

--- a/packages/rollup/test/index.js
+++ b/packages/rollup/test/index.js
@@ -124,4 +124,50 @@ test('@mdx-js/rollup', async function (t) {
     assert.match(code, /Hello Vite/)
     assert.match(code, /jsxs?\(/)
   })
+
+  await t.test('should support the ?raw query', async () => {
+    const result = /** @type {Array<RollupOutput>} */ (
+      await build({
+        build: {
+          lib: {
+            entry:
+              fileURLToPath(new URL('vite-entry.mdx?raw', import.meta.url)) +
+              '?raw',
+            name: 'query'
+          },
+          write: false
+        },
+        logLevel: 'silent',
+        plugins: [rollupMdx()]
+      })
+    )
+
+    const code = result[0].output[0].code
+
+    assert.match(code, /# Hello Vite/)
+    assert.doesNotMatch(code, /jsxs/)
+  })
+
+  await t.test('should support the ?url query', async () => {
+    const result = /** @type {Array<RollupOutput>} */ (
+      await build({
+        build: {
+          lib: {
+            entry:
+              fileURLToPath(new URL('vite-entry.mdx?url', import.meta.url)) +
+              '?url',
+            name: 'query'
+          },
+          write: false
+        },
+        logLevel: 'silent',
+        plugins: [rollupMdx()]
+      })
+    )
+
+    const code = result[0].output[0].code
+
+    assert.match(code, /data:text\/mdx;base64/)
+    assert.doesNotMatch(code, /jsxs/)
+  })
 })

--- a/packages/rollup/test/index.js
+++ b/packages/rollup/test/index.js
@@ -125,7 +125,7 @@ test('@mdx-js/rollup', async function (t) {
     assert.match(code, /jsxs?\(/)
   })
 
-  await t.test('should support the ?raw query', async () => {
+  await t.test('should support the `?raw` query', async () => {
     const result = /** @type {Array<RollupOutput>} */ (
       await build({
         build: {

--- a/packages/rollup/test/index.js
+++ b/packages/rollup/test/index.js
@@ -131,7 +131,7 @@ test('@mdx-js/rollup', async function (t) {
         build: {
           lib: {
             entry:
-              fileURLToPath(new URL('vite-entry.mdx?raw', import.meta.url)) +
+              fileURLToPath(new URL('vite-entry.mdx', import.meta.url)) +
               '?raw',
             name: 'query'
           },
@@ -154,7 +154,7 @@ test('@mdx-js/rollup', async function (t) {
         build: {
           lib: {
             entry:
-              fileURLToPath(new URL('vite-entry.mdx?url', import.meta.url)) +
+              fileURLToPath(new URL('vite-entry.mdx', import.meta.url)) +
               '?url',
             name: 'query'
           },


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Vite has special treatment for the `raw` and `url` query parameters. Unfortunately, there’s not dedicated API to detect which file ID gets special treatment, and which does not. So we have to hard code it.

Closes #2657
Refs https://github.com/vitejs/vite/issues/22417

<!--do not edit: pr-->
