### PR TITLE
Log vfile messages in Webpack loader

### DIFF
--- a/packages/loader/lib/index.js
+++ b/packages/loader/lib/index.js
@@ -85,9 +85,42 @@ export function loader(value, callback) {
 
   const context = this.context
   const filePath = this.resourcePath
+  const logger = this.getLogger()
 
   process({value, path: filePath}).then(
     function (file) {
+      for (const message of file.messages) {
+        let log = filePath
+        if (message.line) {
+          log += ':' + message.line
+
+          if (message.column) {
+            log += ':' + message.column
+          }
+        }
+
+        log += ' '
+        if (message.source) {
+          log += message.source
+
+          if (message.ruleId) {
+            log += ':' + message.ruleId
+          }
+
+          log += ' '
+        } else if (message.ruleId) {
+          log += message.ruleId + ' '
+        }
+
+        log += message.message
+
+        if (message.fatal === undefined || message.fatal === null) {
+          logger.info(log)
+        } else {
+          logger.warn(log)
+        }
+      }
+
       callback(
         undefined,
         Buffer.from(file.value),

--- a/packages/loader/lib/index.js
+++ b/packages/loader/lib/index.js
@@ -90,34 +90,10 @@ export function loader(value, callback) {
   process({value, path: filePath}).then(
     function (file) {
       for (const message of file.messages) {
-        let log = filePath
-        if (message.line) {
-          log += ':' + message.line
-
-          if (message.column) {
-            log += ':' + message.column
-          }
-        }
-
-        log += ' '
-        if (message.source) {
-          log += message.source
-
-          if (message.ruleId) {
-            log += ':' + message.ruleId
-          }
-
-          log += ' '
-        } else if (message.ruleId) {
-          log += message.ruleId + ' '
-        }
-
-        log += message.message
-
         if (message.fatal === undefined || message.fatal === null) {
-          logger.info(log)
+          logger.info(toLogLine(message))
         } else {
-          logger.warn(log)
+          logger.warn(toLogLine(message))
         }
       }
 
@@ -166,4 +142,38 @@ function getOptionsHash(options) {
   }
 
   return hash.digest('hex').slice(0, 16)
+}
+
+/**
+ * Turn a vfile message into a log line.
+ *
+ * @param {VFileMessage} message
+ *   The vfile message
+ * @returns {string}
+ *   Log line
+ */
+function toLogLine(message) {
+  let log = message.file ?? ''
+  if (message.line) {
+    log += ':' + message.line
+
+    if (message.column) {
+      log += ':' + message.column
+    }
+  }
+
+  log += ' '
+  if (message.source) {
+    log += message.source
+
+    if (message.ruleId) {
+      log += ':' + message.ruleId
+    }
+
+    log += ' '
+  } else if (message.ruleId) {
+    log += message.ruleId + ' '
+  }
+
+  return log + message.reason
 }

--- a/packages/loader/test/index.js
+++ b/packages/loader/test/index.js
@@ -1,4 +1,6 @@
 /**
+ * @import {Options} from '@mdx-js/loader'
+ * @import {Root} from 'mdast'
  * @import {MDXContent} from 'mdx/types.js'
  */
 
@@ -228,5 +230,86 @@ webpack.mdx:1:22: Unexpected end of file in expression, expected a corresponding
 
     await fs.rm(mdxUrl)
     await fs.rm(new URL('webpack.cjs', folderUrl))
+  })
+
+  await t.test('should log messages', async () => {
+    const folderUrl = new URL('./', import.meta.url)
+    const mdxUrl = new URL('webpack.mdx', import.meta.url)
+    const mdxPath = fileURLToPath(mdxUrl)
+
+    await fs.writeFile(
+      mdxUrl,
+      'export function Message() { return <>World!</> }\n\n# Hello, <Message />'
+    )
+
+    const result = await webpack({
+      // @ts-expect-error: webpack types do not include `context`, which does work.
+      context: fileURLToPath(folderUrl),
+      entry: './webpack.mdx',
+      mode: 'none',
+      module: {
+        rules: [
+          {
+            test: /\.mdx$/,
+            use: [
+              {
+                loader: '@mdx-js/loader',
+                options: /** @satisfies {Options} */ ({
+                  remarkPlugins: [
+                    () =>
+                      /**
+                       * @type {Root}
+                       */
+                      (ast, file) => {
+                        file.info('info with position', ast)
+                        file.info('info with source', {source: 'source'})
+                        file.message('warning with ruleId', {ruleId: 'rule-id'})
+                        file.message('warning with source and ruleId', {
+                          source: 'source',
+                          ruleId: 'rule-id'
+                        })
+                      }
+                  ]
+                })
+              }
+            ]
+          }
+        ]
+      },
+      output: {
+        filename: 'webpack.cjs',
+        libraryTarget: 'commonjs',
+        path: fileURLToPath(folderUrl)
+      }
+    })
+
+    await fs.rm(mdxUrl)
+    await fs.rm(new URL('webpack.cjs', folderUrl))
+
+    assert(result)
+    const {logging} = result.toJson({logging: 'info'})
+    assert(logging)
+    const entries = Object.values(logging)[0].entries.map((entry) => ({
+      type: entry.type,
+      message: entry.message
+    }))
+    assert.deepEqual(entries, [
+      {
+        type: 'info',
+        message: mdxPath + ':1:1 info with position'
+      },
+      {
+        type: 'info',
+        message: mdxPath + ' source info with source'
+      },
+      {
+        type: 'warn',
+        message: mdxPath + ' rule-id warning with ruleId'
+      },
+      {
+        type: 'warn',
+        message: mdxPath + ' source:rule-id warning with source and ruleId'
+      }
+    ])
   })
 })

--- a/packages/loader/test/index.js
+++ b/packages/loader/test/index.js
@@ -258,7 +258,7 @@ webpack.mdx:1:22: Unexpected end of file in expression, expected a corresponding
                   remarkPlugins: [
                     () =>
                       /**
-                       * @type {Root}
+                       * @param {Root} ast
                        */
                       (ast, file) => {
                         file.info('info with position', ast)


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Some of our integrations turn vfile messages into log messages for the tool they integrate with. This was missing from the Webpack loader. This change logs vfile messages in the Webpack loader.

For more information on Webpack logger severity, see https://webpack.js.org/api/logging/#logger-methods.

The Webpack logger allows you to log arbritrary values. These get stringified. However, this is extremely verbose. Instead, I decided to represent messaged with single-line strings. The logs contain a full file path with line number. I find this useful, because some terminal editors make this format clickable.

The following screenshot shows that it looks like

<img width="1030" height="708" alt="Webpack output with a warning and an info messages for 2 MDX files." src="https://github.com/user-attachments/assets/9058ab9e-d7ff-4c81-a6db-5598114bb6e4" />


<!--do not edit: pr-->
